### PR TITLE
chore(npm): rename package to @daghis/teamcity-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The TeamCity MCP Server allows developers using AI-powered coding assistants (Cl
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/teamcity-mcp.git
+git clone https://github.com/Daghis/teamcity-mcp.git
 cd teamcity-mcp
 
 # Install dependencies
@@ -68,7 +68,7 @@ npm run dev
 ### npm Package (Coming Soon)
 
 ```bash
-npx @teamcity/mcp-server --mode=dev
+npx @daghis/teamcity-mcp --mode=dev
 ```
 
 ## Configuration
@@ -242,7 +242,7 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for deta
 
 ## Support
 
-- GitHub Issues: [Report bugs or request features](https://github.com/yourusername/teamcity-mcp/issues)
+- GitHub Issues: [Report bugs or request features](https://github.com/Daghis/teamcity-mcp/issues)
 - Documentation: See the `docs/` folder in this repository
 
 ## Acknowledgments

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@teamcity/mcp-server",
+  "name": "@daghis/teamcity-mcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@teamcity/mcp-server",
+      "name": "@daghis/teamcity-mcp",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@teamcity/mcp-server",
+  "name": "@daghis/teamcity-mcp",
   "version": "0.1.0",
   "description": "Model Control Protocol server for TeamCity CI/CD integration with AI coding assistants",
   "main": "dist/index.js",
@@ -51,7 +51,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yourusername/teamcity-mcp.git"
+    "url": "https://github.com/Daghis/teamcity-mcp.git"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.5.0",

--- a/tests/setup.test.js
+++ b/tests/setup.test.js
@@ -24,7 +24,7 @@ describe('Project Setup', () => {
     });
 
     test('should have required fields', () => {
-      expect(packageJson).toHaveProperty('name', '@teamcity/mcp-server');
+      expect(packageJson).toHaveProperty('name', '@daghis/teamcity-mcp');
       expect(packageJson).toHaveProperty('version');
       expect(packageJson).toHaveProperty('description');
       expect(packageJson).toHaveProperty('main');


### PR DESCRIPTION
- Rename package scope to @daghis/teamcity-mcp
- Update repository URLs in README
- Adjust tests to expect new package name
- Update package-lock.json

After merge, create a granular npm token scoped to @daghis and add as NPM_TOKEN to publish.