### PR TITLE
ci(release-please): switch to googleapis action + add concurrency

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,10 +11,11 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-please
+      cancel-in-progress: true
     steps:
       - name: Release Please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           release-type: node
-          package-name: "@daghis/teamcity-mcp"
-


### PR DESCRIPTION
- Use googleapis/release-please-action@v4 (the previous google-github-actions action is deprecated)
- Remove unsupported input 'package-name' (node releaser infers from package.json)
- Add concurrency to prevent duplicate runs

This resolves the warnings shown in Actions and keeps behavior unchanged (PR-based releases).