### PR TITLE
chore: enforce conventional commit standards

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,7 @@
+repository:
+  allow_merge_commit: false
+  allow_rebase_merge: false
+  allow_squash_merge: true
+  delete_branch_on_merge: true
+  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_message: PR_BODY

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,19 @@
+name: Commitlint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .commitlintrc.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,10 +53,16 @@ Tools must return standardized JSON payloads. Tests should assert:
 
 - Imperative mood: “Add X”, “Fix Y”.
 - Include ticket IDs when applicable: `[TMCP-123] Short summary`.
+- Follow [Conventional Commits](https://www.conventionalcommits.org/):
+  - Use lower‑case `type` prefixes like `feat`, `fix`, or `chore`.
+  - Keep the summary within 72 characters.
+  - PR titles must also follow this format and will become the squash merge commit message.
+- Commit message linting runs in CI to enforce the convention.
 
 ## Pull Requests
 
 - Describe scope, rationale, and testing.
 - Link issues/tickets; include logs or CLI output if relevant.
 - Ensure CI is green and `npm run check` passes locally.
+- Use **Squash and merge** so the merge commit inherits the PR’s conventional title.
 

--- a/tests/typescript.test.js
+++ b/tests/typescript.test.js
@@ -78,7 +78,7 @@ describe('TypeScript Configuration', () => {
       try {
         const tscScript = path.join(rootDir, 'node_modules', 'typescript', 'bin', 'tsc');
         const node = process.execPath;
-        execSync(`"${node}" "${tscScript}" --noEmit`, {
+        execSync(`"${node}" "${tscScript}" -p tsconfig.build.json --noEmit`, {
           cwd: rootDir,
           stdio: 'pipe',
         });

--- a/tests/unit/teamcity/build-queue-manager.test.ts
+++ b/tests/unit/teamcity/build-queue-manager.test.ts
@@ -614,6 +614,10 @@ describe('BuildQueueManager', () => {
           })
         );
 
+      const completed = new Promise<void>((resolve) => {
+        manager.once('build:completed', () => resolve());
+      });
+
       await manager.monitorBuild(
         '701',
         (status) => {
@@ -622,8 +626,7 @@ describe('BuildQueueManager', () => {
         { pollInterval: 10 }
       );
 
-      // Wait for monitoring to complete
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await completed;
 
       expect(statusUpdates.length).toBeGreaterThanOrEqual(1);
       expect(statusUpdates[statusUpdates.length - 1]?.state).toBe('finished');


### PR DESCRIPTION
## Summary
- document conventional commit requirements and squash-merge policy
- add commitlint config and CI check
- configure repository settings to allow only squash merges
- stabilize build monitoring and TypeScript compile tests

## Testing
- `npm test tests/unit/teamcity/build-queue-manager.test.ts`
- `npm test tests/typescript.test.js`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c2f1d9d1308320bb0938ab7fd8326f