### PR TITLE
ci: trigger CI on release-please branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-please--*'
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
- Add push trigger for 'release-please--*' so PRs opened by Release Please get CI checks automatically.
- No changes to job logic; preserves aggregator required check.