### PR TITLE
ci(publish): trigger on Release Please workflow_run (in addition to release)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ["Release Please"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -10,6 +13,9 @@ permissions:
 
 jobs:
   publish:
+    if: >-
+      ${{ github.event_name == 'release' ||
+          (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     name: Publish package
     runs-on: ubuntu-latest
     steps:
@@ -39,4 +45,3 @@ jobs:
           NPM_CONFIG_PROVENANCE: 'true'
         run: |
           npm publish --access public --provenance
-


### PR DESCRIPTION
- Add workflow_run trigger for 'Release Please' with success gating to publish when releases are created by Actions.
- Retain release.published trigger; this change is a safe fallback for cases where release events from GITHUB_TOKEN do not fire downstream workflows.