### PR TITLE
ci(commitlint): switch to ESM config (.commitlintrc.mjs)

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -1,0 +1,23 @@
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+        'deps'
+      ]
+    ]
+  }
+};

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5
+      - uses: wagoid/commitlint-github-action@v6
         with:
-          configFile: .commitlintrc.js
+          configFile: .commitlintrc.mjs
           commitDepth: 1


### PR DESCRIPTION
Commitlint GitHub Action v6 requires an ESM config file.\n\n- Add .commitlintrc.mjs (extends conventional, includes 'deps' type)\n- Update workflow to reference .commitlintrc.mjs and v6\n- Remove old .commitlintrc.js in a follow-up if desired