### PR TITLE
ci(commitlint): disable body-max-line-length

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -1,6 +1,8 @@
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
+    // Allow Dependabot-style commit bodies with long URLs/metadata
+    'body-max-line-length': [0, 'always'],
     'type-enum': [
       2,
       'always',


### PR DESCRIPTION
Dependabot commit bodies often include long URLs and metadata lines that exceed 100 chars.\n\n- Disable body-max-line-length to avoid false negatives\n- Keeps 'deps' type support intact