### PR TITLE
ci(publish): skip npm publish when version already exists

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,26 @@ jobs:
       - name: Verify package contents
         run: npm pack --dry-run
 
+      - name: Read package version
+        id: pkg
+        run: echo "version=$(node -p -e \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version already exists on npm
+        id: exists
+        run: |
+          set -e
+          PKG_NAME=$(node -p -e "require('./package.json').name")
+          VERSION=${{ steps.pkg.outputs.version }}
+          if npm view "${PKG_NAME}@${VERSION}" version > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} already published for ${PKG_NAME}; skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} not found on registry; will publish."
+          fi
+
       - name: Publish to npm
+        if: steps.exists.outputs.exists == 'false'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
Avoid E403 re-publish failures by checking if the current package.json version is already on npm. If found, skip publish and exit successfully. This keeps the publish job idempotent for reruns/duplicate releases.\n\n- Reads version via Node\n- Uses 'npm view <name>@<version>'\n- Gates publish step with 'if'\n\nNo code changes; only workflow adjustment.