### PR TITLE
ci(publish): fix version output step for bash compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,8 @@ jobs:
 
       - name: Read package version
         id: pkg
-        run: echo "version=$(node -p -e \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          node -e "console.log('version=' + require('./package.json').version)" >> "$GITHUB_OUTPUT"
 
       - name: Check if version already exists on npm
         id: exists


### PR DESCRIPTION
Fix the 'Read package version' step to write to GITHUB_OUTPUT via node console.log instead of shell substitution. This avoids the bash syntax error seen in the Publish job logs and keeps the idempotent publish guard intact.\n\nWorkflow-only change; no app code affected.