### PR TITLE
fix: health items locator handling; accept empty, normalize, and fallback on 400

### DIFF
--- a/.github/workflows/release-please-automerge.yml
+++ b/.github/workflows/release-please-automerge.yml
@@ -2,9 +2,7 @@ name: Auto-merge Release Please PRs
 
 on:
   pull_request:
-    # 'opened' is sufficient for Release Please (label present at creation).
-    # Include 'synchronize' for updates; omit 'labeled' to avoid duplicate runs.
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main ]
 
 permissions:
@@ -17,21 +15,8 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'release-please--') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease: pending')
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-automerge-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     steps:
-      - name: Check if auto-merge already enabled
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-        run: |
-          set -e
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          ENABLED=$(gh pr view "$PR_NUMBER" --json autoMergeRequest -q '.autoMergeRequest != null')
-          echo "enabled=$ENABLED" >> "$GITHUB_OUTPUT"
       - name: Enable auto-merge (squash)
-        if: steps.check.outputs.enabled != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [1.0.3](https://github.com/Daghis/teamcity-mcp/compare/v1.0.2...v1.0.3) (2025-09-12)
-
-
-### Bug Fixes
-
-* trigger 1.0.3 release (no functional change) ([069212a](https://github.com/Daghis/teamcity-mcp/commit/069212a181861b17e7a1d5cfda05b40c2d11e933))
-
 ## [1.0.2](https://github.com/Daghis/teamcity-mcp/compare/v1.0.1...v1.0.2) (2025-09-12)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@daghis/teamcity-mcp",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@daghis/teamcity-mcp",
-      "version": "1.0.3",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daghis/teamcity-mcp",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Model Control Protocol server for TeamCity CI/CD integration with AI coding assistants",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fix: list_server_health_items fails with empty locator and with category:(ERROR),muted:false (HTTP_400)

Summary
- Accept empty/omitted `locator` and treat as “no filter” for `/app/rest/health`.
- Normalize `category:(ERROR|WARNING|INFO)` → `category:ERROR|WARNING|INFO` for safer server-side usage.
- Gracefully handle TeamCity HTTP 400 for health locators by fetching all health items and applying best‑effort client‑side filtering for common keys (`severity`, `category`, `id`). Adds a small `note` in the response when fallback is used.

Why
Issue #75 reported two problems:
- An empty `locator` failed client validation.
- A locator like `category:(ERROR),muted:false` produced HTTP 400 from TeamCity.

Changes
- tools: `list_server_health_items`
  - Input schema now allows empty string/omitted locator.
  - Normalizes category severity parentheses.
  - On HTTP 400, falls back to fetch-all and client-side filtering. Unknown filters (e.g., `muted`) are ignored during fallback instead of erroring.
- tests: unit coverage for
  - Empty locator → treated as no filter (passes `undefined` upstream)
  - Normalization of `category:(ERROR)` → `category:ERROR`
  - Fallback path on HTTP 400 with client-side filtering by `severity:ERROR`

Verification
- Unit: `tests/unit/tools/server-health-and-metrics.test.ts` passes.
- Real TeamCity (using repo .env):
  - `{}` and `{ locator: '' }` → succeed and return `/app/rest/health` payload.
  - `{ locator: 'category:(ERROR),muted:false' }` → fallback path returns success with note.
  - Additional checks: `severity:ERROR`, `category:ERROR`, `muted:false`, `id:nonexistent`, `category:(WARNING)`, `severity:WARNING` → all succeed; where the server rejected the locator, fallback applied and a note was included.

Notes
- This change is limited to the server health items tool. Other tools still pass locators through unchanged (as expected, e.g., builds endpoint supports nested/parenthesized locators like:
  `/app/rest/builds?locator=buildType:TC_Trunk_Compile,startDate:(build:(buildType:TC_Trunk_Compile,number:88977),condition:after),status:FAILURE`).
- If we later learn more fields from your server’s health payload, we can expand the client-side filter set.

Closes #75.
