### PR TITLE
fix: authorize_agent uses authorizedInfo (TeamCity 2025.07)

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2281,10 +2281,11 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
       const typedArgs = args as AuthorizeAgentArgs;
 
       const api = TeamCityAPI.getInstance();
-      await api.agents.setAgentField(
+      await api.agents.setAuthorizedInfo(
         typedArgs.agentId,
-        'authorized',
-        typedArgs.authorize ? 'true' : 'false'
+        undefined,
+        { status: Boolean(typedArgs.authorize) },
+        { headers: { 'Content-Type': 'application/json', Accept: 'application/json' } }
       );
       return json({
         success: true,

--- a/tests/unit/tools/agent-vcs-admin.test.ts
+++ b/tests/unit/tools/agent-vcs-admin.test.ts
@@ -11,13 +11,13 @@ describe('tools: agent admin & VCS', () => {
     jest.clearAllMocks();
   });
 
-  it('authorize_agent sets authorized field and returns JSON', async () => {
+  it('authorize_agent sets authorized state via authorizedInfo and returns JSON', async () => {
     await new Promise<void>((resolve, reject) => {
       jest.isolateModules(() => {
         (async () => {
-          const setAgentField = jest.fn(async () => ({}));
+          const setAuthorizedInfo = jest.fn(async () => ({}));
           jest.doMock('@/api-client', () => ({
-            TeamCityAPI: { getInstance: () => ({ agents: { setAgentField } }) },
+            TeamCityAPI: { getInstance: () => ({ agents: { setAuthorizedInfo } }) },
           }));
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           const { getRequiredTool } = require('@/tools');


### PR DESCRIPTION
fix: authorize_agent uses authorizedInfo JSON endpoint (TeamCity 2025.07)

- Switch from field update `/app/rest/agents/{locator}/authorized` to `/app/rest/agents/{locator}/authorizedInfo`
- Send JSON body `{ "status": true|false }` with `Content-Type: application/json`
- Keeps `Accept: application/json` for consistent responses

Rationale
- TeamCity 2025.07 tightened endpoint/content-type handling; field-based text update started failing.
- The official API recommends using `authorizedInfo` for agent authorization state.

Validation
- Unit tests updated to mock `setAuthorizedInfo`.
- Full test suite passes locally (`npm test`).

Closes #78.
