### PR TITLE
feat: TeamCity service message escaping helper

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,7 @@
 // Import the required modules for the utilities object
 import * as asyncUtils from './async';
 import * as loggerUtils from './logger';
+import * as serviceMessageUtils from './teamcity-service-messages';
 import * as validationUtils from './validation';
 
 export * from './logger';
@@ -61,6 +62,7 @@ export type {
 // Re-export with deprecation warnings
 export * from './error-logger';
 export * from './lru-cache';
+export * from './teamcity-service-messages';
 
 // Add deprecation notice for legacy import pattern
 const warnLegacyImport = () => {
@@ -75,6 +77,7 @@ export interface IUtilities {
   logger: typeof loggerUtils;
   validation: typeof validationUtils;
   asyncUtils: typeof asyncUtils;
+  serviceMessages: typeof serviceMessageUtils;
 }
 
 // Create a utilities object for convenient access
@@ -82,6 +85,7 @@ export const utilities: IUtilities = {
   logger: loggerUtils,
   validation: validationUtils,
   asyncUtils,
+  serviceMessages: serviceMessageUtils,
 };
 
 // Default export for convenience

--- a/src/utils/teamcity-service-messages.ts
+++ b/src/utils/teamcity-service-messages.ts
@@ -1,0 +1,37 @@
+/**
+ * TeamCity service message escaping utilities.
+ * Escapes special characters according to TeamCity rules to prevent parsing warnings.
+ *
+ * Rules:
+ *  - '|'  => '||'
+ *  - '\n' => '|n'
+ *  - '\r' => '|r'
+ *  - '['  => '|['
+ *  - ']'  => '|]'
+ *  - "'" => "|'"
+ */
+export const escapeTeamCityServiceMessage = (text: string): string => {
+  if (text == null || text === '') return '';
+  return text
+    .replace(/\|/g, '||')
+    .replace(/\n/g, '|n')
+    .replace(/\r/g, '|r')
+    .replace(/\[/g, '|[')
+    .replace(/\]/g, '|]')
+    .replace(/'/g, "|'");
+};
+
+/**
+ * Wraps a message as a TeamCity service message with proper escaping for values.
+ * Example: serviceMessage('message', { text: 'Hello' }) => ##teamcity[message text='Hello']
+ */
+export const formatServiceMessage = (
+  name: string,
+  attrs: Record<string, string | number | boolean | undefined>
+): string => {
+  const parts = Object.entries(attrs)
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => `${k}='${escapeTeamCityServiceMessage(String(v))}'`)
+    .join(' ');
+  return `##teamcity[${name}${parts ? ` ${parts}` : ''}]`;
+};

--- a/tests/unit/utils/teamcity-service-messages.test.ts
+++ b/tests/unit/utils/teamcity-service-messages.test.ts
@@ -1,0 +1,14 @@
+import { escapeTeamCityServiceMessage, formatServiceMessage } from '@/utils';
+
+describe('utils: TeamCity service messages', () => {
+  it('escapes special characters correctly', () => {
+    const input = "pipe|quote'brackets[]new\nline\rcarriage";
+    const escaped = escapeTeamCityServiceMessage(input);
+    expect(escaped).toBe("pipe||quote|'brackets|[|]new|nline|rcarriage");
+  });
+
+  it('formats service message with escaped attributes', () => {
+    const msg = formatServiceMessage('message', { text: 'hello|world' });
+    expect(msg).toBe("##teamcity[message text='hello||world']");
+  });
+});


### PR DESCRIPTION
feat: TeamCity service message escaping helper

- Add `escapeTeamCityServiceMessage(text)` implementing official escaping rules
- Add `formatServiceMessage(name, attrs)` to build service messages safely
- Export via `@/utils` and include unit tests

Why
- Ansible/logging steps emitting special characters (quotes, brackets, pipes, newlines) can trigger TeamCity service message parsing warnings.
- This utility makes it easy for any output we generate to be properly escaped.

Usage
- `escapeTeamCityServiceMessage("O'Hara [x] | \n") // => O|'Hara |[x|] || |n`
- `formatServiceMessage('message', { text: "Hello | world" })`

Closes #82.
