### PR TITLE
docs(readme): align with shipped tool surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ const newBuild = await api.triggerBuild('BuildConfigId', {
 });
 ```
 
+> **Note:** The legacy helpers exported from `src/teamcity/index.ts` remain only for compatibility and include placeholder implementations. Prefer the MCP tools (see the reference linked above) or the `TeamCityAPI` shown here when automating workflows.
+
 ## Development
 
 ```bash
@@ -248,12 +250,14 @@ The MCP server exposes tools for TeamCity operations. Each tool corresponds to s
   - Build steps (script, Maven, Gradle, npm, Docker, PowerShell)
   - Triggers (VCS, schedule, finish-build, maven-snapshot)
   - Parameters and template-based configurations
-  - See the Tool Reference for details: docs/mcp-tools-reference.md
-- `CloneBuildConfig` - Duplicate configurations (coming soon)
-- `ManageBuildSteps` - Add/edit/remove steps (coming soon)
-- `ManageVCS` - Configure version control (coming soon)
+  - See the [MCP Tool Reference](docs/mcp-tools-reference.md) for argument details and additional options.
+- `clone_build_config` - Duplicate existing configurations into any project, preserving steps, triggers, and parameters.
+- `update_build_config` - Adjust names, descriptions, artifact rules, and pause state for a configuration.
+- `manage_build_steps` - Add, update, remove, or reorder build steps through a single tool surface.
+- `manage_build_triggers` - Add or delete build triggers with full property support.
+- `create_vcs_root` & `add_vcs_root_to_build` - Define VCS roots and attach them to build configurations.
 
-See also: `docs/TEAMCITY_MCP_TOOLS_GUIDE.md` for an overview. Some advanced sections in that guide describe future enhancements; the behavior above reflects the current implementation.
+See also: [`docs/TEAMCITY_MCP_TOOLS_GUIDE.md`](docs/TEAMCITY_MCP_TOOLS_GUIDE.md) for expanded workflows and examples that align with the current MCP implementation.
 
 ## Contributing
 

--- a/docs/TEAMCITY_MCP_TOOLS_GUIDE.md
+++ b/docs/TEAMCITY_MCP_TOOLS_GUIDE.md
@@ -4,6 +4,8 @@
 
 The TeamCity MCP (Model Context Protocol) server provides a set of tools for interacting with JetBrains TeamCity CI/CD server via AI-powered coding assistants using MCP tools. This document provides a reference for the available tools, their capabilities, and practical workflows.
 
+> For exhaustive argument and mode details, see the [MCP Tool Reference](./mcp-tools-reference.md). This guide focuses on practical usage patterns and stays aligned with the shipped tool surface.
+
 ## Architecture Overview
 
 ### Core Components
@@ -33,6 +35,7 @@ The live implementation emphasizes a simple, direct architecture. A few practica
 - Enhanced results:
   - `get_build_results` supports options: `includeArtifacts`, `includeStatistics`, `includeChanges`, `includeDependencies`, `artifactFilter`, `maxArtifactSize`.
   - `get_build_status` supports options: `includeTests`, `includeProblems`, `includeQueueTotals`, `includeQueueReason`.
+- Legacy helper exports from `src/teamcity/index.ts` are retained for backwards compatibility but are not updated; use the MCP tools or `TeamCityAPI` for real workflows.
 
 ## Operation Modes
 


### PR DESCRIPTION
## Summary
- update README to reflect the active MCP configuration tools and link to the tool reference
- clarify the legacy status of the helpers exported from src/teamcity/index.ts
- cross-link the TEAMCITY_MCP_TOOLS_GUIDE to the reference and highlight that legacy helpers are compatibility-only

## Testing
- npm run check
- npm run test:unit

Closes #105.
