### PR TITLE
fix(teamcity): route results + problems via shared client

### DIFF
--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -26,10 +26,34 @@ export interface BuildApiLike {
 
 export interface TeamCityClientAdapter {
   builds: BuildApiLike;
+  listBuildArtifacts: (
+    buildId: string,
+    options?: {
+      basePath?: string;
+      locator?: string;
+      fields?: string;
+      resolveParameters?: boolean;
+      logBuildUsage?: boolean;
+    }
+  ) => Promise<AxiosResponse<unknown>>;
+  downloadArtifactContent: (
+    buildId: string,
+    artifactPath: string
+  ) => Promise<AxiosResponse<ArrayBuffer>>;
+  getBuildStatistics: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
+  listChangesForBuild: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
+  listSnapshotDependencies: (buildId: string) => Promise<AxiosResponse<unknown>>;
+  baseUrl: string;
 }
 
 export function createAdapterFromTeamCityAPI(api: TeamCityAPI): TeamCityClientAdapter {
   return {
     builds: api.builds as unknown as BuildApiLike,
+    listBuildArtifacts: (buildId, options) => api.listBuildArtifacts(buildId, options),
+    downloadArtifactContent: (buildId, artifactPath) => api.downloadBuildArtifact(buildId, artifactPath),
+    getBuildStatistics: (buildId, fields) => api.getBuildStatistics(buildId, fields),
+    listChangesForBuild: (buildId, fields) => api.listChangesForBuild(buildId, fields),
+    listSnapshotDependencies: (buildId) => api.listSnapshotDependencies(buildId),
+    baseUrl: api.getBaseUrl(),
   };
 }

--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -50,7 +50,8 @@ export function createAdapterFromTeamCityAPI(api: TeamCityAPI): TeamCityClientAd
   return {
     builds: api.builds as unknown as BuildApiLike,
     listBuildArtifacts: (buildId, options) => api.listBuildArtifacts(buildId, options),
-    downloadArtifactContent: (buildId, artifactPath) => api.downloadBuildArtifact(buildId, artifactPath),
+    downloadArtifactContent: (buildId, artifactPath) =>
+      api.downloadBuildArtifact(buildId, artifactPath),
     getBuildStatistics: (buildId, fields) => api.getBuildStatistics(buildId, fields),
     listChangesForBuild: (buildId, fields) => api.listChangesForBuild(buildId, fields),
     listSnapshotDependencies: (buildId) => api.listSnapshotDependencies(buildId),

--- a/src/teamcity/index.ts
+++ b/src/teamcity/index.ts
@@ -2,6 +2,7 @@
  * TeamCity integration module
  * Main entry point for TeamCity API operations
  */
+import { TeamCityAPI } from '@/api-client';
 import { info, warn } from '@/utils/logger';
 
 import { TeamCityClient } from './client';
@@ -253,14 +254,6 @@ export async function getBuildTestResults(buildId: number): Promise<{
  * Get build log
  */
 export async function getBuildLog(buildId: number): Promise<string> {
-  const client = getTeamCityClient();
-  // Note: This is a simplified example. The actual API might require different approach
-  await client.builds.getBuild(
-    `id:${buildId}`, // buildLocator
-    'href' // fields
-  );
-
-  // Would need to fetch log from a different endpoint
-  // This is just a placeholder
-  return `Build log for ${buildId}`;
+  const api = TeamCityAPI.getInstance();
+  return api.getBuildLog(String(buildId));
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1756,7 +1756,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         async (typed) => {
           const api = TeamCityAPI.getInstance();
           const build = await api.getBuild(typed.buildId);
-          const problems = await api.builds.getBuildProblems(typed.buildId);
+          const problems = await api.builds.getBuildProblems(`id:${typed.buildId}`);
           const failures = await api.listTestFailures(typed.buildId);
           return json({
             buildStatus: build.status,

--- a/tests/unit/teamcity/build-results-manager.test.ts
+++ b/tests/unit/teamcity/build-results-manager.test.ts
@@ -1,32 +1,40 @@
-/**
- * Tests for BuildResultsManager
- */
-import axios from 'axios';
-
 import { BuildResultsManager } from '@/teamcity/build-results-manager';
-import type { TeamCityClient } from '@/teamcity/client';
+import type { TeamCityClientAdapter } from '@/teamcity/client-adapter';
 
-jest.mock('axios');
+type MockAdapter = {
+  builds: {
+    getBuild: jest.Mock;
+    getMultipleBuilds: jest.Mock;
+    getBuildProblems: jest.Mock;
+  };
+  listBuildArtifacts: jest.Mock;
+  downloadArtifactContent: jest.Mock;
+  getBuildStatistics: jest.Mock;
+  listChangesForBuild: jest.Mock;
+  listSnapshotDependencies: jest.Mock;
+  baseUrl: string;
+};
 
 describe('BuildResultsManager', () => {
   let manager: BuildResultsManager;
-  let mockClient: { builds: { getBuild: jest.Mock } };
+  let mockClient: MockAdapter;
 
   beforeEach(() => {
-    // Create mock TeamCity client
     mockClient = {
       builds: {
         getBuild: jest.fn(),
+        getMultipleBuilds: jest.fn(),
+        getBuildProblems: jest.fn(),
       },
+      listBuildArtifacts: jest.fn().mockResolvedValue({ data: {} }),
+      downloadArtifactContent: jest.fn().mockResolvedValue({ data: new ArrayBuffer(0) }),
+      getBuildStatistics: jest.fn().mockResolvedValue({ data: { property: [] } }),
+      listChangesForBuild: jest.fn().mockResolvedValue({ data: {} }),
+      listSnapshotDependencies: jest.fn().mockResolvedValue({ data: {} }),
+      baseUrl: 'https://teamcity.example.com',
     };
 
-    // Mock axios for direct API calls
-    const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-    mockedAxios.get = jest.fn().mockResolvedValue({ data: {} });
-
-    manager = new BuildResultsManager(mockClient as unknown as TeamCityClient);
-
-    // Clear cache before each test without using `any`
+    manager = new BuildResultsManager(mockClient as unknown as TeamCityClientAdapter);
     type PrivateAccess = { cache: Map<string, unknown> };
     (manager as unknown as PrivateAccess).cache.clear();
   });
@@ -35,22 +43,27 @@ describe('BuildResultsManager', () => {
     jest.restoreAllMocks();
   });
 
+  const basicBuild = () => ({
+    data: {
+      id: 12345,
+      buildTypeId: 'MyBuildConfig',
+      number: '42',
+      status: 'SUCCESS',
+      state: 'finished',
+      statusText: 'Build completed',
+      webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
+    },
+  });
+
   describe('Build Summary Retrieval', () => {
-    it('should fetch basic build information', async () => {
+    it('returns normalized build information', async () => {
       const mockBuild = {
         data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
+          ...basicBuild().data,
           branchName: 'main',
+          queuedDate: '20250829T115500+0000',
           startDate: '20250829T120000+0000',
           finishDate: '20250829T121500+0000',
-          queuedDate: '20250829T115500+0000',
-          statusText: 'Tests passed: 150',
-          href: '/app/rest/builds/id:12345',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
           triggered: {
             type: 'user',
             user: { username: 'developer', name: 'John Doe' },
@@ -59,79 +72,44 @@ describe('BuildResultsManager', () => {
         },
       };
 
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
 
       const result = await manager.getBuildResults('12345');
 
       expect(mockClient.builds.getBuild).toHaveBeenCalledWith('id:12345', expect.any(String));
-
       expect(result.build.id).toBe(12345);
-      expect(result.build.number).toBe('42');
-      expect(result.build.status).toBe('SUCCESS');
-      expect(result.build.triggered?.type).toBe('user');
+      expect(result.build.branchName).toBe('main');
       expect(result.build.triggered?.user).toBe('developer');
     });
 
-    it('should handle builds without optional fields', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
+    it('handles missing optional fields', async () => {
+      const mockBuild = basicBuild();
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
 
       const result = await manager.getBuildResults('12345');
 
-      expect(result.build.id).toBe(12345);
       expect(result.build.branchName).toBeUndefined();
-      expect(result.build.startDate).toBeUndefined();
       expect(result.build.triggered).toBeUndefined();
     });
 
-    it('should calculate build duration when dates are available', async () => {
+    it('computes duration from start and finish dates', async () => {
       const mockBuild = {
         data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
+          ...basicBuild().data,
           startDate: '20250829T120000+0000',
           finishDate: '20250829T121500+0000',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
         },
       };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
 
       const result = await manager.getBuildResults('12345');
-
-      expect(result.build.duration).toBe(900000); // 15 minutes in milliseconds
+      expect(result.build.duration).toBe(15 * 60 * 1000);
     });
   });
 
   describe('Artifact Management', () => {
-    it('should fetch artifact listing when requested', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
+    it('lists artifacts when requested', async () => {
+      const mockBuild = basicBuild();
       const mockArtifacts = {
         file: [
           {
@@ -139,7 +117,6 @@ describe('BuildResultsManager', () => {
             fullName: 'target/app.jar',
             size: 10485760,
             modificationTime: '20250829T121400+0000',
-            href: '/app/rest/builds/id:12345/artifacts/metadata/target/app.jar',
             content: { href: '/app/rest/builds/id:12345/artifacts/content/target/app.jar' },
           },
           {
@@ -147,68 +124,31 @@ describe('BuildResultsManager', () => {
             fullName: 'reports/test-report.html',
             size: 524288,
             modificationTime: '20250829T121430+0000',
-            href: '/app/rest/builds/id:12345/artifacts/metadata/reports/test-report.html',
-            content: {
-              href: '/app/rest/builds/id:12345/artifacts/content/reports/test-report.html',
-            },
           },
         ],
       };
 
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      mockedAxios.get.mockResolvedValue({ data: mockArtifacts });
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
 
       const result = await manager.getBuildResults('12345', { includeArtifacts: true });
 
       expect(result.artifacts).toHaveLength(2);
-      const a0 = result.artifacts?.[0];
-      const a1 = result.artifacts?.[1];
-      expect(a0?.name).toBe('app.jar');
-      expect(a0?.path).toBe('target/app.jar');
-      expect(a0?.size).toBe(10485760);
-      expect(a1?.name).toBe('test-report.html');
+      expect(result.artifacts?.[0]?.name).toBe('app.jar');
     });
 
-    it('should filter artifacts by pattern', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
+    it('filters artifacts using glob patterns', async () => {
+      const mockBuild = basicBuild();
       const mockArtifacts = {
         file: [
-          {
-            name: 'app.jar',
-            fullName: 'target/app.jar',
-            size: 10485760,
-            modificationTime: '20250829T121400+0000',
-          },
-          {
-            name: 'lib.jar',
-            fullName: 'target/lib.jar',
-            size: 2097152,
-            modificationTime: '20250829T121400+0000',
-          },
-          {
-            name: 'test-report.html',
-            fullName: 'reports/test-report.html',
-            size: 524288,
-            modificationTime: '20250829T121430+0000',
-          },
+          { name: 'app.jar', fullName: 'target/app.jar' },
+          { name: 'lib.jar', fullName: 'target/lib.jar' },
+          { name: 'notes.txt', fullName: 'docs/notes.txt' },
         ],
       };
 
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      mockedAxios.get.mockResolvedValue({ data: mockArtifacts });
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
 
       const result = await manager.getBuildResults('12345', {
         includeArtifacts: true,
@@ -216,40 +156,25 @@ describe('BuildResultsManager', () => {
       });
 
       expect(result.artifacts).toHaveLength(2);
-      expect(result.artifacts?.[0]?.name).toBe('app.jar');
-      expect(result.artifacts?.[1]?.name).toBe('lib.jar');
+      expect(result.artifacts?.map((a) => a?.name)).toEqual(['app.jar', 'lib.jar']);
     });
 
-    it('should include base64 content for small artifacts', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
+    it('embeds base64 content for small downloads', async () => {
+      const mockBuild = basicBuild();
       const mockArtifacts = {
         file: [
           {
             name: 'version.txt',
             fullName: 'version.txt',
             size: 10,
-            modificationTime: '20250829T121400+0000',
-            content: { href: '/app/rest/builds/id:12345/artifacts/content/version.txt' },
           },
         ],
       };
 
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      mockedAxios.get
-        .mockResolvedValueOnce({ data: mockArtifacts })
-        .mockResolvedValueOnce({ data: '1.0.0' });
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
+      const payload = Buffer.from('1.0.0');
+      mockClient.downloadArtifactContent.mockResolvedValue({ data: payload } as never);
 
       const result = await manager.getBuildResults('12345', {
         includeArtifacts: true,
@@ -257,25 +182,62 @@ describe('BuildResultsManager', () => {
         maxArtifactSize: 1024,
       });
 
-      expect(result.artifacts?.[0]?.content).toBe('MS4wLjA='); // Base64 of '1.0.0'
+      expect(result.artifacts?.[0]?.content).toBe(Buffer.from('1.0.0').toString('base64'));
+    });
+
+    it('skips downloads when artifact exceeds max size', async () => {
+      const mockBuild = basicBuild();
+      const mockArtifacts = {
+        file: [
+          {
+            name: 'large.zip',
+            fullName: 'large.zip',
+            size: 5 * 1024 * 1024,
+          },
+        ],
+      };
+
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
+
+      await manager.getBuildResults('12345', {
+        includeArtifacts: true,
+        downloadArtifacts: ['large.zip'],
+        maxArtifactSize: 1024,
+      });
+
+      expect(mockClient.downloadArtifactContent).not.toHaveBeenCalled();
+    });
+
+    it('ignores download failures gracefully', async () => {
+      const mockBuild = basicBuild();
+      const mockArtifacts = {
+        file: [
+          {
+            name: 'info.txt',
+            fullName: 'info.txt',
+            size: 10,
+          },
+        ],
+      };
+
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
+      mockClient.downloadArtifactContent.mockRejectedValueOnce(new Error('download failed'));
+
+      const result = await manager.getBuildResults('12345', {
+        includeArtifacts: true,
+        downloadArtifacts: ['info.txt'],
+      });
+
+      expect(result.artifacts?.[0]?.content).toBeUndefined();
     });
   });
 
   describe('Statistics Extraction', () => {
-    it('should fetch build statistics when requested', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
-      const mockStatistics = {
+    it('maps TeamCity properties to friendly names', async () => {
+      const mockBuild = basicBuild();
+      const statsPayload = {
         property: [
           { name: 'BuildDuration', value: '95000' },
           { name: 'TestCount', value: '150' },
@@ -287,342 +249,154 @@ describe('BuildResultsManager', () => {
         ],
       };
 
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      mockedAxios.get.mockResolvedValue({ data: mockStatistics });
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.getBuildStatistics.mockResolvedValue({ data: statsPayload } as never);
 
       const result = await manager.getBuildResults('12345', { includeStatistics: true });
 
       expect(result.statistics?.buildDuration).toBe(95000);
       expect(result.statistics?.testCount).toBe(150);
-      expect(result.statistics?.passedTests).toBe(148);
-      expect(result.statistics?.failedTests).toBe(2);
-      expect(result.statistics?.ignoredTests).toBe(0);
-      expect(result.statistics?.codeCoverage).toBe(92.3); // Takes the higher of L and B coverage
+      expect(result.statistics?.codeCoverage).toBe(92.3);
     });
 
-    it('should handle missing statistics gracefully', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      mockedAxios.get.mockResolvedValue({ data: { property: [] } });
+    it('returns empty object when no stats available', async () => {
+      const mockBuild = basicBuild();
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.getBuildStatistics.mockResolvedValue({ data: { property: [] } } as never);
 
       const result = await manager.getBuildResults('12345', { includeStatistics: true });
-
       expect(result.statistics).toEqual({});
     });
   });
 
   describe('Dependencies Tracking', () => {
-    it('should fetch build dependencies when requested', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
-      const mockDependencies = {
+    it('normalizes snapshot dependencies', async () => {
+      const mockBuild = basicBuild();
+      const depsPayload = {
         build: [
-          {
-            id: 12340,
-            number: '41',
-            buildTypeId: 'CoreLib',
-            status: 'SUCCESS',
-          },
-          {
-            id: 12342,
-            number: '38',
-            buildTypeId: 'AuthModule',
-            status: 'SUCCESS',
-          },
+          { id: 12340, number: '41', buildTypeId: 'CoreLib', status: 'SUCCESS' },
+          { id: 12342, number: '38', buildTypeId: 'AuthModule', status: 'SUCCESS' },
         ],
       };
 
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      mockedAxios.get.mockResolvedValue({ data: mockDependencies });
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listSnapshotDependencies.mockResolvedValue({ data: depsPayload } as never);
 
       const result = await manager.getBuildResults('12345', { includeDependencies: true });
 
       expect(result.dependencies).toHaveLength(2);
-      const dep0 = result.dependencies?.[0];
-      expect(dep0).toBeDefined();
-      if (!dep0) {
-        throw new Error('Expected first dependency');
-      }
-      expect(dep0.buildId).toBe(12340);
-      expect(dep0.buildNumber).toBe('41');
-      expect(dep0.buildTypeId).toBe('CoreLib');
-      expect(dep0.status).toBe('SUCCESS');
+      expect(result.dependencies?.[0]?.buildId).toBe(12340);
     });
 
-    it('should handle missing dependencies gracefully', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      mockedAxios.get.mockResolvedValue({ data: { build: [] } });
+    it('returns empty array when dependencies missing', async () => {
+      const mockBuild = basicBuild();
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listSnapshotDependencies.mockResolvedValue({ data: { build: [] } } as never);
 
       const result = await manager.getBuildResults('12345', { includeDependencies: true });
-
       expect(result.dependencies).toEqual([]);
     });
   });
 
   describe('Change Tracking', () => {
-    it('should fetch VCS changes when requested', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
-      const mockChanges = {
+    it('maps VCS changes payload', async () => {
+      const mockBuild = basicBuild();
+      const changePayload = {
         change: [
           {
-            id: 567,
-            version: 'abc123def456',
-            username: 'developer',
-            date: '20250829T110000+0000',
-            comment: 'Fix authentication bug',
-            files: {
-              file: [
-                { name: 'src/Auth.java', changeType: 'edited' },
-                { name: 'test/AuthTest.java', changeType: 'added' },
-              ],
-            },
-          },
-          {
-            id: 568,
-            version: 'def456ghi789',
-            username: 'another.dev',
-            date: '20250829T111500+0000',
-            comment: 'Update dependencies',
-            files: {
-              file: [{ name: 'pom.xml', changeType: 'edited' }],
-            },
+            version: 'abc123',
+            username: 'alice',
+            date: '20250829T120000+0000',
+            comment: 'Fix issue',
+            files: { file: [{ name: 'src/app.ts', changeType: 'MODIFIED' }] },
           },
         ],
       };
 
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      mockedAxios.get.mockResolvedValue({ data: mockChanges });
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listChangesForBuild.mockResolvedValue({ data: changePayload } as never);
 
       const result = await manager.getBuildResults('12345', { includeChanges: true });
 
-      expect(result.changes).toHaveLength(2);
-      const ch0 = result.changes?.[0];
-      expect(ch0).toBeDefined();
-      if (!ch0) {
-        throw new Error('Expected first change');
-      }
-      expect(ch0.revision).toBe('abc123def456');
-      expect(ch0.author).toBe('developer');
-      expect(ch0.comment).toBe('Fix authentication bug');
-      expect(ch0.files).toHaveLength(2);
+      expect(result.changes).toHaveLength(1);
+      expect(result.changes?.[0]?.files?.[0]?.path).toBe('src/app.ts');
+    });
+
+    it('handles empty change responses', async () => {
+      const mockBuild = basicBuild();
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listChangesForBuild.mockResolvedValue({ data: {} } as never);
+
+      const result = await manager.getBuildResults('12345', { includeChanges: true });
+      expect(result.changes).toEqual([]);
     });
   });
 
-  describe('Parallel Data Fetching', () => {
-    it('should fetch multiple data types in parallel', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
+  describe('Caching Behaviour', () => {
+    it('caches finished build results', async () => {
+      const mockBuild = basicBuild();
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
 
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      const axiosGetSpy = mockedAxios.get
-        .mockResolvedValueOnce({ data: { file: [] } }) // artifacts
-        .mockResolvedValueOnce({ data: { property: [] } }) // statistics
-        .mockResolvedValueOnce({ data: { change: [] } }); // changes
-
-      const startTime = Date.now();
-
-      await manager.getBuildResults('12345', {
-        includeArtifacts: true,
-        includeStatistics: true,
-        includeChanges: true,
-      });
-
-      const endTime = Date.now();
-
-      // All three API calls should be made
-      expect(axiosGetSpy).toHaveBeenCalledTimes(3);
-
-      // Should execute in parallel (not take 3x the time)
-      // Should be fast in tests; allow a bit of CI jitter
-      expect(endTime - startTime).toBeLessThan(150);
-    });
-  });
-
-  describe('Caching', () => {
-    it('should cache results for completed builds', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-
-      // First call
+      await manager.getBuildResults('12345');
       await manager.getBuildResults('12345');
 
-      // Second call should use cache
-      await manager.getBuildResults('12345');
-
-      // Should only call API once
       expect(mockClient.builds.getBuild).toHaveBeenCalledTimes(1);
     });
 
-    it('should not cache results for running builds', async () => {
-      const mockBuild = {
+    it('does not cache running builds', async () => {
+      const runningBuild = {
         data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
+          ...basicBuild().data,
           state: 'running',
-          statusText: 'Tests running...',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
         },
       };
+      mockClient.builds.getBuild.mockResolvedValue(runningBuild as never);
 
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-
-      // First call
+      await manager.getBuildResults('12345');
       await manager.getBuildResults('12345');
 
-      // Second call should not use cache
-      await manager.getBuildResults('12345');
-
-      // Should call API twice
       expect(mockClient.builds.getBuild).toHaveBeenCalledTimes(2);
     });
 
-    it('should respect cache TTL', async () => {
+    it('expires cache entries after TTL', async () => {
       jest.useFakeTimers();
+      const mockBuild = basicBuild();
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
 
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-
-      // First call
       await manager.getBuildResults('12345');
-
-      // Advance time by 9 minutes (still within TTL)
       jest.advanceTimersByTime(9 * 60 * 1000);
       await manager.getBuildResults('12345');
 
-      // Should still use cache
       expect(mockClient.builds.getBuild).toHaveBeenCalledTimes(1);
 
-      // Advance time by 2 more minutes (total 11 minutes, exceeds TTL)
       jest.advanceTimersByTime(2 * 60 * 1000);
       await manager.getBuildResults('12345');
 
-      // Should make new API call
       expect(mockClient.builds.getBuild).toHaveBeenCalledTimes(2);
-
       jest.useRealTimers();
     });
   });
 
   describe('Error Handling', () => {
-    it('should handle build not found errors', async () => {
+    it('surfaces not found errors directly', async () => {
       mockClient.builds.getBuild.mockRejectedValue(new Error('Build not found'));
-
       await expect(manager.getBuildResults('99999')).rejects.toThrow('Build not found');
     });
 
-    it('should handle network errors gracefully', async () => {
+    it('wraps unknown errors with friendly message', async () => {
       mockClient.builds.getBuild.mockRejectedValue(new Error('Network error'));
-
       await expect(manager.getBuildResults('12345')).rejects.toThrow(
-        'Failed to fetch build results'
+        'Failed to fetch build results: Network error'
       );
     });
 
-    it('should handle artifact fetch errors without failing entire request', async () => {
-      const mockBuild = {
-        data: {
-          id: 12345,
-          buildTypeId: 'MyBuildConfig',
-          number: '42',
-          status: 'SUCCESS',
-          state: 'finished',
-          statusText: 'Build completed',
-          webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-        },
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild);
-
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      mockedAxios.get.mockRejectedValue(new Error('Artifact API error'));
+    it('keeps core data when artifacts request fails', async () => {
+      const mockBuild = basicBuild();
+      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
+      mockClient.listBuildArtifacts.mockRejectedValue(new Error('Artifact API error'));
 
       const result = await manager.getBuildResults('12345', { includeArtifacts: true });
 
-      // Should return build data even if artifacts fail
       expect(result.build.id).toBe(12345);
       expect(result.artifacts).toEqual([]);
     });

--- a/tests/unit/teamcity/build-status-manager.test.ts
+++ b/tests/unit/teamcity/build-status-manager.test.ts
@@ -2,7 +2,7 @@
  * Tests for BuildStatusManager
  */
 import { BuildStatusManager, type BuildStatusOptions } from '@/teamcity/build-status-manager';
-import type { TeamCityClient } from '@/teamcity/client';
+import type { TeamCityClientAdapter } from '@/teamcity/client-adapter';
 import { BuildAccessDeniedError, BuildNotFoundError } from '@/teamcity/errors';
 
 // Mock the TeamCityClient
@@ -10,7 +10,19 @@ jest.mock('@/teamcity/client');
 
 describe('BuildStatusManager', () => {
   let manager: BuildStatusManager;
-  type MockClient = { builds: { getBuild: jest.Mock; getMultipleBuilds: jest.Mock } };
+  type MockClient = {
+    builds: {
+      getBuild: jest.Mock;
+      getMultipleBuilds: jest.Mock;
+      getBuildProblems: jest.Mock;
+    };
+    listBuildArtifacts: jest.Mock;
+    downloadArtifactContent: jest.Mock;
+    getBuildStatistics: jest.Mock;
+    listChangesForBuild: jest.Mock;
+    listSnapshotDependencies: jest.Mock;
+    baseUrl: string;
+  };
   let mockClient: MockClient;
 
   beforeEach(() => {
@@ -19,10 +31,17 @@ describe('BuildStatusManager', () => {
       builds: {
         getBuild: jest.fn(),
         getMultipleBuilds: jest.fn(),
+        getBuildProblems: jest.fn(),
       },
+      listBuildArtifacts: jest.fn(),
+      downloadArtifactContent: jest.fn(),
+      getBuildStatistics: jest.fn(),
+      listChangesForBuild: jest.fn(),
+      listSnapshotDependencies: jest.fn(),
+      baseUrl: 'https://teamcity.example.com',
     };
 
-    manager = new BuildStatusManager(mockClient as unknown as TeamCityClient);
+    manager = new BuildStatusManager(mockClient as unknown as TeamCityClientAdapter);
   });
 
   describe('getBuildStatus', () => {

--- a/tests/unit/tools/analyze-build-problems.test.ts
+++ b/tests/unit/tools/analyze-build-problems.test.ts
@@ -1,0 +1,28 @@
+describe('tools: analyze_build_problems', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('passes an id-prefixed locator to getBuildProblems', async () => {
+    const getBuild = jest.fn().mockResolvedValue({ status: 'SUCCESS', statusText: 'All good' });
+    const getBuildProblems = jest.fn().mockResolvedValue({ data: [] });
+    const listTestFailures = jest.fn().mockResolvedValue([]);
+
+    jest.doMock('@/api-client', () => ({
+      TeamCityAPI: {
+        getInstance: () => ({
+          getBuild,
+          builds: { getBuildProblems },
+          listTestFailures,
+        }),
+      },
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getRequiredTool } = require('@/tools');
+    await getRequiredTool('analyze_build_problems').handler({ buildId: '123' });
+
+    expect(getBuildProblems).toHaveBeenCalledWith('id:123');
+  });
+});

--- a/tests/unit/tools/availability-and-queue.test.ts
+++ b/tests/unit/tools/availability-and-queue.test.ts
@@ -91,7 +91,16 @@ describe('tools: availability & queue structured tools', () => {
           const getQueuedBuild = jest.fn(async () => ({ data: { waitReason: 'No agent' } }));
           jest.doMock('@/api-client', () => ({
             TeamCityAPI: {
-              getInstance: () => ({ buildQueue: { getAllQueuedBuilds, getQueuedBuild } }),
+              getInstance: () => ({
+                buildQueue: { getAllQueuedBuilds, getQueuedBuild },
+                builds: {},
+                listBuildArtifacts: jest.fn(),
+                downloadBuildArtifact: jest.fn(),
+                getBuildStatistics: jest.fn(),
+                listChangesForBuild: jest.fn(),
+                listSnapshotDependencies: jest.fn(),
+                getBaseUrl: () => 'https://example.test',
+              }),
             },
           }));
           // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/tests/unit/tools/build-actions-and-status.test.ts
+++ b/tests/unit/tools/build-actions-and-status.test.ts
@@ -111,7 +111,19 @@ describe('tools: build actions and status/basic info', () => {
               }
             },
           }));
-          jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance: () => ({}) } }));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({
+                builds: {},
+                listBuildArtifacts: jest.fn(),
+                downloadBuildArtifact: jest.fn(),
+                getBuildStatistics: jest.fn(),
+                listChangesForBuild: jest.fn(),
+                listSnapshotDependencies: jest.fn(),
+                getBaseUrl: () => 'https://example.test',
+              }),
+            },
+          }));
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           const { getRequiredTool } = require('@/tools');
           const res = await getRequiredTool('get_build_status').handler({ buildId: 'b9' });

--- a/tests/unit/tools/get-status-and-results.test.ts
+++ b/tests/unit/tools/get-status-and-results.test.ts
@@ -25,10 +25,19 @@ describe('tools: enhanced status and results', () => {
     jest.doMock('@/teamcity/build-status-manager', () => ({ BuildStatusManager }));
 
     // Mock TeamCityAPI.getInstance to avoid env dependency
-    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance: () => ({ builds: {} }) } }));
-    // Re-require tools after mocking the module
-    // Mock TeamCityAPI.getInstance to avoid env dependency
-    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance: () => ({ builds: {} }) } }));
+    jest.doMock('@/api-client', () => ({
+      TeamCityAPI: {
+        getInstance: () => ({
+          builds: {},
+          listBuildArtifacts: jest.fn(),
+          downloadBuildArtifact: jest.fn(),
+          getBuildStatistics: jest.fn(),
+          listChangesForBuild: jest.fn(),
+          listSnapshotDependencies: jest.fn(),
+          getBaseUrl: () => 'https://example.test',
+        }),
+      },
+    }));
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { getRequiredTool } = require('@/tools');
     const res = await getRequiredTool('get_build_status').handler({


### PR DESCRIPTION
## Summary
- refactor BuildResultsManager to consume the TeamCityAPI adapter for artifacts, statistics, changes, and dependencies
- extend the adapter surface (plus getBuildLog helper) and fix analyze_build_problems to send id-prefixed locators with regression coverage
- update impacted tool/unit tests to work with the richer adapter mocks

Closes #108

## Testing
- npm run test:unit
