### PR TITLE
feat(tools): expose change and admin REST tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+* **tools:** expose change, problem, investigation, mute, versioned-settings, and user/role MCP tools ([#107](https://github.com/Daghis/teamcity-mcp/issues/107))
+
 ## [1.2.1](https://github.com/Daghis/teamcity-mcp/compare/v1.2.0...v1.2.1) (2025-09-16)
 
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -57,6 +57,20 @@ This document lists all Model Context Protocol (MCP) tools exposed by the TeamCi
 - `analyze_build_problems` — Problems + failing tests summary
   - Args: `buildId: string`
 
+### Changes & Diagnostics
+- `list_changes` — List version control changes (paginated)
+  - Args: `locator?: string`, `projectId?: string`, `buildId?: string`, `pageSize?: number`, `maxPages?: number`, `all?: boolean`, `fields?: string`
+- `list_problems` — List build problems (paginated)
+  - Args: `locator?: string`, `projectId?: string`, `buildId?: string`, `pageSize?: number`, `maxPages?: number`, `all?: boolean`, `fields?: string`
+- `list_problem_occurrences` — List problem occurrences (paginated)
+  - Args: `locator?: string`, `buildId?: string`, `problemId?: string`, `pageSize?: number`, `maxPages?: number`, `all?: boolean`, `fields?: string`
+- `list_investigations` — List investigations (paginated)
+  - Args: `locator?: string`, `projectId?: string`, `buildTypeId?: string`, `assigneeUsername?: string`, `pageSize?: number`, `maxPages?: number`, `all?: boolean`, `fields?: string`
+- `list_muted_tests` — List muted tests (paginated)
+  - Args: `locator?: string`, `projectId?: string`, `buildTypeId?: string`, `testNameId?: string`, `pageSize?: number`, `maxPages?: number`, `all?: boolean`, `fields?: string`
+- `get_versioned_settings_status` — Versioned Settings status for a locator
+  - Args: `locator: string`, `fields?: string`
+
 ### Build Configurations
 - `list_build_configs` — List build configurations (paginated)
   - Args: `locator?: string`, `projectId?: string`, `pageSize?: number`, `maxPages?: number`, `all?: boolean`, `fields?: string`
@@ -132,6 +146,12 @@ This document lists all Model Context Protocol (MCP) tools exposed by the TeamCi
   - Args: `buildId: string`, `includeDisabled?: boolean`
   - Mode: dev, full
 
+### Users & Roles
+- `list_users` — List users (paginated)
+  - Args: `locator?: string`, `groupId?: string`, `pageSize?: number`, `maxPages?: number`, `all?: boolean`, `fields?: string`
+- `list_roles` — List defined roles and permissions
+  - Args: `fields?: string`
+
 ### Tests
 - `list_test_failures` — List failing tests for a build (paginated)
   - Args: `buildId: string`, `pageSize?: number`, `maxPages?: number`, `all?: boolean`, `fields?: string`
@@ -164,6 +184,11 @@ This document lists all Model Context Protocol (MCP) tools exposed by the TeamCi
   - Args: `poolId: string`, `cancelQueuedForBuildTypeId?: string`, `comment?: string`, `until?: string`
 - `resume_queue_for_pool` — Re-enable all agents in a pool
   - Args: `poolId: string`
+
+### Test Administration (full)
+- `mute_tests` — Mute tests within a project or build configuration scope
+  - Args: `testNameIds: string[]`, `buildTypeId?: string`, `projectId?: string`, `comment?: string`, `until?: string`, `fields?: string`
+  - Mode: full
 
 ### Server Health & Metrics
 - `get_server_info` — Returns `/app/rest/server`

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -20,10 +20,18 @@ import { AgentPoolApi } from './teamcity-client/api/agent-pool-api';
 import { BuildApi } from './teamcity-client/api/build-api';
 import { BuildQueueApi } from './teamcity-client/api/build-queue-api';
 import { BuildTypeApi } from './teamcity-client/api/build-type-api';
+import { ChangeApi } from './teamcity-client/api/change-api';
 import { HealthApi } from './teamcity-client/api/health-api';
+import { InvestigationApi } from './teamcity-client/api/investigation-api';
+import { MuteApi } from './teamcity-client/api/mute-api';
+import { ProblemApi } from './teamcity-client/api/problem-api';
+import { ProblemOccurrenceApi } from './teamcity-client/api/problem-occurrence-api';
 import { ProjectApi } from './teamcity-client/api/project-api';
+import { RoleApi } from './teamcity-client/api/role-api';
 import { ServerApi } from './teamcity-client/api/server-api';
 import { TestOccurrenceApi } from './teamcity-client/api/test-occurrence-api';
+import { UserApi } from './teamcity-client/api/user-api';
+import { VersionedSettingsApi } from './teamcity-client/api/versioned-settings-api';
 import { VcsRootApi } from './teamcity-client/api/vcs-root-api';
 import { Configuration } from './teamcity-client/configuration';
 
@@ -43,6 +51,14 @@ export class TeamCityAPI {
   public agentPools: AgentPoolApi;
   public server: ServerApi;
   public health: HealthApi;
+  public changes: ChangeApi;
+  public problems: ProblemApi;
+  public problemOccurrences: ProblemOccurrenceApi;
+  public investigations: InvestigationApi;
+  public mutes: MuteApi;
+  public versionedSettings: VersionedSettingsApi;
+  public roles: RoleApi;
+  public users: UserApi;
 
   private constructor(baseUrl: string, token: string) {
     // Remove trailing slash from base URL
@@ -112,6 +128,14 @@ export class TeamCityAPI {
     this.agentPools = new AgentPoolApi(this.config, basePath, this.axiosInstance);
     this.server = new ServerApi(this.config, basePath, this.axiosInstance);
     this.health = new HealthApi(this.config, basePath, this.axiosInstance);
+    this.changes = new ChangeApi(this.config, basePath, this.axiosInstance);
+    this.problems = new ProblemApi(this.config, basePath, this.axiosInstance);
+    this.problemOccurrences = new ProblemOccurrenceApi(this.config, basePath, this.axiosInstance);
+    this.investigations = new InvestigationApi(this.config, basePath, this.axiosInstance);
+    this.mutes = new MuteApi(this.config, basePath, this.axiosInstance);
+    this.versionedSettings = new VersionedSettingsApi(this.config, basePath, this.axiosInstance);
+    this.roles = new RoleApi(this.config, basePath, this.axiosInstance);
+    this.users = new UserApi(this.config, basePath, this.axiosInstance);
 
     info('TeamCityAPI initialized', { baseUrl: basePath });
   }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -10,6 +10,8 @@ import { BuildResultsManager } from '@/teamcity/build-results-manager';
 import type { TeamCityClient } from '@/teamcity/client';
 import { createAdapterFromTeamCityAPI } from '@/teamcity/client-adapter';
 import { createPaginatedFetcher, fetchAllPages } from '@/teamcity/pagination';
+import type { Mutes } from '@/teamcity-client/models';
+import { ResolutionTypeEnum } from '@/teamcity-client/models';
 import { debug } from '@/utils/logger';
 import { json, runTool } from '@/utils/mcp';
 
@@ -1769,6 +1771,535 @@ const DEV_TOOLS: ToolDefinition[] = [
     },
   },
 
+  // === Changes, Problems & Diagnostics ===
+  {
+    name: 'list_changes',
+    description: 'List VCS changes (supports pagination)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        locator: { type: 'string', description: 'Optional change locator to filter results' },
+        projectId: { type: 'string', description: 'Filter by project ID via locator helper' },
+        buildId: { type: 'string', description: 'Filter by build ID via locator helper' },
+        pageSize: { type: 'number', description: 'Items per page (default 100)' },
+        maxPages: { type: 'number', description: 'Max pages to fetch (when all=true)' },
+        all: { type: 'boolean', description: 'Fetch all pages up to maxPages' },
+        fields: {
+          type: 'string',
+          description: 'Optional fields selector for server-side projection',
+        },
+      },
+    },
+    handler: async (args: unknown) => {
+      const schema = z.object({
+        locator: z.string().min(1).optional(),
+        projectId: z.string().min(1).optional(),
+        buildId: z.string().min(1).optional(),
+        pageSize: z.number().int().min(1).max(1000).optional(),
+        maxPages: z.number().int().min(1).max(1000).optional(),
+        all: z.boolean().optional(),
+        fields: z.string().min(1).optional(),
+      });
+      return runTool(
+        'list_changes',
+        schema,
+        async (typed) => {
+          const api = TeamCityAPI.getInstance();
+          const baseParts: string[] = [];
+          if (typed.locator) baseParts.push(typed.locator);
+          if (typed.projectId) baseParts.push(`project:(id:${typed.projectId})`);
+          if (typed.buildId) baseParts.push(`build:(id:${typed.buildId})`);
+
+          const pageSize = typed.pageSize ?? 100;
+          const baseFetch = async ({ count, start }: { count?: number; start?: number }) => {
+            const parts = [...baseParts];
+            if (typeof count === 'number') parts.push(`count:${count}`);
+            if (typeof start === 'number') parts.push(`start:${start}`);
+            const locator = parts.length > 0 ? parts.join(',') : undefined;
+            return api.changes.getAllChanges(locator as string | undefined, typed.fields);
+          };
+
+          const fetcher = createPaginatedFetcher(
+            baseFetch,
+            (response: unknown) => {
+              const data = response as { change?: unknown[]; count?: number };
+              return Array.isArray(data.change) ? (data.change as unknown[]) : [];
+            },
+            (response: unknown) => {
+              const data = response as { count?: number };
+              return typeof data.count === 'number' ? data.count : undefined;
+            }
+          );
+
+          if (typed.all) {
+            const items = await fetchAllPages(fetcher, { pageSize, maxPages: typed.maxPages });
+            return json({ items, pagination: { mode: 'all', pageSize, fetched: items.length } });
+          }
+
+          const firstPage = await fetcher({ count: pageSize, start: 0 });
+          return json({ items: firstPage.items, pagination: { page: 1, pageSize } });
+        },
+        args
+      );
+    },
+  },
+
+  {
+    name: 'list_problems',
+    description: 'List build problems (supports pagination)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        locator: { type: 'string', description: 'Optional problem locator to filter results' },
+        projectId: { type: 'string', description: 'Filter by project ID via locator helper' },
+        buildId: { type: 'string', description: 'Filter by build ID via locator helper' },
+        pageSize: { type: 'number', description: 'Items per page (default 100)' },
+        maxPages: { type: 'number', description: 'Max pages to fetch (when all=true)' },
+        all: { type: 'boolean', description: 'Fetch all pages up to maxPages' },
+        fields: {
+          type: 'string',
+          description: 'Optional fields selector for server-side projection',
+        },
+      },
+    },
+    handler: async (args: unknown) => {
+      const schema = z.object({
+        locator: z.string().min(1).optional(),
+        projectId: z.string().min(1).optional(),
+        buildId: z.string().min(1).optional(),
+        pageSize: z.number().int().min(1).max(1000).optional(),
+        maxPages: z.number().int().min(1).max(1000).optional(),
+        all: z.boolean().optional(),
+        fields: z.string().min(1).optional(),
+      });
+      return runTool(
+        'list_problems',
+        schema,
+        async (typed) => {
+          const api = TeamCityAPI.getInstance();
+          const baseParts: string[] = [];
+          if (typed.locator) baseParts.push(typed.locator);
+          if (typed.projectId) baseParts.push(`project:(id:${typed.projectId})`);
+          if (typed.buildId) baseParts.push(`build:(id:${typed.buildId})`);
+
+          const pageSize = typed.pageSize ?? 100;
+          const baseFetch = async ({ count, start }: { count?: number; start?: number }) => {
+            const parts = [...baseParts];
+            if (typeof count === 'number') parts.push(`count:${count}`);
+            if (typeof start === 'number') parts.push(`start:${start}`);
+            const locator = parts.length > 0 ? parts.join(',') : undefined;
+            return api.problems.getAllBuildProblems(locator as string | undefined, typed.fields);
+          };
+
+          const fetcher = createPaginatedFetcher(
+            baseFetch,
+            (response: unknown) => {
+              const data = response as { problem?: unknown[]; count?: number };
+              return Array.isArray(data.problem) ? (data.problem as unknown[]) : [];
+            },
+            (response: unknown) => {
+              const data = response as { count?: number };
+              return typeof data.count === 'number' ? data.count : undefined;
+            }
+          );
+
+          if (typed.all) {
+            const items = await fetchAllPages(fetcher, { pageSize, maxPages: typed.maxPages });
+            return json({ items, pagination: { mode: 'all', pageSize, fetched: items.length } });
+          }
+
+          const firstPage = await fetcher({ count: pageSize, start: 0 });
+          return json({ items: firstPage.items, pagination: { page: 1, pageSize } });
+        },
+        args
+      );
+    },
+  },
+
+  {
+    name: 'list_problem_occurrences',
+    description: 'List problem occurrences (supports pagination)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        locator: {
+          type: 'string',
+          description: 'Optional problem occurrence locator to filter results',
+        },
+        buildId: { type: 'string', description: 'Filter by build ID via locator helper' },
+        problemId: {
+          type: 'string',
+          description: 'Filter by problem ID via locator helper',
+        },
+        pageSize: { type: 'number', description: 'Items per page (default 100)' },
+        maxPages: { type: 'number', description: 'Max pages to fetch (when all=true)' },
+        all: { type: 'boolean', description: 'Fetch all pages up to maxPages' },
+        fields: {
+          type: 'string',
+          description: 'Optional fields selector for server-side projection',
+        },
+      },
+    },
+    handler: async (args: unknown) => {
+      const schema = z.object({
+        locator: z.string().min(1).optional(),
+        buildId: z.string().min(1).optional(),
+        problemId: z.string().min(1).optional(),
+        pageSize: z.number().int().min(1).max(1000).optional(),
+        maxPages: z.number().int().min(1).max(1000).optional(),
+        all: z.boolean().optional(),
+        fields: z.string().min(1).optional(),
+      });
+      return runTool(
+        'list_problem_occurrences',
+        schema,
+        async (typed) => {
+          const api = TeamCityAPI.getInstance();
+          const baseParts: string[] = [];
+          if (typed.locator) baseParts.push(typed.locator);
+          if (typed.buildId) baseParts.push(`build:(id:${typed.buildId})`);
+          if (typed.problemId) baseParts.push(`problem:(id:${typed.problemId})`);
+
+          const pageSize = typed.pageSize ?? 100;
+          const baseFetch = async ({ count, start }: { count?: number; start?: number }) => {
+            const parts = [...baseParts];
+            if (typeof count === 'number') parts.push(`count:${count}`);
+            if (typeof start === 'number') parts.push(`start:${start}`);
+            const locator = parts.length > 0 ? parts.join(',') : undefined;
+            return api.problemOccurrences.getAllBuildProblemOccurrences(
+              locator as string | undefined,
+              typed.fields
+            );
+          };
+
+          const fetcher = createPaginatedFetcher(
+            baseFetch,
+            (response: unknown) => {
+              const data = response as { problemOccurrence?: unknown[]; count?: number };
+              return Array.isArray(data.problemOccurrence)
+                ? (data.problemOccurrence as unknown[])
+                : [];
+            },
+            (response: unknown) => {
+              const data = response as { count?: number };
+              return typeof data.count === 'number' ? data.count : undefined;
+            }
+          );
+
+          if (typed.all) {
+            const items = await fetchAllPages(fetcher, { pageSize, maxPages: typed.maxPages });
+            return json({ items, pagination: { mode: 'all', pageSize, fetched: items.length } });
+          }
+
+          const firstPage = await fetcher({ count: pageSize, start: 0 });
+          return json({ items: firstPage.items, pagination: { page: 1, pageSize } });
+        },
+        args
+      );
+    },
+  },
+
+  {
+    name: 'list_investigations',
+    description: 'List open investigations (supports pagination)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        locator: {
+          type: 'string',
+          description: 'Optional investigation locator to filter results',
+        },
+        projectId: { type: 'string', description: 'Filter by project ID via locator helper' },
+        buildTypeId: {
+          type: 'string',
+          description: 'Filter by build configuration ID via locator helper',
+        },
+        assigneeUsername: {
+          type: 'string',
+          description: 'Filter by responsible user username via locator helper',
+        },
+        pageSize: { type: 'number', description: 'Items per page (default 100)' },
+        maxPages: { type: 'number', description: 'Max pages to fetch (when all=true)' },
+        all: { type: 'boolean', description: 'Fetch all pages up to maxPages' },
+        fields: {
+          type: 'string',
+          description: 'Optional fields selector for server-side projection',
+        },
+      },
+    },
+    handler: async (args: unknown) => {
+      const schema = z.object({
+        locator: z.string().min(1).optional(),
+        projectId: z.string().min(1).optional(),
+        buildTypeId: z.string().min(1).optional(),
+        assigneeUsername: z.string().min(1).optional(),
+        pageSize: z.number().int().min(1).max(1000).optional(),
+        maxPages: z.number().int().min(1).max(1000).optional(),
+        all: z.boolean().optional(),
+        fields: z.string().min(1).optional(),
+      });
+      return runTool(
+        'list_investigations',
+        schema,
+        async (typed) => {
+          const api = TeamCityAPI.getInstance();
+          const baseParts: string[] = [];
+          if (typed.locator) baseParts.push(typed.locator);
+          if (typed.projectId) baseParts.push(`project:(id:${typed.projectId})`);
+          if (typed.buildTypeId) baseParts.push(`buildType:(id:${typed.buildTypeId})`);
+          if (typed.assigneeUsername)
+            baseParts.push(`responsible:(user:(username:${typed.assigneeUsername}))`);
+
+          const pageSize = typed.pageSize ?? 100;
+          const baseFetch = async ({ count, start }: { count?: number; start?: number }) => {
+            const parts = [...baseParts];
+            if (typeof count === 'number') parts.push(`count:${count}`);
+            if (typeof start === 'number') parts.push(`start:${start}`);
+            const locator = parts.length > 0 ? parts.join(',') : undefined;
+            return api.investigations.getAllInvestigations(
+              locator as string | undefined,
+              typed.fields
+            );
+          };
+
+          const fetcher = createPaginatedFetcher(
+            baseFetch,
+            (response: unknown) => {
+              const data = response as { investigation?: unknown[]; count?: number };
+              return Array.isArray(data.investigation) ? (data.investigation as unknown[]) : [];
+            },
+            (response: unknown) => {
+              const data = response as { count?: number };
+              return typeof data.count === 'number' ? data.count : undefined;
+            }
+          );
+
+          if (typed.all) {
+            const items = await fetchAllPages(fetcher, { pageSize, maxPages: typed.maxPages });
+            return json({ items, pagination: { mode: 'all', pageSize, fetched: items.length } });
+          }
+
+          const firstPage = await fetcher({ count: pageSize, start: 0 });
+          return json({ items: firstPage.items, pagination: { page: 1, pageSize } });
+        },
+        args
+      );
+    },
+  },
+
+  {
+    name: 'list_muted_tests',
+    description: 'List muted tests (supports pagination)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        locator: { type: 'string', description: 'Optional mute locator to filter results' },
+        projectId: { type: 'string', description: 'Filter by project ID via locator helper' },
+        buildTypeId: {
+          type: 'string',
+          description: 'Filter by build configuration ID via locator helper',
+        },
+        testNameId: { type: 'string', description: 'Filter by test name ID via locator helper' },
+        pageSize: { type: 'number', description: 'Items per page (default 100)' },
+        maxPages: { type: 'number', description: 'Max pages to fetch (when all=true)' },
+        all: { type: 'boolean', description: 'Fetch all pages up to maxPages' },
+        fields: {
+          type: 'string',
+          description: 'Optional fields selector for server-side projection',
+        },
+      },
+    },
+    handler: async (args: unknown) => {
+      const schema = z.object({
+        locator: z.string().min(1).optional(),
+        projectId: z.string().min(1).optional(),
+        buildTypeId: z.string().min(1).optional(),
+        testNameId: z.string().min(1).optional(),
+        pageSize: z.number().int().min(1).max(1000).optional(),
+        maxPages: z.number().int().min(1).max(1000).optional(),
+        all: z.boolean().optional(),
+        fields: z.string().min(1).optional(),
+      });
+      return runTool(
+        'list_muted_tests',
+        schema,
+        async (typed) => {
+          const api = TeamCityAPI.getInstance();
+          const baseParts: string[] = [];
+          if (typed.locator) baseParts.push(typed.locator);
+          if (typed.projectId) baseParts.push(`project:(id:${typed.projectId})`);
+          if (typed.buildTypeId) baseParts.push(`buildType:(id:${typed.buildTypeId})`);
+          if (typed.testNameId) baseParts.push(`test:(id:${typed.testNameId})`);
+
+          const pageSize = typed.pageSize ?? 100;
+          const baseFetch = async ({ count, start }: { count?: number; start?: number }) => {
+            const parts = [...baseParts];
+            if (typeof count === 'number') parts.push(`count:${count}`);
+            if (typeof start === 'number') parts.push(`start:${start}`);
+            const locator = parts.length > 0 ? parts.join(',') : undefined;
+            return api.mutes.getAllMutedTests(locator as string | undefined, typed.fields);
+          };
+
+          const fetcher = createPaginatedFetcher(
+            baseFetch,
+            (response: unknown) => {
+              const data = response as { mute?: unknown[]; count?: number };
+              return Array.isArray(data.mute) ? (data.mute as unknown[]) : [];
+            },
+            (response: unknown) => {
+              const data = response as { count?: number };
+              return typeof data.count === 'number' ? data.count : undefined;
+            }
+          );
+
+          if (typed.all) {
+            const items = await fetchAllPages(fetcher, { pageSize, maxPages: typed.maxPages });
+            return json({ items, pagination: { mode: 'all', pageSize, fetched: items.length } });
+          }
+
+          const firstPage = await fetcher({ count: pageSize, start: 0 });
+          return json({ items: firstPage.items, pagination: { page: 1, pageSize } });
+        },
+        args
+      );
+    },
+  },
+
+  {
+    name: 'get_versioned_settings_status',
+    description: 'Get Versioned Settings status for a locator',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        locator: {
+          type: 'string',
+          description: 'Locator identifying a project/buildType for Versioned Settings',
+        },
+        fields: {
+          type: 'string',
+          description: 'Optional fields selector for server-side projection',
+        },
+      },
+      required: ['locator'],
+    },
+    handler: async (args: unknown) => {
+      const schema = z.object({
+        locator: z.string().min(1),
+        fields: z.string().min(1).optional(),
+      });
+      return runTool(
+        'get_versioned_settings_status',
+        schema,
+        async (typed) => {
+          const api = TeamCityAPI.getInstance();
+          const response = await api.versionedSettings.getVersionedSettingsStatus(
+            typed.locator,
+            typed.fields
+          );
+          return json(response.data);
+        },
+        args
+      );
+    },
+  },
+
+  {
+    name: 'list_users',
+    description: 'List TeamCity users (supports pagination)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        locator: { type: 'string', description: 'Optional user locator to filter results' },
+        groupId: { type: 'string', description: 'Filter by group ID via locator helper' },
+        pageSize: { type: 'number', description: 'Items per page (default 100)' },
+        maxPages: { type: 'number', description: 'Max pages to fetch (when all=true)' },
+        all: { type: 'boolean', description: 'Fetch all pages up to maxPages' },
+        fields: {
+          type: 'string',
+          description: 'Optional fields selector for server-side projection',
+        },
+      },
+    },
+    handler: async (args: unknown) => {
+      const schema = z.object({
+        locator: z.string().min(1).optional(),
+        groupId: z.string().min(1).optional(),
+        pageSize: z.number().int().min(1).max(1000).optional(),
+        maxPages: z.number().int().min(1).max(1000).optional(),
+        all: z.boolean().optional(),
+        fields: z.string().min(1).optional(),
+      });
+      return runTool(
+        'list_users',
+        schema,
+        async (typed) => {
+          const api = TeamCityAPI.getInstance();
+          const baseParts: string[] = [];
+          if (typed.locator) baseParts.push(typed.locator);
+          if (typed.groupId) baseParts.push(`group:(id:${typed.groupId})`);
+
+          const pageSize = typed.pageSize ?? 100;
+          const baseFetch = async ({ count, start }: { count?: number; start?: number }) => {
+            const parts = [...baseParts];
+            if (typeof count === 'number') parts.push(`count:${count}`);
+            if (typeof start === 'number') parts.push(`start:${start}`);
+            const locator = parts.length > 0 ? parts.join(',') : undefined;
+            return api.users.getAllUsers(locator as string | undefined, typed.fields);
+          };
+
+          const fetcher = createPaginatedFetcher(
+            baseFetch,
+            (response: unknown) => {
+              const data = response as { user?: unknown[]; count?: number };
+              return Array.isArray(data.user) ? (data.user as unknown[]) : [];
+            },
+            (response: unknown) => {
+              const data = response as { count?: number };
+              return typeof data.count === 'number' ? data.count : undefined;
+            }
+          );
+
+          if (typed.all) {
+            const items = await fetchAllPages(fetcher, { pageSize, maxPages: typed.maxPages });
+            return json({ items, pagination: { mode: 'all', pageSize, fetched: items.length } });
+          }
+
+          const firstPage = await fetcher({ count: pageSize, start: 0 });
+          return json({ items: firstPage.items, pagination: { page: 1, pageSize } });
+        },
+        args
+      );
+    },
+  },
+
+  {
+    name: 'list_roles',
+    description: 'List defined roles and their permissions',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        fields: {
+          type: 'string',
+          description: 'Optional fields selector for server-side projection',
+        },
+      },
+    },
+    handler: async (args: unknown) => {
+      const schema = z.object({ fields: z.string().min(1).optional() });
+      return runTool(
+        'list_roles',
+        schema,
+        async (typed) => {
+          const api = TeamCityAPI.getInstance();
+          const response = await api.roles.getRoles(typed.fields);
+          const roles = (response.data?.role ?? []) as unknown[];
+          return json({ items: roles, count: roles.length });
+        },
+        args
+      );
+    },
+  },
+
   {
     name: 'list_branches',
     description: 'List branches for a project or build configuration',
@@ -2692,6 +3223,101 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
             canceled,
             paused: typed.paused,
             ids: typed.buildTypeIds,
+          });
+        },
+        args
+      );
+    },
+    mode: 'full',
+  },
+
+  // === Test Administration ===
+  {
+    name: 'mute_tests',
+    description: 'Mute tests within a project or build configuration scope',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        testNameIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Test name IDs to mute',
+        },
+        buildTypeId: {
+          type: 'string',
+          description: 'Scope mute to a specific build configuration ID',
+        },
+        projectId: {
+          type: 'string',
+          description: 'Scope mute to a project (required if buildTypeId omitted)',
+        },
+        comment: { type: 'string', description: 'Optional mute comment' },
+        until: {
+          type: 'string',
+          description: 'Optional ISO timestamp to auto-unmute (yyyyMMddTHHmmss+ZZZZ)',
+        },
+        fields: {
+          type: 'string',
+          description: 'Optional fields selector for server-side projection',
+        },
+      },
+      required: ['testNameIds'],
+    },
+    handler: async (args: unknown) => {
+      const schema = z
+        .object({
+          testNameIds: z.array(z.string().min(1)).min(1),
+          buildTypeId: z.string().min(1).optional(),
+          projectId: z.string().min(1).optional(),
+          comment: z.string().optional(),
+          until: z.string().min(1).optional(),
+          fields: z.string().min(1).optional(),
+        })
+        .refine((value) => Boolean(value.buildTypeId ?? value.projectId), {
+          message: 'Either buildTypeId or projectId is required',
+          path: ['buildTypeId'],
+        });
+
+      return runTool(
+        'mute_tests',
+        schema,
+        async (typed) => {
+          const api = TeamCityAPI.getInstance();
+          const scope: { buildType?: { id: string }; project?: { id: string } } = typed.buildTypeId
+            ? { buildType: { id: typed.buildTypeId } }
+            : { project: { id: typed.projectId as string } };
+
+          const payload: Mutes = {
+            mute: [
+              {
+                scope,
+                target: {
+                  tests: {
+                    test: typed.testNameIds.map((id) => ({ id })),
+                  },
+                },
+                assignment: typed.comment ? { text: typed.comment } : undefined,
+                resolution: typed.until
+                  ? { type: ResolutionTypeEnum.AtTime, time: typed.until }
+                  : undefined,
+              },
+            ],
+          };
+
+          const response = await api.mutes.muteMultipleTests(typed.fields, payload, {
+            headers: {
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+            },
+          });
+
+          const muted = Array.isArray(typed.testNameIds) ? typed.testNameIds.length : 0;
+          return json({
+            success: true,
+            action: 'mute_tests',
+            muted,
+            scope,
+            response: response.data,
           });
         },
         args

--- a/tests/unit/tools/changes-problems-admin.test.ts
+++ b/tests/unit/tools/changes-problems-admin.test.ts
@@ -1,0 +1,209 @@
+import { getRequiredTool } from '@/tools';
+import type { ToolDefinition } from '@/tools';
+
+type PaginatedMock = jest.Mock<Promise<{ data: Record<string, unknown> }>, [string?]>;
+
+const createPaginatedMock = (items: unknown[], key: string): PaginatedMock =>
+  jest.fn(async (locator?: string) => {
+    const startMatch = locator?.match(/start:(\d+)/);
+    const countMatch = locator?.match(/count:(\d+)/);
+    const start = startMatch?.[1] ? parseInt(startMatch[1], 10) : 0;
+    const count = countMatch?.[1] ? parseInt(countMatch[1], 10) : 100;
+
+    const slice = items.slice(start, start + count);
+    const nextHref = start + count < items.length ? '/next' : undefined;
+
+    const data: Record<string, unknown> = { count: items.length };
+    data[key] = slice;
+    if (nextHref) data['nextHref'] = nextHref;
+
+    return { data };
+  });
+
+const getAllChanges = createPaginatedMock(
+  [{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }],
+  'change'
+);
+const getAllBuildProblems = createPaginatedMock(
+  [{ id: 'p1' }, { id: 'p2' }],
+  'problem'
+);
+const getAllBuildProblemOccurrences = createPaginatedMock(
+  [{ id: 'o1' }, { id: 'o2' }, { id: 'o3' }],
+  'problemOccurrence'
+);
+const getAllInvestigations = createPaginatedMock(
+  [{ id: 'i1' }, { id: 'i2' }],
+  'investigation'
+);
+const getAllMutedTests = createPaginatedMock(
+  [{ id: 'm1' }, { id: 'm2' }],
+  'mute'
+);
+const getVersionedSettingsStatus = jest.fn(async () => ({
+  data: { status: 'UP_TO_DATE', revision: '123' },
+}));
+const getAllUsers = createPaginatedMock(
+  [{ id: 'u1' }, { id: 'u2' }, { id: 'u3' }, { id: 'u4' }],
+  'user'
+);
+const getRoles = jest.fn(async () => ({ data: { role: [{ id: 'SYSTEM_ADMINISTRATOR' }] } }));
+const muteMultipleTests = jest.fn(async () => ({ data: { result: 'ok' } }));
+
+jest.mock('@/api-client', () => ({
+  TeamCityAPI: {
+    getInstance: () => ({
+      changes: { getAllChanges },
+      problems: { getAllBuildProblems },
+      problemOccurrences: { getAllBuildProblemOccurrences },
+      investigations: { getAllInvestigations },
+      mutes: { getAllMutedTests, muteMultipleTests },
+      versionedSettings: { getVersionedSettingsStatus },
+      users: { getAllUsers },
+      roles: { getRoles },
+    }),
+  },
+}));
+
+describe('changes/problems/investigation tools', () => {
+  beforeEach(() => {
+    getAllChanges.mockClear();
+    getAllBuildProblems.mockClear();
+    getAllBuildProblemOccurrences.mockClear();
+    getAllInvestigations.mockClear();
+    getAllMutedTests.mockClear();
+    getAllUsers.mockClear();
+    getVersionedSettingsStatus.mockClear();
+    getRoles.mockClear();
+    muteMultipleTests.mockClear();
+  });
+
+  it('lists changes with helper filters and pagination', async () => {
+    const res = await getRequiredTool('list_changes').handler({
+      projectId: 'Proj',
+      buildId: 'B1',
+      pageSize: 2,
+      all: true,
+    });
+    expect(getAllChanges).toHaveBeenCalled();
+    const locator = getAllChanges.mock.calls[0]?.[0];
+    expect(locator).toContain('project:(id:Proj)');
+    expect(locator).toContain('build:(id:B1)');
+    const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+    expect(payload.items).toHaveLength(3);
+    expect(payload.pagination.mode).toBe('all');
+  });
+
+  it('lists build problems with pagination helpers', async () => {
+    const res = await getRequiredTool('list_problems').handler({
+      projectId: 'Proj',
+      all: false,
+      pageSize: 1,
+    });
+    const locator = getAllBuildProblems.mock.calls[0]?.[0];
+    expect(locator).toContain('project:(id:Proj)');
+    const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+    expect(payload.items).toHaveLength(1);
+    expect(payload.pagination.page).toBe(1);
+  });
+
+  it('lists problem occurrences and applies helper filters', async () => {
+    await getRequiredTool('list_problem_occurrences').handler({
+      buildId: 'Build123',
+      problemId: 'Problem42',
+      pageSize: 3,
+    });
+    const locator = getAllBuildProblemOccurrences.mock.calls[0]?.[0];
+    expect(locator).toContain('build:(id:Build123)');
+    expect(locator).toContain('problem:(id:Problem42)');
+  });
+
+  it('lists investigations including responsible username helper', async () => {
+    await getRequiredTool('list_investigations').handler({
+      assigneeUsername: 'alice',
+      buildTypeId: 'bt1',
+      pageSize: 1,
+    });
+    const locator = getAllInvestigations.mock.calls[0]?.[0];
+    expect(locator).toContain('buildType:(id:bt1)');
+    expect(locator).toContain('responsible:(user:(username:alice))');
+  });
+
+  it('lists muted tests with helper filters', async () => {
+    await getRequiredTool('list_muted_tests').handler({
+      projectId: 'Proj',
+      testNameId: 'Test123',
+    });
+    const locator = getAllMutedTests.mock.calls[0]?.[0];
+    expect(locator).toContain('project:(id:Proj)');
+    expect(locator).toContain('test:(id:Test123)');
+  });
+
+  it('fetches Versioned Settings status', async () => {
+    const res = await getRequiredTool('get_versioned_settings_status').handler({
+      locator: 'project:(id:Proj)',
+    });
+    expect(getVersionedSettingsStatus).toHaveBeenCalledWith('project:(id:Proj)', undefined);
+    const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+    expect(payload.status).toBe('UP_TO_DATE');
+  });
+
+  it('lists users with helper filters and pagination', async () => {
+    await getRequiredTool('list_users').handler({ groupId: 'devs', all: true, pageSize: 2 });
+    const locator = getAllUsers.mock.calls[0]?.[0];
+    expect(locator).toContain('group:(id:devs)');
+    expect(getAllUsers).toHaveBeenCalledTimes(3);
+  });
+
+  it('lists roles and returns items/count', async () => {
+    const res = await getRequiredTool('list_roles').handler({});
+    expect(getRoles).toHaveBeenCalled();
+    const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+    expect(payload.items).toHaveLength(1);
+    expect(payload.count).toBe(1);
+  });
+
+  it('mutes tests with correct payload and scope helpers', async () => {
+    let tool: ToolDefinition | undefined;
+    const originalMode = process.env['MCP_MODE'];
+    process.env['MCP_MODE'] = 'full';
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+      const { getRequiredTool: getTool } = require('@/tools') as typeof import('@/tools');
+      tool = getTool('mute_tests');
+    });
+    if (originalMode === undefined) {
+      delete process.env['MCP_MODE'];
+    } else {
+      process.env['MCP_MODE'] = originalMode;
+    }
+
+    if (!tool) {
+      throw new Error('mute_tests tool not available');
+    }
+
+    await tool.handler({
+      testNameIds: ['t1', 't2'],
+      projectId: 'Proj',
+      comment: 'Mute for investigation',
+    });
+    const call = muteMultipleTests.mock.calls[0];
+    if (!call) {
+      throw new Error('muteMultipleTests not called');
+    }
+    const args = call as unknown[];
+    const fields = args[0] as string | undefined;
+    const payload = args[1] as Record<string, unknown> | undefined;
+    expect(fields).toBeUndefined();
+    expect(payload).toBeDefined();
+    expect(payload).toMatchObject({
+      mute: [
+        {
+          scope: { project: { id: 'Proj' } },
+          target: { tests: { test: [{ id: 't1' }, { id: 't2' }] } },
+          assignment: { text: 'Mute for investigation' },
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add read-only MCP tools for TeamCity changes, problems, investigations, muted tests, versioned settings, users, and roles
- add a full-mode `mute_tests` action and wire new API clients through the TeamCity API singleton
- document the new tools and cover them with unit tests

## Testing
- npm run test:unit

Closes #107
