### PR TITLE
fix(teamcity): route build list manager through adapter

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -15,6 +15,8 @@ import {
 import { TeamCityAPIError, isRetryableError } from '@/teamcity/errors';
 import { info } from '@/utils/logger';
 
+import type { TeamCityRequestFn } from '@/teamcity/types/client';
+
 import { AgentApi } from './teamcity-client/api/agent-api';
 import { AgentPoolApi } from './teamcity-client/api/agent-pool-api';
 import { BuildApi } from './teamcity-client/api/build-api';
@@ -329,17 +331,6 @@ export class TeamCityAPI {
     );
   }
 
-  async getBuildCount(locator?: string): Promise<AxiosResponse<string>> {
-    return this.axiosInstance.get('/app/rest/builds/count', {
-      params: locator ? { locator } : undefined,
-      headers: {
-        Accept: 'text/plain',
-      },
-      responseType: 'text',
-      transformResponse: [(data) => data],
-    });
-  }
-
   async downloadBuildArtifact(
     buildId: string,
     artifactPath: string
@@ -375,6 +366,13 @@ export class TeamCityAPI {
 
   getBaseUrl(): string {
     return this.baseUrl;
+  }
+
+  request<T>(fn: TeamCityRequestFn<T>): Promise<T> {
+    return fn({
+      axios: this.axiosInstance,
+      baseUrl: this.baseUrl,
+    });
   }
 
   async listVcsRoots(projectId?: string) {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -329,6 +329,17 @@ export class TeamCityAPI {
     );
   }
 
+  async getBuildCount(locator?: string): Promise<AxiosResponse<string>> {
+    return this.axiosInstance.get('/app/rest/builds/count', {
+      params: locator ? { locator } : undefined,
+      headers: {
+        Accept: 'text/plain',
+      },
+      responseType: 'text',
+      transformResponse: [(data) => data],
+    });
+  }
+
   async downloadBuildArtifact(
     buildId: string,
     artifactPath: string

--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -2,61 +2,25 @@
  * Lightweight adapter so managers can work with the unified TeamCityAPI
  * without depending on the legacy TeamCityClient implementation.
  */
-import type { AxiosResponse, RawAxiosRequestConfig } from 'axios';
-
 import type { TeamCityAPI } from '@/api-client';
 
-export interface BuildApiLike {
-  getBuild: (
-    buildLocator: string,
-    fields?: string,
-    options?: RawAxiosRequestConfig
-  ) => Promise<AxiosResponse<unknown>>;
-  getMultipleBuilds: (
-    locator: string,
-    fields?: string,
-    options?: RawAxiosRequestConfig
-  ) => Promise<AxiosResponse<unknown>>;
-  getBuildProblems: (
-    buildLocator: string,
-    fields?: string,
-    options?: RawAxiosRequestConfig
-  ) => Promise<AxiosResponse<unknown>>;
-}
+import type { BuildApiLike, TeamCityUnifiedClient } from './types/client';
 
-export interface TeamCityClientAdapter {
-  builds: BuildApiLike;
-  getBuildCount: (locator?: string) => Promise<AxiosResponse<string>>;
-  listBuildArtifacts: (
-    buildId: string,
-    options?: {
-      basePath?: string;
-      locator?: string;
-      fields?: string;
-      resolveParameters?: boolean;
-      logBuildUsage?: boolean;
-    }
-  ) => Promise<AxiosResponse<unknown>>;
-  downloadArtifactContent: (
-    buildId: string,
-    artifactPath: string
-  ) => Promise<AxiosResponse<ArrayBuffer>>;
-  getBuildStatistics: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
-  listChangesForBuild: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
-  listSnapshotDependencies: (buildId: string) => Promise<AxiosResponse<unknown>>;
-  baseUrl: string;
-}
+export type TeamCityClientAdapter = TeamCityUnifiedClient;
 
 export function createAdapterFromTeamCityAPI(api: TeamCityAPI): TeamCityClientAdapter {
   return {
+    modules: {
+      builds: api.builds,
+    },
+    request: (fn) => api.request(fn),
+    baseUrl: api.getBaseUrl(),
     builds: api.builds as unknown as BuildApiLike,
-    getBuildCount: (locator) => api.getBuildCount(locator),
     listBuildArtifacts: (buildId, options) => api.listBuildArtifacts(buildId, options),
     downloadArtifactContent: (buildId, artifactPath) =>
       api.downloadBuildArtifact(buildId, artifactPath),
     getBuildStatistics: (buildId, fields) => api.getBuildStatistics(buildId, fields),
     listChangesForBuild: (buildId, fields) => api.listChangesForBuild(buildId, fields),
     listSnapshotDependencies: (buildId) => api.listSnapshotDependencies(buildId),
-    baseUrl: api.getBaseUrl(),
   };
 }

--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -26,6 +26,7 @@ export interface BuildApiLike {
 
 export interface TeamCityClientAdapter {
   builds: BuildApiLike;
+  getBuildCount: (locator?: string) => Promise<AxiosResponse<string>>;
   listBuildArtifacts: (
     buildId: string,
     options?: {
@@ -49,6 +50,7 @@ export interface TeamCityClientAdapter {
 export function createAdapterFromTeamCityAPI(api: TeamCityAPI): TeamCityClientAdapter {
   return {
     builds: api.builds as unknown as BuildApiLike,
+    getBuildCount: (locator) => api.getBuildCount(locator),
     listBuildArtifacts: (buildId, options) => api.listBuildArtifacts(buildId, options),
     downloadArtifactContent: (buildId, artifactPath) =>
       api.downloadBuildArtifact(buildId, artifactPath),

--- a/src/teamcity/types/client.ts
+++ b/src/teamcity/types/client.ts
@@ -1,0 +1,57 @@
+import type { AxiosInstance, AxiosResponse, RawAxiosRequestConfig } from 'axios';
+
+import type { BuildApi } from '@/teamcity-client/api/build-api';
+
+export interface TeamCityRequestContext {
+  axios: AxiosInstance;
+  baseUrl: string;
+  requestId?: string;
+}
+
+export type TeamCityRequestFn<T> = (ctx: TeamCityRequestContext) => Promise<T>;
+
+export interface BuildApiLike {
+  getBuild: (
+    buildLocator: string,
+    fields?: string,
+    options?: RawAxiosRequestConfig
+  ) => Promise<AxiosResponse<unknown>>;
+  getMultipleBuilds: (
+    locator: string,
+    fields?: string,
+    options?: RawAxiosRequestConfig
+  ) => Promise<AxiosResponse<unknown>>;
+  getBuildProblems: (
+    buildLocator: string,
+    fields?: string,
+    options?: RawAxiosRequestConfig
+  ) => Promise<AxiosResponse<unknown>>;
+}
+
+export interface TeamCityApiModules {
+  builds: BuildApi;
+}
+
+export interface TeamCityUnifiedClient {
+  modules: TeamCityApiModules;
+  request<T>(fn: TeamCityRequestFn<T>): Promise<T>;
+  baseUrl: string;
+  builds: BuildApiLike;
+  listBuildArtifacts: (
+    buildId: string,
+    options?: {
+      basePath?: string;
+      locator?: string;
+      fields?: string;
+      resolveParameters?: boolean;
+      logBuildUsage?: boolean;
+    }
+  ) => Promise<AxiosResponse<unknown>>;
+  downloadArtifactContent: (
+    buildId: string,
+    artifactPath: string
+  ) => Promise<AxiosResponse<ArrayBuffer>>;
+  getBuildStatistics: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
+  listChangesForBuild: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
+  listSnapshotDependencies: (buildId: string) => Promise<AxiosResponse<unknown>>;
+}

--- a/tests/unit/teamcity/build-results-manager.test.ts
+++ b/tests/unit/teamcity/build-results-manager.test.ts
@@ -2,12 +2,19 @@ import { BuildResultsManager } from '@/teamcity/build-results-manager';
 import type { TeamCityClientAdapter } from '@/teamcity/client-adapter';
 
 type MockAdapter = {
+  modules: {
+    builds: {
+      getBuild: jest.Mock;
+      getMultipleBuilds: jest.Mock;
+      getBuildProblems: jest.Mock;
+    };
+  };
+  request: jest.Mock;
   builds: {
     getBuild: jest.Mock;
     getMultipleBuilds: jest.Mock;
     getBuildProblems: jest.Mock;
   };
-  getBuildCount: jest.Mock;
   listBuildArtifacts: jest.Mock;
   downloadArtifactContent: jest.Mock;
   getBuildStatistics: jest.Mock;
@@ -21,13 +28,18 @@ describe('BuildResultsManager', () => {
   let mockClient: MockAdapter;
 
   beforeEach(() => {
+    const builds = {
+      getBuild: jest.fn(),
+      getMultipleBuilds: jest.fn(),
+      getBuildProblems: jest.fn(),
+    };
+
     mockClient = {
-      builds: {
-        getBuild: jest.fn(),
-        getMultipleBuilds: jest.fn(),
-        getBuildProblems: jest.fn(),
+      modules: {
+        builds,
       },
-      getBuildCount: jest.fn(),
+      request: jest.fn(),
+      builds,
       listBuildArtifacts: jest.fn().mockResolvedValue({ data: {} }),
       downloadArtifactContent: jest.fn().mockResolvedValue({ data: new ArrayBuffer(0) }),
       getBuildStatistics: jest.fn().mockResolvedValue({ data: { property: [] } }),

--- a/tests/unit/teamcity/build-results-manager.test.ts
+++ b/tests/unit/teamcity/build-results-manager.test.ts
@@ -7,6 +7,7 @@ type MockAdapter = {
     getMultipleBuilds: jest.Mock;
     getBuildProblems: jest.Mock;
   };
+  getBuildCount: jest.Mock;
   listBuildArtifacts: jest.Mock;
   downloadArtifactContent: jest.Mock;
   getBuildStatistics: jest.Mock;
@@ -26,6 +27,7 @@ describe('BuildResultsManager', () => {
         getMultipleBuilds: jest.fn(),
         getBuildProblems: jest.fn(),
       },
+      getBuildCount: jest.fn(),
       listBuildArtifacts: jest.fn().mockResolvedValue({ data: {} }),
       downloadArtifactContent: jest.fn().mockResolvedValue({ data: new ArrayBuffer(0) }),
       getBuildStatistics: jest.fn().mockResolvedValue({ data: { property: [] } }),

--- a/tests/unit/teamcity/build-status-manager.test.ts
+++ b/tests/unit/teamcity/build-status-manager.test.ts
@@ -11,12 +11,19 @@ jest.mock('@/teamcity/client');
 describe('BuildStatusManager', () => {
   let manager: BuildStatusManager;
   type MockClient = {
+    modules: {
+      builds: {
+        getBuild: jest.Mock;
+        getMultipleBuilds: jest.Mock;
+        getBuildProblems: jest.Mock;
+      };
+    };
+    request: jest.Mock;
     builds: {
       getBuild: jest.Mock;
       getMultipleBuilds: jest.Mock;
       getBuildProblems: jest.Mock;
     };
-    getBuildCount: jest.Mock;
     listBuildArtifacts: jest.Mock;
     downloadArtifactContent: jest.Mock;
     getBuildStatistics: jest.Mock;
@@ -28,13 +35,18 @@ describe('BuildStatusManager', () => {
 
   beforeEach(() => {
     // Create mock TeamCity client with proper jest mocks
+    const builds = {
+      getBuild: jest.fn(),
+      getMultipleBuilds: jest.fn(),
+      getBuildProblems: jest.fn(),
+    };
+
     mockClient = {
-      builds: {
-        getBuild: jest.fn(),
-        getMultipleBuilds: jest.fn(),
-        getBuildProblems: jest.fn(),
+      modules: {
+        builds,
       },
-      getBuildCount: jest.fn(),
+      request: jest.fn(),
+      builds,
       listBuildArtifacts: jest.fn(),
       downloadArtifactContent: jest.fn(),
       getBuildStatistics: jest.fn(),

--- a/tests/unit/teamcity/build-status-manager.test.ts
+++ b/tests/unit/teamcity/build-status-manager.test.ts
@@ -16,6 +16,7 @@ describe('BuildStatusManager', () => {
       getMultipleBuilds: jest.Mock;
       getBuildProblems: jest.Mock;
     };
+    getBuildCount: jest.Mock;
     listBuildArtifacts: jest.Mock;
     downloadArtifactContent: jest.Mock;
     getBuildStatistics: jest.Mock;
@@ -33,6 +34,7 @@ describe('BuildStatusManager', () => {
         getMultipleBuilds: jest.fn(),
         getBuildProblems: jest.fn(),
       },
+      getBuildCount: jest.fn(),
       listBuildArtifacts: jest.fn(),
       downloadArtifactContent: jest.fn(),
       getBuildStatistics: jest.fn(),


### PR DESCRIPTION
## Summary
- route BuildListManager through the TeamCity adapter and shared count endpoint
- expose `getBuildCount` on the API adapter to remove inline axios usage
- refresh build list/reporting unit suites to stub the adapter count path

## Testing
- npm run lint:check
- npm run test:unit

Closes #116
