### PR TITLE
refactor(teamcity): expand TeamCityAPI surface

### DIFF
--- a/src/teamcity/index.ts
+++ b/src/teamcity/index.ts
@@ -21,6 +21,7 @@ export * from './errors';
 export * from './circuit-breaker';
 export * from './pagination';
 export * from './config';
+export * from './types/client';
 
 // Re-export configuration
 export * from '@/teamcity-client/configuration';

--- a/src/teamcity/types/client.ts
+++ b/src/teamcity/types/client.ts
@@ -1,0 +1,79 @@
+import type { AxiosInstance } from 'axios';
+
+import type { TeamCityFullConfig } from '@/teamcity/config';
+import type { AgentApi } from '@/teamcity-client/api/agent-api';
+import type { AgentPoolApi } from '@/teamcity-client/api/agent-pool-api';
+import type { AgentTypeApi } from '@/teamcity-client/api/agent-type-api';
+import type { AuditApi } from '@/teamcity-client/api/audit-api';
+import type { AvatarApi } from '@/teamcity-client/api/avatar-api';
+import type { BuildApi } from '@/teamcity-client/api/build-api';
+import type { BuildQueueApi } from '@/teamcity-client/api/build-queue-api';
+import type { BuildTypeApi } from '@/teamcity-client/api/build-type-api';
+import type { ChangeApi } from '@/teamcity-client/api/change-api';
+import type { CloudInstanceApi } from '@/teamcity-client/api/cloud-instance-api';
+import type { DeploymentDashboardApi } from '@/teamcity-client/api/deployment-dashboard-api';
+import type { GlobalServerSettingsApi } from '@/teamcity-client/api/global-server-settings-api';
+import type { GroupApi } from '@/teamcity-client/api/group-api';
+import type { HealthApi } from '@/teamcity-client/api/health-api';
+import type { InvestigationApi } from '@/teamcity-client/api/investigation-api';
+import type { MuteApi } from '@/teamcity-client/api/mute-api';
+import type { NodeApi } from '@/teamcity-client/api/node-api';
+import type { ProblemApi } from '@/teamcity-client/api/problem-api';
+import type { ProblemOccurrenceApi } from '@/teamcity-client/api/problem-occurrence-api';
+import type { ProjectApi } from '@/teamcity-client/api/project-api';
+import type { RoleApi } from '@/teamcity-client/api/role-api';
+import type { RootApi } from '@/teamcity-client/api/root-api';
+import type { ServerApi } from '@/teamcity-client/api/server-api';
+import type { ServerAuthenticationSettingsApi } from '@/teamcity-client/api/server-authentication-settings-api';
+import type { TestApi } from '@/teamcity-client/api/test-api';
+import type { TestOccurrenceApi } from '@/teamcity-client/api/test-occurrence-api';
+import type { UserApi } from '@/teamcity-client/api/user-api';
+import type { VcsRootApi } from '@/teamcity-client/api/vcs-root-api';
+import type { VcsRootInstanceApi } from '@/teamcity-client/api/vcs-root-instance-api';
+import type { VersionedSettingsApi } from '@/teamcity-client/api/versioned-settings-api';
+
+export interface TeamCityApiSurface {
+  agents: AgentApi;
+  agentPools: AgentPoolApi;
+  agentTypes: AgentTypeApi;
+  audits: AuditApi;
+  avatars: AvatarApi;
+  builds: BuildApi;
+  buildQueue: BuildQueueApi;
+  buildTypes: BuildTypeApi;
+  changes: ChangeApi;
+  cloudInstances: CloudInstanceApi;
+  deploymentDashboards: DeploymentDashboardApi;
+  globalServerSettings: GlobalServerSettingsApi;
+  groups: GroupApi;
+  health: HealthApi;
+  investigations: InvestigationApi;
+  mutes: MuteApi;
+  nodes: NodeApi;
+  problems: ProblemApi;
+  problemOccurrences: ProblemOccurrenceApi;
+  projects: ProjectApi;
+  roles: RoleApi;
+  root: RootApi;
+  server: ServerApi;
+  serverAuthSettings: ServerAuthenticationSettingsApi;
+  testMetadata: TestApi;
+  tests: TestOccurrenceApi;
+  users: UserApi;
+  vcsRootInstances: VcsRootInstanceApi;
+  vcsRoots: VcsRootApi;
+  versionedSettings: VersionedSettingsApi;
+}
+
+export interface TeamCityRequestContext {
+  axios: AxiosInstance;
+  baseUrl: string;
+  requestId?: string;
+}
+
+export interface TeamCityUnifiedClient {
+  modules: TeamCityApiSurface;
+  request<T>(fn: (context: TeamCityRequestContext) => Promise<T>): Promise<T>;
+  getConfig(): TeamCityFullConfig;
+  getAxios(): AxiosInstance;
+}

--- a/tests/unit/teamcity/api-client.test.ts
+++ b/tests/unit/teamcity/api-client.test.ts
@@ -23,6 +23,10 @@ describe('TeamCityAPI surface', () => {
     expect(api.testMetadata).toBeInstanceOf(TestApi);
     expect(api.tests).toBe(api.testOccurrences);
     expect(api.http.defaults.baseURL).toBe(BASE_CONFIG.baseUrl);
+    expect(api.modules.tests).toBe(api.tests);
+    expect(api.modules.testMetadata).toBe(api.testMetadata);
+    expect(api.modules.buildTypes).toBe(api.buildTypes);
+    expect(Object.isFrozen(api.modules)).toBe(true);
   });
 
   it('continues to support the legacy positional overrides', () => {

--- a/tests/unit/teamcity/api-client.test.ts
+++ b/tests/unit/teamcity/api-client.test.ts
@@ -1,0 +1,34 @@
+import { TeamCityAPI, type TeamCityAPIClientConfig } from '@/api-client';
+import { AgentTypeApi } from '@/teamcity-client/api/agent-type-api';
+import { TestApi } from '@/teamcity-client/api/test-api';
+
+const BASE_CONFIG: TeamCityAPIClientConfig = {
+  baseUrl: 'https://teamcity.example.com',
+  token: 'test-token',
+};
+
+describe('TeamCityAPI surface', () => {
+  beforeEach(() => {
+    TeamCityAPI.reset();
+  });
+
+  afterEach(() => {
+    TeamCityAPI.reset();
+  });
+
+  it('wires newly exposed API modules and shares the axios instance', () => {
+    const api = TeamCityAPI.getInstance(BASE_CONFIG);
+
+    expect(api.agentTypes).toBeInstanceOf(AgentTypeApi);
+    expect(api.testMetadata).toBeInstanceOf(TestApi);
+    expect(api.tests).toBe(api.testOccurrences);
+    expect(api.http.defaults.baseURL).toBe(BASE_CONFIG.baseUrl);
+  });
+
+  it('continues to support the legacy positional overrides', () => {
+    const api = TeamCityAPI.getInstance('https://legacy.example.com/', 'legacy-token');
+
+    expect(api.getBaseUrl()).toBe('https://legacy.example.com');
+    expect(api.http.defaults.baseURL).toBe('https://legacy.example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- instantiate the remaining generated REST API clients in TeamCityAPI and expose them via readonly properties
- surface the shared axios instance and accept typed config overrides for tests while keeping the legacy signature
- add targeted unit coverage to guard the new surface and ensure metadata/test module wiring

## Testing
- npm run lint
- npx jest --runTestsByPath tests/unit/teamcity/api-client.test.ts

Closes #113
