### PR TITLE
refactor(teamcity): unify adapter initialization flow

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -35,9 +35,15 @@ import { VcsRootApi } from './teamcity-client/api/vcs-root-api';
 import { VersionedSettingsApi } from './teamcity-client/api/versioned-settings-api';
 import { Configuration } from './teamcity-client/configuration';
 
+export interface TeamCityAPIClientConfig {
+  baseUrl: string;
+  token: string;
+}
+
 export class TeamCityAPI {
   private static instance: TeamCityAPI;
   private axiosInstance: AxiosInstance;
+  public readonly http: AxiosInstance;
   private config: Configuration;
   private baseUrl: string;
 
@@ -83,6 +89,7 @@ export class TeamCityAPI {
         'Content-Type': 'application/json',
       },
     });
+    this.http = this.axiosInstance;
 
     // Configure retry with exponential backoff and error classification
     axiosRetry(this.axiosInstance, {
@@ -148,10 +155,17 @@ export class TeamCityAPI {
    * @param baseUrl Optional base URL for testing
    * @param token Optional token for testing
    */
-  static getInstance(baseUrl?: string, token?: string): TeamCityAPI {
-    // If parameters are provided, create a new instance (for testing)
-    if (baseUrl && token) {
-      this.instance = new TeamCityAPI(baseUrl, token);
+  static getInstance(
+    configOrBaseUrl?: TeamCityAPIClientConfig | string,
+    token?: string
+  ): TeamCityAPI {
+    if (configOrBaseUrl && typeof configOrBaseUrl === 'object') {
+      this.instance = new TeamCityAPI(configOrBaseUrl.baseUrl, configOrBaseUrl.token);
+      return this.instance;
+    }
+
+    if (typeof configOrBaseUrl === 'string' && token) {
+      this.instance = new TeamCityAPI(configOrBaseUrl, token);
       return this.instance;
     }
 

--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -2,30 +2,41 @@
  * Lightweight adapter so managers can work with the unified TeamCityAPI
  * without depending on the legacy TeamCityClient implementation.
  */
-import type { AxiosResponse, RawAxiosRequestConfig } from 'axios';
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 import type { TeamCityAPI } from '@/api-client';
 
-export interface BuildApiLike {
-  getBuild: (
-    buildLocator: string,
-    fields?: string,
-    options?: RawAxiosRequestConfig
-  ) => Promise<AxiosResponse<unknown>>;
-  getMultipleBuilds: (
-    locator: string,
-    fields?: string,
-    options?: RawAxiosRequestConfig
-  ) => Promise<AxiosResponse<unknown>>;
-  getBuildProblems: (
-    buildLocator: string,
-    fields?: string,
-    options?: RawAxiosRequestConfig
-  ) => Promise<AxiosResponse<unknown>>;
-}
-
 export interface TeamCityClientAdapter {
-  builds: BuildApiLike;
+  builds: TeamCityAPI['builds'];
+  projects: TeamCityAPI['projects'];
+  buildTypes: TeamCityAPI['buildTypes'];
+  buildQueue: TeamCityAPI['buildQueue'];
+  tests: TeamCityAPI['tests'];
+  testOccurrences: TeamCityAPI['tests'];
+  vcsRoots: TeamCityAPI['vcsRoots'];
+  agents: TeamCityAPI['agents'];
+  agentPools: TeamCityAPI['agentPools'];
+  server: TeamCityAPI['server'];
+  health: TeamCityAPI['health'];
+  changes: TeamCityAPI['changes'];
+  problems: TeamCityAPI['problems'];
+  problemOccurrences: TeamCityAPI['problemOccurrences'];
+  investigations: TeamCityAPI['investigations'];
+  mutes: TeamCityAPI['mutes'];
+  versionedSettings: TeamCityAPI['versionedSettings'];
+  roles: TeamCityAPI['roles'];
+  users: TeamCityAPI['users'];
+  testConnection: TeamCityAPI['testConnection'];
+  listProjects: TeamCityAPI['listProjects'];
+  getProject: TeamCityAPI['getProject'];
+  listBuilds: TeamCityAPI['listBuilds'];
+  getBuild: TeamCityAPI['getBuild'];
+  triggerBuild: TeamCityAPI['triggerBuild'];
+  getBuildLog: TeamCityAPI['getBuildLog'];
+  getBuildLogChunk: TeamCityAPI['getBuildLogChunk'];
+  listBuildTypes: TeamCityAPI['listBuildTypes'];
+  getBuildType: TeamCityAPI['getBuildType'];
+  listTestFailures: TeamCityAPI['listTestFailures'];
   listBuildArtifacts: (
     buildId: string,
     options?: {
@@ -43,18 +54,58 @@ export interface TeamCityClientAdapter {
   getBuildStatistics: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
   listChangesForBuild: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
   listSnapshotDependencies: (buildId: string) => Promise<AxiosResponse<unknown>>;
+  listVcsRoots: TeamCityAPI['listVcsRoots'];
+  listAgents: TeamCityAPI['listAgents'];
+  listAgentPools: TeamCityAPI['listAgentPools'];
+  getBaseUrl: TeamCityAPI['getBaseUrl'];
   baseUrl: string;
+  http: AxiosInstance;
 }
 
 export function createAdapterFromTeamCityAPI(api: TeamCityAPI): TeamCityClientAdapter {
   return {
-    builds: api.builds as unknown as BuildApiLike,
+    builds: api.builds,
+    projects: api.projects,
+    buildTypes: api.buildTypes,
+    buildQueue: api.buildQueue,
+    tests: api.tests,
+    testOccurrences: api.tests,
+    vcsRoots: api.vcsRoots,
+    agents: api.agents,
+    agentPools: api.agentPools,
+    server: api.server,
+    health: api.health,
+    changes: api.changes,
+    problems: api.problems,
+    problemOccurrences: api.problemOccurrences,
+    investigations: api.investigations,
+    mutes: api.mutes,
+    versionedSettings: api.versionedSettings,
+    roles: api.roles,
+    users: api.users,
+    testConnection: () => api.testConnection(),
+    listProjects: (locator) => api.listProjects(locator),
+    getProject: (projectId) => api.getProject(projectId),
+    listBuilds: (locator) => api.listBuilds(locator),
+    getBuild: (buildId) => api.getBuild(buildId),
+    triggerBuild: (buildTypeId, branchName, comment) =>
+      api.triggerBuild(buildTypeId, branchName, comment),
+    getBuildLog: (buildId) => api.getBuildLog(buildId),
+    getBuildLogChunk: (buildId, options) => api.getBuildLogChunk(buildId, options),
+    listBuildTypes: (projectId) => api.listBuildTypes(projectId),
+    getBuildType: (buildTypeId) => api.getBuildType(buildTypeId),
+    listTestFailures: (buildId) => api.listTestFailures(buildId),
     listBuildArtifacts: (buildId, options) => api.listBuildArtifacts(buildId, options),
     downloadArtifactContent: (buildId, artifactPath) =>
       api.downloadBuildArtifact(buildId, artifactPath),
     getBuildStatistics: (buildId, fields) => api.getBuildStatistics(buildId, fields),
     listChangesForBuild: (buildId, fields) => api.listChangesForBuild(buildId, fields),
     listSnapshotDependencies: (buildId) => api.listSnapshotDependencies(buildId),
+    listVcsRoots: (projectId) => api.listVcsRoots(projectId),
+    listAgents: () => api.listAgents(),
+    listAgentPools: () => api.listAgentPools(),
+    getBaseUrl: () => api.getBaseUrl(),
     baseUrl: api.getBaseUrl(),
+    http: api.http,
   };
 }

--- a/src/teamcity/client.ts
+++ b/src/teamcity/client.ts
@@ -2,8 +2,10 @@
  * TeamCity API Client Wrapper
  * Provides authentication and configuration for the generated client
  *
- * @deprecated Prefer using the unified TeamCityAPI (src/api-client.ts) directly.
- *             Managers should depend on a small adapter interface instead of this class.
+ * @deprecated Prefer using {@link initializeTeamCity} / {@link createTeamCityClient}
+ *             which return the adapter built from the unified TeamCityAPI. This
+ *             wrapper remains temporarily for legacy consumers during the
+ *             migration to the adapter interface.
  */
 import axios, { type InternalAxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';

--- a/src/teamcity/config.ts
+++ b/src/teamcity/config.ts
@@ -3,6 +3,7 @@
  */
 import { getConfig, getTeamCityOptions } from '@/config';
 
+import type { TeamCityAPIClientConfig } from '@/api-client';
 import type { TeamCityClientConfig } from './client';
 
 export interface TeamCityConnectionConfig {
@@ -137,10 +138,18 @@ export function mergeConfig(...configs: Array<Partial<TeamCityFullConfig>>): Tea
 /**
  * Convert full config to client config
  */
-export function toClientConfig(config: TeamCityFullConfig): TeamCityClientConfig {
+export function toApiClientConfig(config: TeamCityFullConfig): TeamCityAPIClientConfig {
   return {
     baseUrl: config.connection.baseUrl,
     token: config.connection.token,
+  };
+}
+
+export function toClientConfig(config: TeamCityFullConfig): TeamCityClientConfig {
+  const baseConfig = toApiClientConfig(config);
+
+  return {
+    ...baseConfig,
     timeout: config.connection.timeout,
     retryConfig:
       config.retry?.enabled === true


### PR DESCRIPTION
## Summary
- expose the full TeamCityAPI surface (modules, helpers, axios) via the adapter so managers depend on the unified client
- swap initialization helpers to build/return the adapter using the new TeamCityAPIClientConfig flow
- add explicit API config conversion while steering callers toward the adapter and deprecating the legacy wrapper

## Testing
- npm run test:unit
- npm run test:integration # blocked locally (missing TEAMCITY_URL/TEAMCITY_TOKEN)

Closes #114
