### PR TITLE
refactor(teamcity): unify adapter initialization

### DIFF
--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -2,7 +2,7 @@
  * Lightweight adapter so managers can work with the unified TeamCityAPI
  * without depending on the legacy TeamCityClient implementation.
  */
-import type { AxiosInstance } from 'axios';
+import axios, { type AxiosInstance } from 'axios';
 
 import type { TeamCityAPI, TeamCityAPIClientConfig } from '@/api-client';
 import type { TeamCityFullConfig } from '@/teamcity/config';
@@ -72,10 +72,8 @@ export function createAdapterFromTeamCityAPI(
   options: AdapterOptions = {}
 ): TeamCityClientAdapter {
   const modules = resolveModules(api);
-  if (api.http == null) {
-    throw new Error('TeamCityAPI instance missing shared http client');
-  }
-  const httpInstance: AxiosInstance = api.http;
+  const httpInstance: AxiosInstance =
+    api.http ?? axios.create({ baseURL: api.getBaseUrl() });
   const resolvedApiConfig: TeamCityAPIClientConfig = {
     baseUrl: options.apiConfig?.baseUrl ?? api.getBaseUrl(),
     token: options.apiConfig?.token ?? '',

--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -2,53 +2,105 @@
  * Lightweight adapter so managers can work with the unified TeamCityAPI
  * without depending on the legacy TeamCityClient implementation.
  */
-import type { AxiosResponse, RawAxiosRequestConfig } from 'axios';
+import type { AxiosInstance } from 'axios';
 
-import type { TeamCityAPI } from '@/api-client';
+import type { TeamCityAPI, TeamCityAPIClientConfig } from '@/api-client';
+import type { TeamCityFullConfig } from '@/teamcity/config';
 
-export interface BuildApiLike {
-  getBuild: (
-    buildLocator: string,
-    fields?: string,
-    options?: RawAxiosRequestConfig
-  ) => Promise<AxiosResponse<unknown>>;
-  getMultipleBuilds: (
-    locator: string,
-    fields?: string,
-    options?: RawAxiosRequestConfig
-  ) => Promise<AxiosResponse<unknown>>;
-  getBuildProblems: (
-    buildLocator: string,
-    fields?: string,
-    options?: RawAxiosRequestConfig
-  ) => Promise<AxiosResponse<unknown>>;
+import type {
+  BuildApiLike,
+  TeamCityApiSurface,
+  TeamCityClientAdapter,
+  TeamCityRequestContext,
+} from './types/client';
+
+export type { TeamCityClientAdapter } from './types/client';
+
+interface AdapterOptions {
+  fullConfig?: TeamCityFullConfig;
+  apiConfig?: TeamCityAPIClientConfig;
 }
 
-export interface TeamCityClientAdapter {
-  builds: BuildApiLike;
-  listBuildArtifacts: (
-    buildId: string,
-    options?: {
-      basePath?: string;
-      locator?: string;
-      fields?: string;
-      resolveParameters?: boolean;
-      logBuildUsage?: boolean;
-    }
-  ) => Promise<AxiosResponse<unknown>>;
-  downloadArtifactContent: (
-    buildId: string,
-    artifactPath: string
-  ) => Promise<AxiosResponse<ArrayBuffer>>;
-  getBuildStatistics: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
-  listChangesForBuild: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
-  listSnapshotDependencies: (buildId: string) => Promise<AxiosResponse<unknown>>;
-  baseUrl: string;
-}
+const resolveModules = (api: TeamCityAPI): Readonly<TeamCityApiSurface> => {
+  const candidate = (api as { modules?: Readonly<TeamCityApiSurface> }).modules;
+  if (candidate != null) {
+    return candidate;
+  }
 
-export function createAdapterFromTeamCityAPI(api: TeamCityAPI): TeamCityClientAdapter {
+  const legacy = api as unknown as Record<string, unknown>;
+  const pick = <K extends keyof TeamCityApiSurface>(key: K): TeamCityApiSurface[K] =>
+    (legacy[key as string] ?? {}) as TeamCityApiSurface[K];
+
+  const fallback: TeamCityApiSurface = {
+    agents: pick('agents'),
+    agentPools: pick('agentPools'),
+    agentTypes: pick('agentTypes'),
+    audit: pick('audit'),
+    avatars: pick('avatars'),
+    builds: pick('builds'),
+    buildQueue: pick('buildQueue'),
+    buildTypes: pick('buildTypes'),
+    changes: pick('changes'),
+    cloudInstances: pick('cloudInstances'),
+    deploymentDashboards: pick('deploymentDashboards'),
+    globalServerSettings: pick('globalServerSettings'),
+    groups: pick('groups'),
+    health: pick('health'),
+    investigations: pick('investigations'),
+    mutes: pick('mutes'),
+    nodes: pick('nodes'),
+    problems: pick('problems'),
+    problemOccurrences: pick('problemOccurrences'),
+    projects: pick('projects'),
+    roles: pick('roles'),
+    root: pick('root'),
+    server: pick('server'),
+    serverAuthSettings: pick('serverAuthSettings'),
+    tests: pick('tests'),
+    testMetadata: pick('testMetadata'),
+    users: pick('users'),
+    vcsRoots: pick('vcsRoots'),
+    vcsRootInstances: pick('vcsRootInstances'),
+    versionedSettings: pick('versionedSettings'),
+  };
+
+  return Object.freeze(fallback);
+};
+
+export function createAdapterFromTeamCityAPI(
+  api: TeamCityAPI,
+  options: AdapterOptions = {}
+): TeamCityClientAdapter {
+  const modules = resolveModules(api);
+  const httpInstance = api.http ?? ({} as AxiosInstance);
+  const resolvedApiConfig: TeamCityAPIClientConfig = {
+    baseUrl: options.apiConfig?.baseUrl ?? api.getBaseUrl(),
+    token: options.apiConfig?.token ?? '',
+    timeout: options.apiConfig?.timeout ?? undefined,
+  };
+
+  const resolvedFullConfig: TeamCityFullConfig =
+    options.fullConfig ?? {
+      connection: {
+        baseUrl: resolvedApiConfig.baseUrl,
+        token: resolvedApiConfig.token,
+        timeout: resolvedApiConfig.timeout,
+      },
+    };
+
+  const request = async <T>(fn: (ctx: TeamCityRequestContext) => Promise<T>): Promise<T> =>
+    fn({ axios: httpInstance, baseUrl: api.getBaseUrl(), requestId: undefined });
+
+  const buildApi = modules.builds as unknown as BuildApiLike;
+
   return {
-    builds: api.builds as unknown as BuildApiLike,
+    modules,
+    http: httpInstance,
+    request,
+    getConfig: () => resolvedFullConfig,
+    getApiConfig: () => resolvedApiConfig,
+    getAxios: () => httpInstance,
+    builds: buildApi,
     listBuildArtifacts: (buildId, options) => api.listBuildArtifacts(buildId, options),
     downloadArtifactContent: (buildId, artifactPath) =>
       api.downloadBuildArtifact(buildId, artifactPath),

--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -72,21 +72,23 @@ export function createAdapterFromTeamCityAPI(
   options: AdapterOptions = {}
 ): TeamCityClientAdapter {
   const modules = resolveModules(api);
-  const httpInstance = api.http ?? ({} as AxiosInstance);
+  if (api.http == null) {
+    throw new Error('TeamCityAPI instance missing shared http client');
+  }
+  const httpInstance: AxiosInstance = api.http;
   const resolvedApiConfig: TeamCityAPIClientConfig = {
     baseUrl: options.apiConfig?.baseUrl ?? api.getBaseUrl(),
     token: options.apiConfig?.token ?? '',
     timeout: options.apiConfig?.timeout ?? undefined,
   };
 
-  const resolvedFullConfig: TeamCityFullConfig =
-    options.fullConfig ?? {
-      connection: {
-        baseUrl: resolvedApiConfig.baseUrl,
-        token: resolvedApiConfig.token,
-        timeout: resolvedApiConfig.timeout,
-      },
-    };
+  const resolvedFullConfig: TeamCityFullConfig = options.fullConfig ?? {
+    connection: {
+      baseUrl: resolvedApiConfig.baseUrl,
+      token: resolvedApiConfig.token,
+      timeout: resolvedApiConfig.timeout,
+    },
+  };
 
   const request = async <T>(fn: (ctx: TeamCityRequestContext) => Promise<T>): Promise<T> =>
     fn({ axios: httpInstance, baseUrl: api.getBaseUrl(), requestId: undefined });

--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -72,8 +72,7 @@ export function createAdapterFromTeamCityAPI(
   options: AdapterOptions = {}
 ): TeamCityClientAdapter {
   const modules = resolveModules(api);
-  const httpInstance: AxiosInstance =
-    api.http ?? axios.create({ baseURL: api.getBaseUrl() });
+  const httpInstance: AxiosInstance = api.http ?? axios.create({ baseURL: api.getBaseUrl() });
   const resolvedApiConfig: TeamCityAPIClientConfig = {
     baseUrl: options.apiConfig?.baseUrl ?? api.getBaseUrl(),
     token: options.apiConfig?.token ?? '',

--- a/src/teamcity/client.ts
+++ b/src/teamcity/client.ts
@@ -2,8 +2,8 @@
  * TeamCity API Client Wrapper
  * Provides authentication and configuration for the generated client
  *
- * @deprecated Prefer using the unified TeamCityAPI (src/api-client.ts) directly.
- *             Managers should depend on a small adapter interface instead of this class.
+ * @deprecated Prefer using createAdapterFromTeamCityAPI with the TeamCityAPI singleton.
+ *             This wrapper remains temporarily for legacy consumers and will be removed.
  */
 import axios, { type InternalAxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';

--- a/src/teamcity/config.ts
+++ b/src/teamcity/config.ts
@@ -1,9 +1,9 @@
 /**
  * Configuration module for TeamCity client
  */
+import type { TeamCityAPIClientConfig } from '@/api-client';
 import { getConfig, getTeamCityOptions } from '@/config';
 
-import type { TeamCityAPIClientConfig } from '@/api-client';
 import type { TeamCityClientConfig } from './client';
 
 export interface TeamCityConnectionConfig {

--- a/src/teamcity/config.ts
+++ b/src/teamcity/config.ts
@@ -3,6 +3,7 @@
  */
 import { getConfig, getTeamCityOptions } from '@/config';
 
+import type { TeamCityAPIClientConfig } from '@/api-client';
 import type { TeamCityClientConfig } from './client';
 
 export interface TeamCityConnectionConfig {
@@ -136,6 +137,17 @@ export function mergeConfig(...configs: Array<Partial<TeamCityFullConfig>>): Tea
 
 /**
  * Convert full config to client config
+ */
+export function toApiClientConfig(config: TeamCityFullConfig): TeamCityAPIClientConfig {
+  return {
+    baseUrl: config.connection.baseUrl,
+    token: config.connection.token,
+    timeout: config.connection.timeout,
+  };
+}
+
+/**
+ * @deprecated Use toApiClientConfig instead.
  */
 export function toClientConfig(config: TeamCityFullConfig): TeamCityClientConfig {
   return {

--- a/src/teamcity/index.ts
+++ b/src/teamcity/index.ts
@@ -5,6 +5,7 @@
 import { TeamCityAPI } from '@/api-client';
 import { info, warn } from '@/utils/logger';
 
+import { type TeamCityClientAdapter, createAdapterFromTeamCityAPI } from './client-adapter';
 import {
   type TeamCityFullConfig,
   loadTeamCityConfig,
@@ -12,7 +13,6 @@ import {
   toApiClientConfig,
   validateConfig,
 } from './config';
-import { createAdapterFromTeamCityAPI, type TeamCityClientAdapter } from './client-adapter';
 
 // Re-export all public types and utilities
 export * from './client';
@@ -140,8 +140,8 @@ export async function getProjectBuilds(projectId: string): Promise<BuildData[]> 
     undefined // fields
   );
   // Map Build[] to BuildData[]
-  const builds = response.data.build ?? [];
-  return builds.map(
+  const buildList = response.data.build ?? [];
+  return buildList.map(
     (build: {
       id?: string | number;
       number?: string | number;
@@ -243,14 +243,14 @@ export async function getBuildTestResults(buildId: number): Promise<{
   const { tests } = client.modules;
   const response = await tests.getAllTestOccurrences(`build:${buildId}`);
 
-  const tests = response.data.testOccurrence ?? [];
-  const failures = tests.filter((t: TestOccurrence) => t.status === 'FAILURE');
+  const occurrences = response.data.testOccurrence ?? [];
+  const failures = occurrences.filter((t: TestOccurrence) => t.status === 'FAILURE');
 
   return {
-    total: tests.length,
-    passed: tests.filter((t: TestOccurrence) => t.status === 'SUCCESS').length,
+    total: occurrences.length,
+    passed: occurrences.filter((t: TestOccurrence) => t.status === 'SUCCESS').length,
     failed: failures.length,
-    ignored: tests.filter((t: TestOccurrence) => t.ignored === true).length,
+    ignored: occurrences.filter((t: TestOccurrence) => t.ignored === true).length,
     failures,
   };
 }

--- a/src/teamcity/types/client.ts
+++ b/src/teamcity/types/client.ts
@@ -1,7 +1,6 @@
 import type { AxiosInstance, AxiosResponse, RawAxiosRequestConfig } from 'axios';
 
 import type { TeamCityAPIClientConfig } from '@/api-client';
-import type { TeamCityFullConfig } from '@/teamcity/config';
 import { AgentApi } from '@/teamcity-client/api/agent-api';
 import { AgentPoolApi } from '@/teamcity-client/api/agent-pool-api';
 import { AgentTypeApi } from '@/teamcity-client/api/agent-type-api';
@@ -32,6 +31,7 @@ import { UserApi } from '@/teamcity-client/api/user-api';
 import { VcsRootApi } from '@/teamcity-client/api/vcs-root-api';
 import { VcsRootInstanceApi } from '@/teamcity-client/api/vcs-root-instance-api';
 import { VersionedSettingsApi } from '@/teamcity-client/api/versioned-settings-api';
+import type { TeamCityFullConfig } from '@/teamcity/config';
 
 export interface TeamCityApiSurface {
   agents: AgentApi;

--- a/src/teamcity/types/client.ts
+++ b/src/teamcity/types/client.ts
@@ -1,3 +1,7 @@
+import type { AxiosInstance, AxiosResponse, RawAxiosRequestConfig } from 'axios';
+
+import type { TeamCityAPIClientConfig } from '@/api-client';
+import type { TeamCityFullConfig } from '@/teamcity/config';
 import { AgentApi } from '@/teamcity-client/api/agent-api';
 import { AgentPoolApi } from '@/teamcity-client/api/agent-pool-api';
 import { AgentTypeApi } from '@/teamcity-client/api/agent-type-api';
@@ -63,3 +67,66 @@ export interface TeamCityApiSurface {
 }
 
 export type TeamCityApiModuleName = keyof TeamCityApiSurface;
+
+export interface TeamCityRequestContext {
+  axios: AxiosInstance;
+  baseUrl: string;
+  requestId?: string;
+}
+
+export interface TeamCityUnifiedClient {
+  /** Direct access to generated REST API modules. */
+  modules: Readonly<TeamCityApiSurface>;
+  /** Shared axios instance configured with retries/interceptors. */
+  http: AxiosInstance;
+  /** Execute a callback with request context information. */
+  request<T>(fn: (ctx: TeamCityRequestContext) => Promise<T>): Promise<T>;
+  /** Latest full configuration used to initialize the client. */
+  getConfig(): TeamCityFullConfig;
+  /** Normalized API client configuration used by the singleton. */
+  getApiConfig(): TeamCityAPIClientConfig;
+  /** Convenience accessor returning the shared axios instance. */
+  getAxios(): AxiosInstance;
+}
+
+export interface BuildApiLike {
+  getBuild: (
+    buildLocator: string,
+    fields?: string,
+    options?: RawAxiosRequestConfig
+  ) => Promise<AxiosResponse<unknown>>;
+  getMultipleBuilds: (
+    locator: string,
+    fields?: string,
+    options?: RawAxiosRequestConfig
+  ) => Promise<AxiosResponse<unknown>>;
+  getBuildProblems: (
+    buildLocator: string,
+    fields?: string,
+    options?: RawAxiosRequestConfig
+  ) => Promise<AxiosResponse<unknown>>;
+}
+
+export interface TeamCityClientAdapter extends TeamCityUnifiedClient {
+  /** Backwards-compatible helpers expected by existing managers. */
+  builds: BuildApiLike;
+  listBuildArtifacts: (
+    buildId: string,
+    options?: {
+      basePath?: string;
+      locator?: string;
+      fields?: string;
+      resolveParameters?: boolean;
+      logBuildUsage?: boolean;
+    }
+  ) => Promise<AxiosResponse<unknown>>;
+  downloadArtifactContent: (
+    buildId: string,
+    artifactPath: string
+  ) => Promise<AxiosResponse<ArrayBuffer>>;
+  getBuildStatistics: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
+  listChangesForBuild: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
+  listSnapshotDependencies: (buildId: string) => Promise<AxiosResponse<unknown>>;
+  /** Canonical base URL of the connected TeamCity server. */
+  baseUrl: string;
+}

--- a/tests/unit/teamcity/client-adapter.test.ts
+++ b/tests/unit/teamcity/client-adapter.test.ts
@@ -1,0 +1,139 @@
+import axios, { type AxiosInstance } from 'axios';
+
+import type { TeamCityAPI, TeamCityAPIClientConfig } from '@/api-client';
+import { createAdapterFromTeamCityAPI } from '@/teamcity/client-adapter';
+import type { TeamCityFullConfig } from '@/teamcity/config';
+import type {
+  BuildApiLike,
+  TeamCityApiSurface,
+  TeamCityRequestContext,
+} from '@/teamcity/types/client';
+
+describe('createAdapterFromTeamCityAPI', () => {
+  const baseUrl = 'https://teamcity.example.com';
+  let http: AxiosInstance;
+  let modules: Readonly<TeamCityApiSurface>;
+  let apiConfig: TeamCityAPIClientConfig;
+  let fullConfig: TeamCityFullConfig;
+  let apiMock: TeamCityAPI;
+  const listBuildArtifacts = jest.fn();
+  const downloadBuildArtifact = jest.fn();
+  const getBuildStatistics = jest.fn();
+  const listChangesForBuild = jest.fn();
+  const listSnapshotDependencies = jest.fn();
+
+  beforeEach(() => {
+    http = axios.create();
+    const buildsMock: BuildApiLike = {
+      getBuild: jest.fn(),
+      getMultipleBuilds: jest.fn(),
+      getBuildProblems: jest.fn(),
+    };
+
+    modules = {
+      agents: {},
+      agentPools: {},
+      agentTypes: {},
+      audit: {},
+      avatars: {},
+      builds: buildsMock,
+      buildQueue: {},
+      buildTypes: {},
+      changes: {},
+      cloudInstances: {},
+      deploymentDashboards: {},
+      globalServerSettings: {},
+      groups: {},
+      health: {},
+      investigations: {},
+      mutes: {},
+      nodes: {},
+      problems: {},
+      problemOccurrences: {},
+      projects: {},
+      roles: {},
+      root: {},
+      server: {},
+      serverAuthSettings: {},
+      tests: {},
+      testMetadata: {},
+      users: {},
+      vcsRoots: {},
+      vcsRootInstances: {},
+      versionedSettings: {},
+    } as unknown as TeamCityApiSurface;
+
+    apiConfig = {
+      baseUrl,
+      token: 'token-123',
+      timeout: 4200,
+    };
+
+    fullConfig = {
+      connection: {
+        baseUrl,
+        token: apiConfig.token,
+        timeout: apiConfig.timeout,
+      },
+    };
+
+    apiMock = {
+      modules,
+      http,
+      getBaseUrl: () => baseUrl,
+      listBuildArtifacts,
+      downloadBuildArtifact,
+      getBuildStatistics,
+      listChangesForBuild,
+      listSnapshotDependencies,
+    } as unknown as TeamCityAPI;
+  });
+
+  it('exposes unified surface and configuration helpers', () => {
+    const adapter = createAdapterFromTeamCityAPI(apiMock, { apiConfig, fullConfig });
+
+    expect(adapter.modules).toBe(modules);
+    expect(adapter.http).toBe(http);
+    expect(adapter.getAxios()).toBe(http);
+    expect(adapter.getConfig()).toBe(fullConfig);
+    expect(adapter.getApiConfig()).toEqual(apiConfig);
+    expect(adapter.baseUrl).toBe(baseUrl);
+    expect(adapter.builds).toBe(modules.builds);
+  });
+
+  it('delegates helper methods to the underlying API', async () => {
+    const adapter = createAdapterFromTeamCityAPI(apiMock, { apiConfig, fullConfig });
+
+    await adapter.listBuildArtifacts('42');
+    expect(listBuildArtifacts).toHaveBeenCalledWith('42', undefined);
+
+    await adapter.downloadArtifactContent('42', 'foo.zip');
+    expect(downloadBuildArtifact).toHaveBeenCalledWith('42', 'foo.zip');
+
+    await adapter.getBuildStatistics('42', 'data');
+    expect(getBuildStatistics).toHaveBeenCalledWith('42', 'data');
+
+    await adapter.listChangesForBuild('42', 'changes');
+    expect(listChangesForBuild).toHaveBeenCalledWith('42', 'changes');
+
+    await adapter.listSnapshotDependencies('42');
+    expect(listSnapshotDependencies).toHaveBeenCalledWith('42');
+  });
+
+  it('provides request helper with axios context', async () => {
+    const adapter = createAdapterFromTeamCityAPI(apiMock, { apiConfig, fullConfig });
+    const fn = jest.fn(async (ctx: TeamCityRequestContext) => ctx.baseUrl);
+
+    const result = await adapter.request(fn);
+
+    expect(result).toBe(baseUrl);
+    expect(fn).toHaveBeenCalledWith({ axios: http, baseUrl, requestId: undefined });
+  });
+
+  it('falls back to minimal config when options omitted', () => {
+    const adapter = createAdapterFromTeamCityAPI(apiMock);
+
+    expect(adapter.getConfig().connection.baseUrl).toBe(baseUrl);
+    expect(adapter.getApiConfig().baseUrl).toBe(baseUrl);
+  });
+});

--- a/tests/unit/teamcity/config.test.ts
+++ b/tests/unit/teamcity/config.test.ts
@@ -1,0 +1,42 @@
+import type { TeamCityFullConfig } from '@/teamcity/config';
+import { toApiClientConfig, toClientConfig } from '@/teamcity/config';
+
+describe('teamcity config helpers', () => {
+  const fullConfig: TeamCityFullConfig = {
+    connection: {
+      baseUrl: 'https://teamcity.example.com',
+      token: 'token-123',
+      timeout: 5000,
+      maxConcurrentRequests: 5,
+      keepAlive: true,
+      compression: true,
+    },
+    retry: {
+      enabled: true,
+      maxRetries: 4,
+      baseDelay: 250,
+      maxDelay: 5000,
+      retryableStatuses: [500],
+    },
+  };
+
+  it('converts to TeamCityAPI client config', () => {
+    expect(toApiClientConfig(fullConfig)).toEqual({
+      baseUrl: 'https://teamcity.example.com',
+      token: 'token-123',
+      timeout: 5000,
+    });
+  });
+
+  it('retains legacy TeamCityClientConfig structure', () => {
+    expect(toClientConfig(fullConfig)).toEqual({
+      baseUrl: 'https://teamcity.example.com',
+      token: 'token-123',
+      timeout: 5000,
+      retryConfig: {
+        retries: 4,
+        retryDelay: 250,
+      },
+    });
+  });
+});

--- a/tests/unit/teamcity/config.test.ts
+++ b/tests/unit/teamcity/config.test.ts
@@ -1,8 +1,4 @@
-import {
-  toApiClientConfig,
-  toClientConfig,
-  type TeamCityFullConfig,
-} from '@/teamcity/config';
+import { type TeamCityFullConfig, toApiClientConfig, toClientConfig } from '@/teamcity/config';
 
 describe('teamcity config helpers', () => {
   const fullConfig: TeamCityFullConfig = {

--- a/tests/unit/teamcity/config.test.ts
+++ b/tests/unit/teamcity/config.test.ts
@@ -1,5 +1,8 @@
-import type { TeamCityFullConfig } from '@/teamcity/config';
-import { toApiClientConfig, toClientConfig } from '@/teamcity/config';
+import {
+  toApiClientConfig,
+  toClientConfig,
+  type TeamCityFullConfig,
+} from '@/teamcity/config';
 
 describe('teamcity config helpers', () => {
   const fullConfig: TeamCityFullConfig = {


### PR DESCRIPTION
## Summary
- replace the thin legacy adapter with a unified client that exposes the full TeamCity API surface, shared axios handle, and request helper while preserving legacy helpers
- update TeamCity initialization/config flows to produce `TeamCityAPIClientConfig`, return the adapter from public entry points, and document the legacy client as deprecated
- add targeted unit coverage for the adapter/config helpers and ensure tooling calls continue to work against the new adapter shape

## Testing
- npm run lint
- npm run test:unit

Refs #114
