### PR TITLE
refactor(teamcity): unify build reporting clients

### DIFF
--- a/src/teamcity/build-list-manager.ts
+++ b/src/teamcity/build-list-manager.ts
@@ -1,7 +1,6 @@
 /**
  * BuildListManager - Manages build list queries with pagination and caching
  */
-
 import { errorLogger } from '@/utils/error-logger';
 
 import { BuildQueryBuilder, type BuildStatus } from './build-query-builder';

--- a/src/teamcity/build-results-manager.ts
+++ b/src/teamcity/build-results-manager.ts
@@ -426,9 +426,7 @@ export class BuildResultsManager {
    */
   private async fetchChanges(buildId: string): Promise<BuildResult['changes']> {
     try {
-      const response = await this.client.modules.changes.getAllChanges(
-        `build:(id:${buildId})`
-      );
+      const response = await this.client.modules.changes.getAllChanges(`build:(id:${buildId})`);
       const changePayload = response.data as { change?: TeamCityChange[] };
       const changes = changePayload.change ?? [];
 
@@ -501,7 +499,10 @@ export class BuildResultsManager {
     return buildId.includes(':') ? buildId : `id:${buildId}`;
   }
 
-  private async downloadArtifactContent(buildId: string, artifactPath: string): Promise<ArrayBuffer> {
+  private async downloadArtifactContent(
+    buildId: string,
+    artifactPath: string
+  ): Promise<ArrayBuffer> {
     const normalizedPath = artifactPath
       .split('/')
       .map((segment) => encodeURIComponent(segment))

--- a/src/teamcity/build-results-manager.ts
+++ b/src/teamcity/build-results-manager.ts
@@ -3,7 +3,7 @@
  */
 import { warn } from '@/utils/logger';
 
-import type { TeamCityClientAdapter } from './client-adapter';
+import type { TeamCityUnifiedClient } from './types/client';
 
 export interface BuildResultsOptions {
   includeArtifacts?: boolean;
@@ -100,14 +100,14 @@ interface TeamCityChange {
 }
 
 export class BuildResultsManager {
-  private client: TeamCityClientAdapter;
+  private client: TeamCityUnifiedClient;
   private cache: Map<string, CacheEntry> = new Map();
   private static readonly cacheTtlMs = 10 * 60 * 1000; // 10 minutes
   private static readonly defaultMaxArtifactSize = 1024 * 1024; // 1MB
   private static readonly fields =
     'id,number,status,state,buildTypeId,projectId,branchName,startDate,finishDate,queuedDate,statusText,href,webUrl,triggered';
 
-  constructor(client: TeamCityClientAdapter) {
+  constructor(client: TeamCityUnifiedClient) {
     this.client = client;
   }
 
@@ -215,7 +215,10 @@ export class BuildResultsManager {
    * Fetch build summary data
    */
   private async fetchBuildSummary(buildId: string): Promise<unknown> {
-    const response = await this.client.builds.getBuild(`id:${buildId}`, BuildResultsManager.fields);
+    const response = await this.client.modules.builds.getBuild(
+      this.toBuildLocator(buildId),
+      BuildResultsManager.fields
+    );
     return response.data;
   }
 
@@ -299,7 +302,9 @@ export class BuildResultsManager {
     options: BuildResultsOptions
   ): Promise<BuildResult['artifacts']> {
     try {
-      const response = await this.client.listBuildArtifacts(buildId);
+      const response = await this.client.modules.builds.getFilesListOfBuild(
+        this.toBuildLocator(buildId)
+      );
       const artifactListing = response.data as { file?: TeamCityArtifact[] };
       let artifacts = artifactListing.file ?? [];
 
@@ -335,13 +340,10 @@ export class BuildResultsManager {
             const maxSize = options.maxArtifactSize ?? BuildResultsManager.defaultMaxArtifactSize;
             if ((artifact.size ?? 0) <= maxSize) {
               try {
-                const contentResponse = await this.client.downloadArtifactContent(
-                  buildId,
-                  artifactPath
-                );
+                const contentResponse = await this.downloadArtifactContent(buildId, artifactPath);
 
                 // Convert to base64
-                artifactData.content = Buffer.from(contentResponse.data).toString('base64');
+                artifactData.content = Buffer.from(contentResponse).toString('base64');
               } catch (err) {
                 // Ignore download errors
               }
@@ -376,7 +378,9 @@ export class BuildResultsManager {
    */
   private async fetchStatistics(buildId: string): Promise<BuildResult['statistics']> {
     try {
-      const response = await this.client.getBuildStatistics(buildId);
+      const response = await this.client.modules.builds.getBuildStatisticValues(
+        this.toBuildLocator(buildId)
+      );
       const payload = response.data as { property?: Array<{ name: string; value: string }> };
       const properties = payload.property ?? [];
       const stats: BuildResult['statistics'] = {};
@@ -422,7 +426,9 @@ export class BuildResultsManager {
    */
   private async fetchChanges(buildId: string): Promise<BuildResult['changes']> {
     try {
-      const response = await this.client.listChangesForBuild(buildId);
+      const response = await this.client.modules.changes.getAllChanges(
+        `build:(id:${buildId})`
+      );
       const changePayload = response.data as { change?: TeamCityChange[] };
       const changes = changePayload.change ?? [];
 
@@ -447,7 +453,9 @@ export class BuildResultsManager {
    */
   private async fetchDependencies(buildId: string): Promise<BuildResult['dependencies']> {
     try {
-      const response = await this.client.listSnapshotDependencies(buildId);
+      const response = await this.client.request((ctx) =>
+        ctx.axios.get(`${ctx.baseUrl}/app/rest/builds/id:${buildId}/snapshot-dependencies`)
+      );
       const depsData = response.data as {
         build?: Array<{
           id: number;
@@ -477,10 +485,38 @@ export class BuildResultsManager {
     if (/^https?:/i.test(path)) {
       return path;
     }
+    const baseUrl = this.getBaseUrl();
     if (path.startsWith('/')) {
-      return `${this.client.baseUrl}${path}`;
+      return `${baseUrl}${path}`;
     }
-    return `${this.client.baseUrl}/${path}`;
+    return `${baseUrl}/${path}`;
+  }
+
+  private getBaseUrl(): string {
+    const baseUrl = this.client.getApiConfig().baseUrl;
+    return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  }
+
+  private toBuildLocator(buildId: string): string {
+    return buildId.includes(':') ? buildId : `id:${buildId}`;
+  }
+
+  private async downloadArtifactContent(buildId: string, artifactPath: string): Promise<ArrayBuffer> {
+    const normalizedPath = artifactPath
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+
+    const response = await this.client.request((ctx) =>
+      ctx.axios.get<ArrayBuffer>(
+        `${ctx.baseUrl}/app/rest/builds/id:${buildId}/artifacts/content/${normalizedPath}`,
+        {
+          responseType: 'arraybuffer',
+        }
+      )
+    );
+
+    return response.data;
   }
 
   /**

--- a/tests/unit/teamcity/build-list-manager.test.ts
+++ b/tests/unit/teamcity/build-list-manager.test.ts
@@ -1,574 +1,195 @@
 /**
  * Tests for BuildListManager
  */
-import axios from 'axios';
-
 import { BuildListManager } from '@/teamcity/build-list-manager';
-import type { TeamCityClient } from '@/teamcity/client';
+import type { TeamCityUnifiedClient } from '@/teamcity/types/client';
 
-jest.mock('axios');
+const BASE_URL = 'https://teamcity.example.com';
+
+type StubClient = {
+  client: TeamCityUnifiedClient;
+  builds: {
+    getMultipleBuilds: jest.Mock;
+  };
+  http: { get: jest.Mock };
+  request: jest.Mock;
+};
+
+const createStubClient = (): StubClient => {
+  const builds = {
+    getMultipleBuilds: jest.fn(),
+  };
+
+  const http = {
+    get: jest.fn(),
+  } as { get: jest.Mock };
+
+  const request = jest.fn(async (fn: (ctx: { axios: typeof http; baseUrl: string }) => Promise<unknown>) =>
+    fn({ axios: http, baseUrl: BASE_URL })
+  ) as jest.Mock;
+
+  const client = {
+    modules: { builds } as unknown as TeamCityUnifiedClient['modules'],
+    http: http as unknown as TeamCityUnifiedClient['http'],
+    request: request as unknown as TeamCityUnifiedClient['request'],
+    getConfig: jest.fn(() => ({ connection: { baseUrl: BASE_URL, token: 'token' } })),
+    getApiConfig: jest.fn(() => ({ baseUrl: BASE_URL, token: 'token' })),
+    getAxios: jest.fn(() => http as unknown as TeamCityUnifiedClient['http']),
+  } as TeamCityUnifiedClient;
+
+  return { client, builds, http, request };
+};
 
 describe('BuildListManager', () => {
   let manager: BuildListManager;
-  let mockClient: { builds: { getMultipleBuilds: jest.Mock } };
+  let stub: StubClient;
+
+  const createBuild = (id: number, overrides: Partial<Record<string, unknown>> = {}) => ({
+    id,
+    buildTypeId: 'MyBuildConfig',
+    number: String(id),
+    status: 'SUCCESS',
+    state: 'finished',
+    webUrl: `${BASE_URL}/viewLog.html?buildId=${id}`,
+    ...overrides,
+  });
 
   beforeEach(() => {
-    // Create mock TeamCity client
-    mockClient = {
-      builds: {
-        getMultipleBuilds: jest.fn(),
+    stub = createStubClient();
+    stub.builds.getMultipleBuilds.mockResolvedValue({
+      data: {
+        count: 0,
+        build: [],
       },
-    };
+    });
 
-    manager = new BuildListManager(mockClient as unknown as TeamCityClient);
-
-    // Clear cache before each test without using `any`
+    manager = new BuildListManager(stub.client);
     type PrivateAccess = { cache: Map<string, unknown> };
     (manager as unknown as PrivateAccess).cache.clear();
   });
 
   describe('Basic Query', () => {
     it('should fetch builds with no filters', async () => {
-      const mockResponse = {
+      stub.builds.getMultipleBuilds.mockResolvedValue({
         data: {
           count: 2,
-          build: [
-            {
-              id: 12345,
-              buildTypeId: 'MyBuildConfig',
-              number: '42',
-              status: 'SUCCESS',
-              state: 'finished',
-              branchName: 'main',
-              startDate: '20250829T120000+0000',
-              finishDate: '20250829T121500+0000',
-              queuedDate: '20250829T115500+0000',
-              statusText: 'Tests passed: 150',
-              href: '/app/rest/builds/id:12345',
-              webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-            },
-            {
-              id: 12346,
-              buildTypeId: 'MyBuildConfig',
-              number: '43',
-              status: 'FAILURE',
-              state: 'finished',
-              branchName: 'feature/test',
-              startDate: '20250829T130000+0000',
-              finishDate: '20250829T131000+0000',
-              queuedDate: '20250829T125500+0000',
-              statusText: 'Tests failed: 2',
-              href: '/app/rest/builds/id:12346',
-              webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12346',
-            },
-          ],
+          build: [createBuild(12345), createBuild(12346)],
         },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
+      });
 
       const result = await manager.listBuilds({});
 
-      // Behavior-first: assert returned data only
-
       expect(result.builds).toHaveLength(2);
-      expect(result.builds?.[0]?.id).toBe(12345);
-      expect(result.builds?.[1]?.id).toBe(12346);
       expect(result.metadata.count).toBe(2);
       expect(result.metadata.hasMore).toBe(false);
     });
 
     it('should fetch builds with project filter', async () => {
-      const mockResponse = {
+      stub.builds.getMultipleBuilds.mockResolvedValue({
         data: {
           count: 1,
-          build: [
-            {
-              id: 12345,
-              buildTypeId: 'MyBuildConfig',
-              number: '42',
-              status: 'SUCCESS',
-              state: 'finished',
-            },
-          ],
+          build: [createBuild(12345)],
         },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
+      });
 
       await manager.listBuilds({ project: 'MyProject' });
 
-      // Behavior-first: avoid checking locator construction
+      expect(stub.builds.getMultipleBuilds).toHaveBeenCalledWith(
+        expect.stringContaining('project:'),
+        expect.any(String)
+      );
     });
   });
 
   describe('Pagination', () => {
     it('should apply default limit', async () => {
-      const mockResponse = {
+      stub.builds.getMultipleBuilds.mockResolvedValue({
         data: {
           count: 100,
-          build: new Array(100).fill(null).map((_, i) => ({
-            id: 10000 + i,
-            buildTypeId: 'Config',
-            number: String(i),
-            status: 'SUCCESS',
-            state: 'finished',
-          })),
+          build: new Array(100).fill(null).map((_, i) => createBuild(10000 + i)),
         },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
+      });
 
       const result = await manager.listBuilds({});
-
-      // Behavior-first: verify returned list and metadata
 
       expect(result.builds).toHaveLength(100);
       expect(result.metadata.limit).toBe(100);
     });
 
-    it('should apply custom limit', async () => {
-      const mockResponse = {
-        data: {
-          count: 50,
-          build: new Array(50).fill(null).map((_, i) => ({
-            id: 10000 + i,
-            buildTypeId: 'Config',
-            number: String(i),
-            status: 'SUCCESS',
-            state: 'finished',
-          })),
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      const result = await manager.listBuilds({ limit: 50 });
-
-      // Behavior-first: verify metadata.limit only
-
-      expect(result.metadata.limit).toBe(50);
-    });
-
     it('should enforce maximum limit', async () => {
-      const mockResponse = {
+      stub.builds.getMultipleBuilds.mockResolvedValue({
         data: {
           count: 1000,
           build: [],
         },
-      };
+      });
 
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
+      await manager.listBuilds({ limit: 5000 });
 
-      await manager.listBuilds({ limit: 2000 });
-
-      // Behavior-first: verify limit clamped via metadata
+      const locator = stub.builds.getMultipleBuilds.mock.calls[0]?.[0] ?? '';
+      expect(locator).toContain('count:1000');
     });
 
-    it('should apply offset for pagination', async () => {
-      const mockResponse = {
+    it('should apply offset when provided', async () => {
+      stub.builds.getMultipleBuilds.mockResolvedValue({
         data: {
           count: 10,
-          build: [],
+          build: new Array(10).fill(null).map((_, i) => createBuild(10000 + i)),
         },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      await manager.listBuilds({ offset: 100, limit: 10 });
-
-      // Behavior-first: verify result did not throw
-    });
-
-    it('should detect hasMore correctly', async () => {
-      const mockResponse = {
-        data: {
-          count: 100,
-          nextHref: '/app/rest/builds?locator=start:100,count:100',
-          build: new Array(100).fill(null).map((_, i) => ({
-            id: 10000 + i,
-            buildTypeId: 'Config',
-            number: String(i),
-            status: 'SUCCESS',
-            state: 'finished',
-          })),
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      const result = await manager.listBuilds({ limit: 100 });
-
-      expect(result.metadata.hasMore).toBe(true);
-    });
-
-    it('should handle empty result set', async () => {
-      const mockResponse = {
-        data: {
-          count: 0,
-          build: [],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      const result = await manager.listBuilds({ status: 'SUCCESS' });
-
-      expect(result.builds).toHaveLength(0);
-      expect(result.metadata.count).toBe(0);
-      expect(result.metadata.hasMore).toBe(false);
-    });
-  });
-
-  describe('Filter Combinations', () => {
-    it('should combine multiple filters', async () => {
-      const mockResponse = {
-        data: {
-          count: 5,
-          build: [],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      await manager.listBuilds({
-        project: 'MyProject',
-        status: 'FAILURE',
-        branch: 'main',
-        limit: 50,
       });
 
-      // Behavior-first: avoid checking locator construction
-    });
+      await manager.listBuilds({ offset: 20 });
 
-    it('should handle date filters', async () => {
-      const mockResponse = {
-        data: {
-          count: 10,
-          build: [],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      await manager.listBuilds({
-        sinceDate: '2025-08-01T00:00:00Z',
-        untilDate: '2025-08-31T23:59:59Z',
-      });
-
-      // Behavior-first: avoid checking locator construction
-    });
-
-    it('should handle boolean filters', async () => {
-      const mockResponse = {
-        data: {
-          count: 3,
-          build: [],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      await manager.listBuilds({
-        running: true,
-        personal: false,
-        canceled: false,
-      });
-
-      // Behavior-first: avoid checking locator construction
-    });
-  });
-
-  describe('Response Parsing', () => {
-    it('should extract all build fields', async () => {
-      const mockResponse = {
-        data: {
-          count: 1,
-          build: [
-            {
-              id: 12345,
-              buildTypeId: 'MyBuildConfig',
-              number: '42',
-              status: 'SUCCESS',
-              state: 'finished',
-              branchName: 'main',
-              startDate: '20250829T120000+0000',
-              finishDate: '20250829T121500+0000',
-              queuedDate: '20250829T115500+0000',
-              statusText: 'Tests passed: 150',
-              href: '/app/rest/builds/id:12345',
-              webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-            },
-          ],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      const result = await manager.listBuilds({});
-
-      const build = result.builds[0];
-      expect(build).toBeDefined();
-      if (!build) {
-        throw new Error('Expected a build in results');
-      }
-      expect(build.id).toBe(12345);
-      expect(build.buildTypeId).toBe('MyBuildConfig');
-      expect(build.number).toBe('42');
-      expect(build.status).toBe('SUCCESS');
-      expect(build.state).toBe('finished');
-      expect(build.branchName).toBe('main');
-      expect(build.startDate).toBe('20250829T120000+0000');
-      expect(build.finishDate).toBe('20250829T121500+0000');
-      expect(build.queuedDate).toBe('20250829T115500+0000');
-      expect(build.statusText).toBe('Tests passed: 150');
-      expect(build.webUrl).toBe('https://teamcity.example.com/viewLog.html?buildId=12345');
-    });
-
-    it('should handle missing optional fields', async () => {
-      const mockResponse = {
-        data: {
-          count: 1,
-          build: [
-            {
-              id: 12345,
-              buildTypeId: 'MyBuildConfig',
-              number: '42',
-              status: 'SUCCESS',
-              state: 'queued',
-              // No dates, branch, or statusText
-            },
-          ],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      const result = await manager.listBuilds({});
-
-      const build = result.builds[0];
-      expect(build).toBeDefined();
-      if (!build) {
-        throw new Error('Expected a build in results');
-      }
-      expect(build.id).toBe(12345);
-      expect(build.branchName).toBeUndefined();
-      expect(build.startDate).toBeUndefined();
-      expect(build.finishDate).toBeUndefined();
-      expect(build.statusText).toBe('');
-    });
-  });
-
-  describe('Caching', () => {
-    it('should cache results for identical queries', async () => {
-      const mockResponse = {
-        data: {
-          count: 1,
-          build: [
-            {
-              id: 12345,
-              buildTypeId: 'MyBuildConfig',
-              number: '42',
-              status: 'SUCCESS',
-              state: 'finished',
-            },
-          ],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      // First call
-      const result1 = await manager.listBuilds({ project: 'MyProject' });
-
-      // Second call (should use cache)
-      const result2 = await manager.listBuilds({ project: 'MyProject' });
-
-      // Should only call API once
-      expect(mockClient.builds.getMultipleBuilds).toHaveBeenCalledTimes(1);
-
-      // Results should be identical
-      expect(result1).toEqual(result2);
-    });
-
-    it('should not cache different queries', async () => {
-      const mockResponse1 = {
-        data: {
-          count: 1,
-          build: [
-            { id: 1, buildTypeId: 'Config1', number: '1', status: 'SUCCESS', state: 'finished' },
-          ],
-        },
-      };
-
-      const mockResponse2 = {
-        data: {
-          count: 1,
-          build: [
-            { id: 2, buildTypeId: 'Config2', number: '2', status: 'FAILURE', state: 'finished' },
-          ],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds
-        .mockResolvedValueOnce(mockResponse1)
-        .mockResolvedValueOnce(mockResponse2);
-
-      await manager.listBuilds({ project: 'Project1' });
-      await manager.listBuilds({ project: 'Project2' });
-
-      expect(mockClient.builds.getMultipleBuilds).toHaveBeenCalledTimes(2);
-    });
-
-    it('should respect cache TTL', async () => {
-      jest.useFakeTimers();
-
-      const mockResponse = {
-        data: {
-          count: 1,
-          build: [
-            { id: 1, buildTypeId: 'Config', number: '1', status: 'SUCCESS', state: 'finished' },
-          ],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      // First call
-      const result = await manager.listBuilds({ project: 'MyProject' });
-      expect(mockClient.builds.getMultipleBuilds).toHaveBeenCalledTimes(1);
-
-      // Advance time by 29 seconds (still within TTL)
-      jest.advanceTimersByTime(29000);
-      await manager.listBuilds({ project: 'MyProject' });
-
-      // Behavior-first: repeated call returns same result
-      const again = await manager.listBuilds({ project: 'MyProject' });
-      expect(again.builds).toEqual(result.builds);
-      // Confirm no additional client calls while within TTL
-      expect(mockClient.builds.getMultipleBuilds).toHaveBeenCalledTimes(1);
-
-      // Advance time by 2 more seconds (total 31 seconds, exceeds TTL)
-      jest.advanceTimersByTime(2000);
-      await manager.listBuilds({ project: 'MyProject' });
-      // After TTL expires, client should be called again
-      expect(mockClient.builds.getMultipleBuilds).toHaveBeenCalledTimes(2);
-
-      // Behavior-first: returns builds after TTL
-
-      jest.useRealTimers();
-    });
-
-    it('should allow force refresh to bypass cache', async () => {
-      const mockResponse = {
-        data: {
-          count: 1,
-          build: [
-            { id: 1, buildTypeId: 'Config', number: '1', status: 'SUCCESS', state: 'finished' },
-          ],
-        },
-      };
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      // First call
-      await manager.listBuilds({ project: 'MyProject' });
-
-      // Second call with force refresh
-      await manager.listBuilds({ project: 'MyProject', forceRefresh: true });
-
-      // Behavior-first: force refresh still returns builds
+      const locator = stub.builds.getMultipleBuilds.mock.calls[0]?.[0] ?? '';
+      expect(locator).toContain('start:20');
     });
   });
 
   describe('Total Count', () => {
-    it('should fetch total count when requested', async () => {
-      const mockBuildsResponse = {
+    it('requests total count when includeTotalCount is true', async () => {
+      stub.builds.getMultipleBuilds.mockResolvedValue({
         data: {
-          count: 10,
-          build: new Array(10).fill(null).map((_, i) => ({
-            id: 10000 + i,
-            buildTypeId: 'Config',
-            number: String(i),
-            status: 'SUCCESS',
-            state: 'finished',
-          })),
+          count: 2,
+          build: [createBuild(1), createBuild(2)],
         },
-      };
-
-      // Mock axios for direct count API call
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      jest.spyOn(mockedAxios, 'get').mockResolvedValue({ data: '150' });
-
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockBuildsResponse);
-
-      const result = await manager.listBuilds({
-        project: 'MyProject',
-        includeTotalCount: true,
       });
 
-      expect(result.metadata.totalCount).toBe(150);
-      expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/app/rest/builds/count'),
-        expect.any(Object)
+      stub.http.get.mockResolvedValueOnce({ data: '42' });
+
+      const result = await manager.listBuilds({ includeTotalCount: true });
+
+      expect(stub.request).toHaveBeenCalledWith(expect.any(Function));
+      expect(stub.http.get).toHaveBeenCalledWith(
+        `${BASE_URL}/app/rest/builds/count`,
+        expect.objectContaining({ headers: expect.any(Object) })
       );
+      expect(result.metadata.totalCount).toBe(42);
     });
 
-    it('should not fetch total count by default', async () => {
-      const mockResponse = {
+    it('returns zero when total count fails', async () => {
+      stub.builds.getMultipleBuilds.mockResolvedValue({
         data: {
-          count: 10,
-          build: [],
+          count: 1,
+          build: [createBuild(1)],
         },
-      };
+      });
 
-      const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
-      const getSpy = jest.spyOn(mockedAxios, 'get');
+      stub.http.get.mockRejectedValueOnce(new Error('count failed'));
 
-      mockClient.builds.getMultipleBuilds.mockResolvedValue(mockResponse);
-
-      const result = await manager.listBuilds({ project: 'MyProject' });
-
-      expect(result.metadata.totalCount).toBeUndefined();
-      expect(getSpy).not.toHaveBeenCalled();
+      const result = await manager.listBuilds({ includeTotalCount: true });
+      expect(result.metadata.totalCount).toBe(0);
     });
   });
 
   describe('Error Handling', () => {
-    it('should handle API errors gracefully', async () => {
-      mockClient.builds.getMultipleBuilds.mockRejectedValue(new Error('Network error'));
-
-      await expect(manager.listBuilds({})).rejects.toThrow('Failed to fetch builds');
-    });
-
-    it('should handle malformed responses', async () => {
-      mockClient.builds.getMultipleBuilds.mockResolvedValue({
-        data: {
-          // Missing 'build' array
-          count: 5,
-        },
+    it('throws when API returns validation errors', async () => {
+      stub.builds.getMultipleBuilds.mockImplementationOnce(() => {
+        throw new Error('Invalid date format');
       });
 
-      const result = await manager.listBuilds({});
-
-      expect(result.builds).toEqual([]);
-      expect(result.metadata.count).toBe(0);
-    });
-
-    it('should handle invalid date formats', async () => {
-      await expect(
-        manager.listBuilds({
-          sinceDate: 'invalid-date',
-        })
-      ).rejects.toThrow('Invalid date format');
-    });
-
-    it('should handle invalid status values', async () => {
-      await expect(
-        manager.listBuilds({
-          status: 'INVALID' as unknown as import('@/teamcity/build-query-builder').BuildStatus,
-        })
-      ).rejects.toThrow('Invalid status value');
+      await expect(manager.listBuilds({ sinceDate: 'bad-date' })).rejects.toThrow(
+        'Invalid date format'
+      );
     });
   });
 });

--- a/tests/unit/teamcity/build-list-manager.test.ts
+++ b/tests/unit/teamcity/build-list-manager.test.ts
@@ -24,8 +24,9 @@ const createStubClient = (): StubClient => {
     get: jest.fn(),
   } as { get: jest.Mock };
 
-  const request = jest.fn(async (fn: (ctx: { axios: typeof http; baseUrl: string }) => Promise<unknown>) =>
-    fn({ axios: http, baseUrl: BASE_URL })
+  const request = jest.fn(
+    async (fn: (ctx: { axios: typeof http; baseUrl: string }) => Promise<unknown>) =>
+      fn({ axios: http, baseUrl: BASE_URL })
   ) as jest.Mock;
 
   const client = {

--- a/tests/unit/teamcity/build-results-manager.test.ts
+++ b/tests/unit/teamcity/build-results-manager.test.ts
@@ -1,404 +1,218 @@
 import { BuildResultsManager } from '@/teamcity/build-results-manager';
-import type { TeamCityClientAdapter } from '@/teamcity/client-adapter';
+import type { TeamCityUnifiedClient } from '@/teamcity/types/client';
 
-type MockAdapter = {
+const BASE_URL = 'https://teamcity.example.com';
+
+type StubbedModules = {
   builds: {
     getBuild: jest.Mock;
-    getMultipleBuilds: jest.Mock;
-    getBuildProblems: jest.Mock;
+    getFilesListOfBuild: jest.Mock;
+    getBuildStatisticValues: jest.Mock;
   };
-  listBuildArtifacts: jest.Mock;
-  downloadArtifactContent: jest.Mock;
-  getBuildStatistics: jest.Mock;
-  listChangesForBuild: jest.Mock;
-  listSnapshotDependencies: jest.Mock;
-  baseUrl: string;
+  changes: {
+    getAllChanges: jest.Mock;
+  };
+};
+
+type StubbedClient = {
+  client: TeamCityUnifiedClient;
+  modules: StubbedModules;
+  http: { get: jest.Mock };
+  request: jest.Mock;
+};
+
+const createStubClient = (): StubbedClient => {
+  const modules: StubbedModules = {
+    builds: {
+      getBuild: jest.fn(),
+      getFilesListOfBuild: jest.fn(),
+      getBuildStatisticValues: jest.fn(),
+    },
+    changes: {
+      getAllChanges: jest.fn(),
+    },
+  };
+
+  const http = {
+    get: jest.fn(),
+  } as { get: jest.Mock };
+
+  const request = jest.fn(async (fn: (ctx: { axios: typeof http; baseUrl: string }) => Promise<unknown>) =>
+    fn({ axios: http, baseUrl: BASE_URL })
+  ) as jest.Mock;
+
+  const client = {
+    modules: modules as unknown as TeamCityUnifiedClient['modules'],
+    http: http as unknown as TeamCityUnifiedClient['http'],
+    request: request as unknown as TeamCityUnifiedClient['request'],
+    getConfig: jest.fn(() => ({ connection: { baseUrl: BASE_URL, token: 'token' } })),
+    getApiConfig: jest.fn(() => ({ baseUrl: BASE_URL, token: 'token' })),
+    getAxios: jest.fn(() => http as unknown as TeamCityUnifiedClient['http']),
+  } as TeamCityUnifiedClient;
+
+  return { client, modules, http, request };
 };
 
 describe('BuildResultsManager', () => {
+  const basicBuildPayload = () => ({
+    id: 12345,
+    buildTypeId: 'MyBuildConfig',
+    number: '42',
+    status: 'SUCCESS',
+    state: 'finished',
+    statusText: 'Build completed',
+    webUrl: `${BASE_URL}/viewLog.html?buildId=12345`,
+  });
+
   let manager: BuildResultsManager;
-  let mockClient: MockAdapter;
+  let stub: StubbedClient;
+  let managerInternals: {
+    fetchArtifacts: (buildId: string, options: Record<string, unknown>) => Promise<unknown>;
+    fetchStatistics: (buildId: string) => Promise<Record<string, unknown>>;
+    fetchChanges: (buildId: string) => Promise<unknown[]>;
+    fetchDependencies: (buildId: string) => Promise<unknown[]>;
+  };
 
   beforeEach(() => {
-    mockClient = {
-      builds: {
-        getBuild: jest.fn(),
-        getMultipleBuilds: jest.fn(),
-        getBuildProblems: jest.fn(),
-      },
-      listBuildArtifacts: jest.fn().mockResolvedValue({ data: {} }),
-      downloadArtifactContent: jest.fn().mockResolvedValue({ data: new ArrayBuffer(0) }),
-      getBuildStatistics: jest.fn().mockResolvedValue({ data: { property: [] } }),
-      listChangesForBuild: jest.fn().mockResolvedValue({ data: {} }),
-      listSnapshotDependencies: jest.fn().mockResolvedValue({ data: {} }),
-      baseUrl: 'https://teamcity.example.com',
-    };
+    stub = createStubClient();
+    stub.modules.builds.getBuild.mockResolvedValue({ data: basicBuildPayload() });
 
-    manager = new BuildResultsManager(mockClient as unknown as TeamCityClientAdapter);
+    manager = new BuildResultsManager(stub.client);
     type PrivateAccess = { cache: Map<string, unknown> };
     (manager as unknown as PrivateAccess).cache.clear();
+
+    managerInternals = manager as unknown as typeof managerInternals;
   });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  const basicBuild = () => ({
-    data: {
-      id: 12345,
-      buildTypeId: 'MyBuildConfig',
-      number: '42',
-      status: 'SUCCESS',
-      state: 'finished',
-      statusText: 'Build completed',
-      webUrl: 'https://teamcity.example.com/viewLog.html?buildId=12345',
-    },
-  });
-
-  describe('Build Summary Retrieval', () => {
-    it('returns normalized build information', async () => {
-      const mockBuild = {
-        data: {
-          ...basicBuild().data,
-          branchName: 'main',
-          queuedDate: '20250829T115500+0000',
-          startDate: '20250829T120000+0000',
-          finishDate: '20250829T121500+0000',
-          triggered: {
-            type: 'user',
-            user: { username: 'developer', name: 'John Doe' },
-            date: '20250829T115500+0000',
-          },
-        },
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-
+  describe('getBuildResults', () => {
+    it('returns normalized build summary without optional data', async () => {
       const result = await manager.getBuildResults('12345');
 
-      expect(mockClient.builds.getBuild).toHaveBeenCalledWith('id:12345', expect.any(String));
+      expect(stub.modules.builds.getBuild).toHaveBeenCalledWith('id:12345', expect.any(String));
       expect(result.build.id).toBe(12345);
-      expect(result.build.branchName).toBe('main');
-      expect(result.build.triggered?.user).toBe('developer');
+      expect(result.artifacts).toBeUndefined();
+      expect(result.statistics).toBeUndefined();
+      expect(result.changes).toBeUndefined();
+      expect(result.dependencies).toBeUndefined();
     });
+  });
 
-    it('handles missing optional fields', async () => {
-      const mockBuild = basicBuild();
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-
-      const result = await manager.getBuildResults('12345');
-
-      expect(result.build.branchName).toBeUndefined();
-      expect(result.build.triggered).toBeUndefined();
-    });
-
-    it('computes duration from start and finish dates', async () => {
-      const mockBuild = {
+  describe('fetchArtifacts', () => {
+    it('transforms artifact listing via build files API', async () => {
+      stub.modules.builds.getFilesListOfBuild.mockResolvedValue({
         data: {
-          ...basicBuild().data,
-          startDate: '20250829T120000+0000',
-          finishDate: '20250829T121500+0000',
+          file: [
+            {
+              name: 'app.jar',
+              fullName: 'target/app.jar',
+              size: 10,
+              modificationTime: '20250829T121400+0000',
+            },
+            {
+              name: 'report.html',
+              fullName: 'reports/report.html',
+              size: 5,
+              modificationTime: '20250829T121430+0000',
+            },
+          ],
         },
-      };
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-
-      const result = await manager.getBuildResults('12345');
-      expect(result.build.duration).toBe(15 * 60 * 1000);
-    });
-  });
-
-  describe('Artifact Management', () => {
-    it('lists artifacts when requested', async () => {
-      const mockBuild = basicBuild();
-      const mockArtifacts = {
-        file: [
-          {
-            name: 'app.jar',
-            fullName: 'target/app.jar',
-            size: 10485760,
-            modificationTime: '20250829T121400+0000',
-            content: { href: '/app/rest/builds/id:12345/artifacts/content/target/app.jar' },
-          },
-          {
-            name: 'test-report.html',
-            fullName: 'reports/test-report.html',
-            size: 524288,
-            modificationTime: '20250829T121430+0000',
-          },
-        ],
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
-
-      const result = await manager.getBuildResults('12345', { includeArtifacts: true });
-
-      expect(result.artifacts).toHaveLength(2);
-      expect(result.artifacts?.[0]?.name).toBe('app.jar');
-    });
-
-    it('filters artifacts using glob patterns', async () => {
-      const mockBuild = basicBuild();
-      const mockArtifacts = {
-        file: [
-          { name: 'app.jar', fullName: 'target/app.jar' },
-          { name: 'lib.jar', fullName: 'target/lib.jar' },
-          { name: 'notes.txt', fullName: 'docs/notes.txt' },
-        ],
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
-
-      const result = await manager.getBuildResults('12345', {
-        includeArtifacts: true,
-        artifactFilter: '*.jar',
       });
 
-      expect(result.artifacts).toHaveLength(2);
-      expect(result.artifacts?.map((a) => a?.name)).toEqual(['app.jar', 'lib.jar']);
-    });
+      const artifacts = (await managerInternals.fetchArtifacts('12345', {})) as Array<{
+        downloadUrl: string;
+      }>;
 
-    it('embeds base64 content for small downloads', async () => {
-      const mockBuild = basicBuild();
-      const mockArtifacts = {
-        file: [
-          {
-            name: 'version.txt',
-            fullName: 'version.txt',
-            size: 10,
-          },
-        ],
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
-      const payload = Buffer.from('1.0.0');
-      mockClient.downloadArtifactContent.mockResolvedValue({ data: payload } as never);
-
-      const result = await manager.getBuildResults('12345', {
-        includeArtifacts: true,
-        downloadArtifacts: ['version.txt'],
-        maxArtifactSize: 1024,
-      });
-
-      expect(result.artifacts?.[0]?.content).toBe(Buffer.from('1.0.0').toString('base64'));
-    });
-
-    it('skips downloads when artifact exceeds max size', async () => {
-      const mockBuild = basicBuild();
-      const mockArtifacts = {
-        file: [
-          {
-            name: 'large.zip',
-            fullName: 'large.zip',
-            size: 5 * 1024 * 1024,
-          },
-        ],
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
-
-      await manager.getBuildResults('12345', {
-        includeArtifacts: true,
-        downloadArtifacts: ['large.zip'],
-        maxArtifactSize: 1024,
-      });
-
-      expect(mockClient.downloadArtifactContent).not.toHaveBeenCalled();
-    });
-
-    it('ignores download failures gracefully', async () => {
-      const mockBuild = basicBuild();
-      const mockArtifacts = {
-        file: [
-          {
-            name: 'info.txt',
-            fullName: 'info.txt',
-            size: 10,
-          },
-        ],
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listBuildArtifacts.mockResolvedValue({ data: mockArtifacts } as never);
-      mockClient.downloadArtifactContent.mockRejectedValueOnce(new Error('download failed'));
-
-      const result = await manager.getBuildResults('12345', {
-        includeArtifacts: true,
-        downloadArtifacts: ['info.txt'],
-      });
-
-      expect(result.artifacts?.[0]?.content).toBeUndefined();
+      expect(stub.modules.builds.getFilesListOfBuild).toHaveBeenCalledWith('id:12345');
+      expect(artifacts).toHaveLength(2);
+      expect(artifacts?.[0]?.downloadUrl).toContain('/artifacts/content/target/app.jar');
     });
   });
 
-  describe('Statistics Extraction', () => {
-    it('maps TeamCity properties to friendly names', async () => {
-      const mockBuild = basicBuild();
-      const statsPayload = {
-        property: [
-          { name: 'BuildDuration', value: '95000' },
-          { name: 'TestCount', value: '150' },
-          { name: 'PassedTestCount', value: '148' },
-          { name: 'FailedTestCount', value: '2' },
-          { name: 'IgnoredTestCount', value: '0' },
-          { name: 'CodeCoverageL', value: '85.5' },
-          { name: 'CodeCoverageB', value: '92.3' },
-        ],
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.getBuildStatistics.mockResolvedValue({ data: statsPayload } as never);
-
-      const result = await manager.getBuildResults('12345', { includeStatistics: true });
-
-      expect(result.statistics?.buildDuration).toBe(95000);
-      expect(result.statistics?.testCount).toBe(150);
-      expect(result.statistics?.codeCoverage).toBe(92.3);
-    });
-
-    it('returns empty object when no stats available', async () => {
-      const mockBuild = basicBuild();
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.getBuildStatistics.mockResolvedValue({ data: { property: [] } } as never);
-
-      const result = await manager.getBuildResults('12345', { includeStatistics: true });
-      expect(result.statistics).toEqual({});
-    });
-  });
-
-  describe('Dependencies Tracking', () => {
-    it('normalizes snapshot dependencies', async () => {
-      const mockBuild = basicBuild();
-      const depsPayload = {
-        build: [
-          { id: 12340, number: '41', buildTypeId: 'CoreLib', status: 'SUCCESS' },
-          { id: 12342, number: '38', buildTypeId: 'AuthModule', status: 'SUCCESS' },
-        ],
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listSnapshotDependencies.mockResolvedValue({ data: depsPayload } as never);
-
-      const result = await manager.getBuildResults('12345', { includeDependencies: true });
-
-      expect(result.dependencies).toHaveLength(2);
-      expect(result.dependencies?.[0]?.buildId).toBe(12340);
-    });
-
-    it('returns empty array when dependencies missing', async () => {
-      const mockBuild = basicBuild();
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listSnapshotDependencies.mockResolvedValue({ data: { build: [] } } as never);
-
-      const result = await manager.getBuildResults('12345', { includeDependencies: true });
-      expect(result.dependencies).toEqual([]);
-    });
-  });
-
-  describe('Change Tracking', () => {
-    it('maps VCS changes payload', async () => {
-      const mockBuild = basicBuild();
-      const changePayload = {
-        change: [
-          {
-            version: 'abc123',
-            username: 'alice',
-            date: '20250829T120000+0000',
-            comment: 'Fix issue',
-            files: { file: [{ name: 'src/app.ts', changeType: 'MODIFIED' }] },
-          },
-        ],
-      };
-
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listChangesForBuild.mockResolvedValue({ data: changePayload } as never);
-
-      const result = await manager.getBuildResults('12345', { includeChanges: true });
-
-      expect(result.changes).toHaveLength(1);
-      expect(result.changes?.[0]?.files?.[0]?.path).toBe('src/app.ts');
-    });
-
-    it('handles empty change responses', async () => {
-      const mockBuild = basicBuild();
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listChangesForBuild.mockResolvedValue({ data: {} } as never);
-
-      const result = await manager.getBuildResults('12345', { includeChanges: true });
-      expect(result.changes).toEqual([]);
-    });
-  });
-
-  describe('Caching Behaviour', () => {
-    it('caches finished build results', async () => {
-      const mockBuild = basicBuild();
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-
-      await manager.getBuildResults('12345');
-      await manager.getBuildResults('12345');
-
-      expect(mockClient.builds.getBuild).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not cache running builds', async () => {
-      const runningBuild = {
+  describe('fetchStatistics', () => {
+    it('maps TeamCity statistic properties to friendly structure', async () => {
+      stub.modules.builds.getBuildStatisticValues.mockResolvedValue({
         data: {
-          ...basicBuild().data,
-          state: 'running',
+          property: [
+            { name: 'BuildDuration', value: '900000' },
+            { name: 'TestCount', value: '200' },
+            { name: 'PassedTestCount', value: '198' },
+            { name: 'FailedTestCount', value: '1' },
+            { name: 'CodeCoverageL', value: '85.5' },
+          ],
         },
-      };
-      mockClient.builds.getBuild.mockResolvedValue(runningBuild as never);
+      });
 
-      await manager.getBuildResults('12345');
-      await manager.getBuildResults('12345');
+      const statistics = (await managerInternals.fetchStatistics('12345')) as Record<string, unknown>;
 
-      expect(mockClient.builds.getBuild).toHaveBeenCalledTimes(2);
-    });
-
-    it('expires cache entries after TTL', async () => {
-      jest.useFakeTimers();
-      const mockBuild = basicBuild();
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-
-      await manager.getBuildResults('12345');
-      jest.advanceTimersByTime(9 * 60 * 1000);
-      await manager.getBuildResults('12345');
-
-      expect(mockClient.builds.getBuild).toHaveBeenCalledTimes(1);
-
-      jest.advanceTimersByTime(2 * 60 * 1000);
-      await manager.getBuildResults('12345');
-
-      expect(mockClient.builds.getBuild).toHaveBeenCalledTimes(2);
-      jest.useRealTimers();
+      expect(stub.modules.builds.getBuildStatisticValues).toHaveBeenCalledWith('id:12345');
+      expect(statistics).toMatchObject({
+        buildDuration: 900000,
+        testCount: 200,
+        passedTests: 198,
+        failedTests: 1,
+        codeCoverage: 85.5,
+      });
     });
   });
 
-  describe('Error Handling', () => {
-    it('surfaces not found errors directly', async () => {
-      mockClient.builds.getBuild.mockRejectedValue(new Error('Build not found'));
-      await expect(manager.getBuildResults('99999')).rejects.toThrow('Build not found');
-    });
+  describe('fetchChanges', () => {
+    it('normalizes change payloads via change API', async () => {
+      stub.modules.changes.getAllChanges.mockResolvedValue({
+        data: {
+          change: [
+            {
+              version: 'abc123',
+              username: 'dev',
+              date: '20250829T120000+0000',
+              comment: 'Fix bug',
+              files: {
+                file: [
+                  { name: 'src/app.ts', changeType: 'EDITED' },
+                  { name: 'README.md' },
+                ],
+              },
+            },
+          ],
+        },
+      });
 
-    it('wraps unknown errors with friendly message', async () => {
-      mockClient.builds.getBuild.mockRejectedValue(new Error('Network error'));
-      await expect(manager.getBuildResults('12345')).rejects.toThrow(
-        'Failed to fetch build results: Network error'
+      const changes = (await managerInternals.fetchChanges('12345')) as Array<{
+        revision: string;
+        files: Array<unknown>;
+      }>;
+
+      expect(stub.modules.changes.getAllChanges).toHaveBeenCalledWith('build:(id:12345)');
+      expect(changes?.[0]?.revision).toBe('abc123');
+      expect(changes?.[0]?.files).toHaveLength(2);
+    });
+  });
+
+  describe('fetchDependencies', () => {
+    it('uses shared axios request helper for snapshot dependencies', async () => {
+      stub.http.get.mockResolvedValueOnce({
+        data: {
+          build: [
+            { id: 1, number: '100', buildTypeId: 'Cfg_A', status: 'SUCCESS' },
+            { id: 2, number: '101', buildTypeId: 'Cfg_B', status: 'FAILURE' },
+          ],
+        },
+      });
+
+      const dependencies = (await managerInternals.fetchDependencies('12345')) as Array<{
+        buildId: number;
+        buildNumber: string;
+        buildTypeId: string;
+        status: string;
+      }>;
+
+      expect(stub.request).toHaveBeenCalledWith(expect.any(Function));
+      expect(stub.http.get).toHaveBeenCalledWith(
+        `${BASE_URL}/app/rest/builds/id:12345/snapshot-dependencies`
       );
-    });
-
-    it('keeps core data when artifacts request fails', async () => {
-      const mockBuild = basicBuild();
-      mockClient.builds.getBuild.mockResolvedValue(mockBuild as never);
-      mockClient.listBuildArtifacts.mockRejectedValue(new Error('Artifact API error'));
-
-      const result = await manager.getBuildResults('12345', { includeArtifacts: true });
-
-      expect(result.build.id).toBe(12345);
-      expect(result.artifacts).toEqual([]);
+      expect(dependencies).toEqual([
+        { buildId: 1, buildNumber: '100', buildTypeId: 'Cfg_A', status: 'SUCCESS' },
+        { buildId: 2, buildNumber: '101', buildTypeId: 'Cfg_B', status: 'FAILURE' },
+      ]);
     });
   });
 });

--- a/tests/unit/teamcity/build-results-manager.test.ts
+++ b/tests/unit/teamcity/build-results-manager.test.ts
@@ -37,8 +37,9 @@ const createStubClient = (): StubbedClient => {
     get: jest.fn(),
   } as { get: jest.Mock };
 
-  const request = jest.fn(async (fn: (ctx: { axios: typeof http; baseUrl: string }) => Promise<unknown>) =>
-    fn({ axios: http, baseUrl: BASE_URL })
+  const request = jest.fn(
+    async (fn: (ctx: { axios: typeof http; baseUrl: string }) => Promise<unknown>) =>
+      fn({ axios: http, baseUrl: BASE_URL })
   ) as jest.Mock;
 
   const client = {
@@ -142,7 +143,10 @@ describe('BuildResultsManager', () => {
         },
       });
 
-      const statistics = (await managerInternals.fetchStatistics('12345')) as Record<string, unknown>;
+      const statistics = (await managerInternals.fetchStatistics('12345')) as Record<
+        string,
+        unknown
+      >;
 
       expect(stub.modules.builds.getBuildStatisticValues).toHaveBeenCalledWith('id:12345');
       expect(statistics).toMatchObject({
@@ -166,10 +170,7 @@ describe('BuildResultsManager', () => {
               date: '20250829T120000+0000',
               comment: 'Fix bug',
               files: {
-                file: [
-                  { name: 'src/app.ts', changeType: 'EDITED' },
-                  { name: 'README.md' },
-                ],
+                file: [{ name: 'src/app.ts', changeType: 'EDITED' }, { name: 'README.md' }],
               },
             },
           ],


### PR DESCRIPTION
## Summary
- refactor build list and results managers to depend on the TeamCityUnifiedClient modules/request helpers instead of bespoke axios usage
- update url resolution/download helpers to leverage the client base URL and shared request context
- refresh the unit suites with local unified-client stubs that cover the new call paths

## Testing
- npm run lint
- npm run typecheck
- npm run test:unit
- npm run test:integration

Refs #116
