### PR TITLE
fix(teamcity): retain adapter api credentials

### DIFF
--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -74,10 +74,11 @@ export function createAdapterFromTeamCityAPI(
   const modules = resolveModules(api);
   const baseUrl = api.getBaseUrl();
   const httpInstance: AxiosInstance = api.http ?? axios.create({ baseURL: baseUrl });
+  const fallbackApiConfig = resolveApiClientConfigFromApi(api, httpInstance);
   const resolvedApiConfig: TeamCityAPIClientConfig = {
-    baseUrl: options.apiConfig?.baseUrl ?? baseUrl,
-    token: options.apiConfig?.token ?? '',
-    timeout: options.apiConfig?.timeout ?? undefined,
+    baseUrl: options.apiConfig?.baseUrl ?? fallbackApiConfig.baseUrl,
+    token: options.apiConfig?.token ?? fallbackApiConfig.token,
+    timeout: options.apiConfig?.timeout ?? fallbackApiConfig.timeout,
   };
 
   const resolvedFullConfig: TeamCityFullConfig = options.fullConfig ?? {
@@ -125,3 +126,125 @@ export function createAdapterFromTeamCityAPI(
     baseUrl,
   };
 }
+
+interface AxiosHeadersRecord {
+  common?: AxiosHeadersRecord;
+  get?: (name: string) => unknown;
+  [key: string]: unknown;
+}
+
+const isAxiosHeadersRecord = (value: unknown): value is AxiosHeadersRecord =>
+  typeof value === 'object' && value !== null;
+
+/**
+ * Derive API client configuration directly from the TeamCityAPI singleton
+ * so adapters created without an explicit configuration retain credentials.
+ */
+const resolveApiClientConfigFromApi = (
+  api: TeamCityAPI,
+  http: AxiosInstance
+): TeamCityAPIClientConfig => {
+  const timeout = resolveTimeout(http);
+  const authHeader = getAuthorizationHeader(http);
+  const token = stripBearerPrefix(authHeader);
+
+  return {
+    baseUrl: api.getBaseUrl(),
+    token: token ?? '',
+    timeout,
+  };
+};
+
+const getAuthorizationHeader = (http: AxiosInstance): string | undefined => {
+  const headers = http.defaults.headers;
+
+  if (!isAxiosHeadersRecord(headers)) {
+    return undefined;
+  }
+
+  const direct = pickAuthorization(headers);
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  const commonRecord = isAxiosHeadersRecord(headers.common) ? headers.common : undefined;
+  if (commonRecord) {
+    const common = pickAuthorization(commonRecord);
+    if (common !== undefined) {
+      return common;
+    }
+  }
+
+  const getter =
+    resolveHeaderGetter(headers) ?? (commonRecord ? resolveHeaderGetter(commonRecord) : undefined);
+  if (getter) {
+    return readAuthorizationViaGetter(getter, headers);
+  }
+
+  return undefined;
+};
+
+const resolveTimeout = (http: AxiosInstance): number | undefined => {
+  const raw = http.defaults.timeout;
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) {
+    return raw;
+  }
+  return undefined;
+};
+
+const pickAuthorization = (record: AxiosHeadersRecord): string | undefined => {
+  for (const key of Object.keys(record)) {
+    if (key.toLowerCase() !== 'authorization') {
+      continue;
+    }
+
+    const value = record[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      const [first] = value;
+      if (typeof first === 'string') {
+        return first;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const resolveHeaderGetter = (
+  record: AxiosHeadersRecord
+): ((name: string) => unknown) | undefined => {
+  const candidate = record.get;
+  return typeof candidate === 'function' ? candidate : undefined;
+};
+
+const readAuthorizationViaGetter = (
+  getter: (name: string) => unknown,
+  context: unknown
+): string | undefined => {
+  try {
+    const value = getter.call(context, 'Authorization');
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      const [first] = value;
+      return typeof first === 'string' ? first : undefined;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+};
+
+const stripBearerPrefix = (header: string | undefined): string | undefined => {
+  if (typeof header !== 'string') {
+    return undefined;
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match?.[1] ?? header;
+};

--- a/tests/unit/teamcity/client-adapter.test.ts
+++ b/tests/unit/teamcity/client-adapter.test.ts
@@ -37,7 +37,14 @@ describe('createAdapterFromTeamCityAPI', () => {
   const listAgentPools = jest.fn();
 
   beforeEach(() => {
-    http = axios.create();
+    const token = 'token-123';
+    const timeout = 4200;
+
+    http = axios.create({
+      baseURL: baseUrl,
+      timeout,
+      headers: { Authorization: `Bearer ${token}` },
+    });
     const buildsMock: BuildApiLike = {
       getAllBuilds: jest.fn(),
       getBuild: jest.fn(),
@@ -80,8 +87,8 @@ describe('createAdapterFromTeamCityAPI', () => {
 
     apiConfig = {
       baseUrl,
-      token: 'token-123',
-      timeout: 4200,
+      token,
+      timeout,
     };
 
     fullConfig = {
@@ -229,7 +236,17 @@ describe('createAdapterFromTeamCityAPI', () => {
   it('falls back to minimal config when options omitted', () => {
     const adapter = createAdapterFromTeamCityAPI(apiMock);
 
-    expect(adapter.getConfig().connection.baseUrl).toBe(baseUrl);
-    expect(adapter.getApiConfig().baseUrl).toBe(baseUrl);
+    expect(adapter.getApiConfig()).toEqual({
+      baseUrl,
+      token: apiConfig.token,
+      timeout: apiConfig.timeout,
+    });
+    expect(adapter.getConfig()).toEqual({
+      connection: {
+        baseUrl,
+        token: apiConfig.token,
+        timeout: apiConfig.timeout,
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- keep the adapter's API config in sync with the TeamCityAPI singleton when no config bundle is provided
- update the existing unit suite to assert the adapter preserves token and timeout values

## Testing
- npm run test:unit -- --runTestsByPath tests/unit/teamcity/client-adapter.test.ts

Closes #135
