### PR TITLE
refactor(api-client): route build helpers through generated apis

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -455,8 +455,9 @@ export class TeamCityAPI {
       'snapshot-dependencies'
     );
 
-    const dependencies =
-      (response.data as { 'snapshot-dependencies'?: unknown })['snapshot-dependencies'];
+    const dependencies = (response.data as { 'snapshot-dependencies'?: unknown })[
+      'snapshot-dependencies'
+    ];
 
     if (dependencies == null) {
       return response;

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -446,16 +446,26 @@ export class TeamCityAPI {
   }
 
   async listChangesForBuild(buildId: string, fields?: string): Promise<AxiosResponse<unknown>> {
-    return this.axiosInstance.get('/app/rest/changes', {
-      params: {
-        locator: `build:(id:${buildId})`,
-        fields,
-      },
-    });
+    return this.changes.getAllChanges(`build:(id:${buildId})`, fields);
   }
 
   async listSnapshotDependencies(buildId: string): Promise<AxiosResponse<unknown>> {
-    return this.axiosInstance.get(`/app/rest/builds/id:${buildId}/snapshot-dependencies`);
+    const response = await this.builds.getBuild(
+      this.toBuildLocator(buildId),
+      'snapshot-dependencies'
+    );
+
+    const dependencies =
+      (response.data as { 'snapshot-dependencies'?: unknown })['snapshot-dependencies'];
+
+    if (dependencies == null) {
+      return response;
+    }
+
+    return {
+      ...response,
+      data: dependencies,
+    };
   }
 
   getBaseUrl(): string {

--- a/tests/unit/teamcity/api-client.test.ts
+++ b/tests/unit/teamcity/api-client.test.ts
@@ -1,7 +1,8 @@
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
 import { TeamCityAPI, TeamCityAPIClientConfig } from '@/api-client';
 import type { Build } from '@/teamcity-client/models/build';
 import type { Changes } from '@/teamcity-client/models/changes';
-import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 const baseConfig: TeamCityAPIClientConfig = {
   baseUrl: 'https://teamcity.example.com',

--- a/tests/unit/teamcity/api-client.test.ts
+++ b/tests/unit/teamcity/api-client.test.ts
@@ -1,10 +1,21 @@
 import { TeamCityAPI, TeamCityAPIClientConfig } from '@/api-client';
+import type { Build } from '@/teamcity-client/models/build';
+import type { Changes } from '@/teamcity-client/models/changes';
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 const baseConfig: TeamCityAPIClientConfig = {
   baseUrl: 'https://teamcity.example.com',
   token: 'test-token',
   timeout: 4321,
 };
+
+const createAxiosResponse = <T>(data: T): AxiosResponse<T> => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: { headers: {} } as InternalAxiosRequestConfig,
+});
 
 describe('TeamCityAPI unified surface', () => {
   beforeEach(() => {
@@ -50,5 +61,31 @@ describe('TeamCityAPI unified surface', () => {
     const second = TeamCityAPI.getInstance({ ...baseConfig, token: 'alternate-token' });
 
     expect(second).not.toBe(first);
+  });
+
+  it('routes listChangesForBuild through the generated ChangeApi', async () => {
+    const api = TeamCityAPI.getInstance(baseConfig);
+    const mockResponse = createAxiosResponse<Changes>({ change: [] });
+    const getAllChangesSpy = jest
+      .spyOn(api.changes, 'getAllChanges')
+      .mockResolvedValue(mockResponse);
+
+    const response = await api.listChangesForBuild('123', 'change($short)');
+
+    expect(getAllChangesSpy).toHaveBeenCalledWith('build:(id:123)', 'change($short)');
+    expect(response).toBe(mockResponse);
+  });
+
+  it('routes listSnapshotDependencies through the generated BuildApi and unwraps payload', async () => {
+    const api = TeamCityAPI.getInstance(baseConfig);
+    const dependencies = { build: [] };
+    const buildPayload = { 'snapshot-dependencies': dependencies } as Build;
+    const mockResponse = createAxiosResponse<Build>(buildPayload);
+    const getBuildSpy = jest.spyOn(api.builds, 'getBuild').mockResolvedValue(mockResponse);
+
+    const response = await api.listSnapshotDependencies('123');
+
+    expect(getBuildSpy).toHaveBeenCalledWith('id:123', 'snapshot-dependencies');
+    expect(response.data).toBe(dependencies);
   });
 });


### PR DESCRIPTION
## Summary
- route the build change helper through the generated ChangeApi client
- reuse the BuildApi to fetch snapshot dependencies and return the dependency payload
- add unit coverage ensuring both helpers delegate to the generated modules

## Testing
- npm run test:unit -- --runTestsByPath tests/unit/teamcity/api-client.test.ts

Closes #136
