### PR TITLE
refactor(teamcity): inject unified client into project navigator

### DIFF
--- a/tests/unit/teamcity/project-navigator-branches.test.ts
+++ b/tests/unit/teamcity/project-navigator-branches.test.ts
@@ -1,6 +1,20 @@
 // Additional branch coverage for ProjectNavigator
-jest.mock('@/api-client', () => {
-  const getAllProjects = jest.fn(async () => ({
+import { ProjectNavigator } from '@/teamcity/project-navigator';
+
+import {
+  type MockTeamCityClient,
+  createMockTeamCityClient,
+} from '../../test-utils/mock-teamcity-client';
+
+type NavigatorSetup = {
+  nav: ProjectNavigator;
+  client: MockTeamCityClient;
+};
+
+const setupNavigator = (): NavigatorSetup => {
+  const client = createMockTeamCityClient();
+
+  client.projects.getAllProjects.mockImplementation(async () => ({
     data: {
       count: 3,
       project: [
@@ -11,47 +25,56 @@ jest.mock('@/api-client', () => {
     },
   }));
 
-  const getProject = jest.fn(async (id: string) => {
-    // Provide different shapes to drive various branches
+  client.projects.getProject.mockImplementation(async (id: string) => {
     if (id === 'Root') {
       return {
-        data: { id: 'Root', name: 'Root', projects: { project: [{ id: 'A' }, { id: 'B' }] } },
+        data: {
+          id: 'Root',
+          name: 'Root',
+          projects: { project: [{ id: 'A' }, { id: 'B' }] },
+        },
       };
     }
     if (id === 'A') {
-      // Points back to Root to simulate a cycle for descendants
-      return { data: { id: 'A', name: 'A', projects: { project: [{ id: 'Root' }] } } };
+      return {
+        data: {
+          id: 'A',
+          name: 'A',
+          projects: { project: [{ id: 'Root' }] },
+        },
+      };
     }
     if (id === 'B') {
-      // Leaf
       return { data: { id: 'B', name: 'B' } };
     }
     if (id === 'C') {
-      // Self-referential to trigger circular reference in hierarchy
-      return { data: { id: 'C', name: 'C', projects: { project: [{ id: 'C' }] } } };
+      return {
+        data: {
+          id: 'C',
+          name: 'C',
+          projects: { project: [{ id: 'C' }] },
+        },
+      };
     }
-    // Default project for ancestors chain
-    if (id === 'Child') return { data: { id: 'Child', name: 'Child', parentProjectId: 'Parent' } };
-    if (id === 'Parent')
-      return { data: { id: 'Parent', name: 'Parent', parentProjectId: '_Root' } };
-    // Fallback
+    if (id === 'Child') {
+      return {
+        data: { id: 'Child', name: 'Child', parentProjectId: 'Parent' },
+      };
+    }
+    if (id === 'Parent') {
+      return {
+        data: { id: 'Parent', name: 'Parent', parentProjectId: '_Root' },
+      };
+    }
     return { data: { id, name: id } };
   });
 
-  return {
-    TeamCityAPI: {
-      getInstance: () => ({
-        projects: { getAllProjects, getProject },
-      }),
-    },
-  };
-});
+  return { nav: new ProjectNavigator(client), client };
+};
 
 describe('ProjectNavigator extra branches', () => {
   it('validateParams: invalid page and pageSize', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { ProjectNavigator } = require('@/teamcity/project-navigator');
-    const nav = new ProjectNavigator();
+    const { nav } = setupNavigator();
     let res = await nav.listProjects({ pagination: { page: -1, pageSize: 10 } });
     expect(res.success).toBe(false);
     res = await nav.listProjects({ pagination: { page: 1, pageSize: -1 } });
@@ -61,9 +84,7 @@ describe('ProjectNavigator extra branches', () => {
   });
 
   it('validateParams: ancestors/descendants without projectId', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { ProjectNavigator } = require('@/teamcity/project-navigator');
-    const nav = new ProjectNavigator();
+    const { nav } = setupNavigator();
     let res = await nav.listProjects({ mode: 'ancestors' });
     expect(res.success).toBe(false);
     expect(res.error).toContain('projectId is required');
@@ -72,9 +93,7 @@ describe('ProjectNavigator extra branches', () => {
   });
 
   it('formatError: returns friendly messages for statuses and fallback', () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { ProjectNavigator } = require('@/teamcity/project-navigator');
-    const nav = new ProjectNavigator();
+    const { nav } = setupNavigator();
     const fn = (nav as unknown as { formatError: (e: unknown) => string }).formatError.bind(nav);
     expect(fn({ response: { status: 401 } })).toContain('Authentication failed');
     expect(fn({ response: { status: 403 } })).toContain('Permission denied');
@@ -83,10 +102,8 @@ describe('ProjectNavigator extra branches', () => {
     expect(fn('weird')).toBe('An unexpected error occurred');
   });
 
-  it('sortProjects default branch: unknown sort key leaves order stable', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { ProjectNavigator } = require('@/teamcity/project-navigator');
-    const nav = new ProjectNavigator();
+  it('sortProjects default branch: unknown sort key leaves order stable', () => {
+    const { nav } = setupNavigator();
     const sort = (
       nav as unknown as {
         sortProjects: <T extends { name?: string; id?: string; level?: number }>(
@@ -102,66 +119,50 @@ describe('ProjectNavigator extra branches', () => {
   });
 
   it('getList sorting by id and level', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { ProjectNavigator } = require('@/teamcity/project-navigator');
-    const nav = new ProjectNavigator();
-    // sort by id asc
+    const { nav } = setupNavigator();
     let res = await nav.listProjects({ mode: 'list', sort: { by: 'id', order: 'asc' } });
     const idsAsc = (res.data?.projects ?? []).map((p: { id: string }) => p.id);
     expect(idsAsc).toEqual(['A', 'B', 'C']);
-    // sort by id desc
     res = await nav.listProjects({ mode: 'list', sort: { by: 'id', order: 'desc' } });
     const idsDesc = (res.data?.projects ?? []).map((p: { id: string }) => p.id);
     expect(idsDesc).toEqual(['C', 'B', 'A']);
-    // sort by level (all zero, ensure no crash and same length)
     res = await nav.listProjects({ mode: 'list', sort: { by: 'level', order: 'asc' } });
     expect((res.data?.projects ?? []).length).toBe(3);
   });
 
   it('getAncestors returns normal chain including root', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { ProjectNavigator } = require('@/teamcity/project-navigator');
-    const nav = new ProjectNavigator();
+    const { nav } = setupNavigator();
     const res = await nav.listProjects({ mode: 'ancestors', projectId: 'Child' });
     expect(res.success).toBe(true);
     const ancestors = res.data?.ancestors ?? [];
-    // Expect root and parent and child somewhere in the chain; order is root first
     expect(ancestors[0]?.id).toBe('_Root');
     expect(ancestors.map((a: { id: string }) => a.id)).toContain('Parent');
   });
 
   it('getHierarchy with leaf maxDepth not reached', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { ProjectNavigator } = require('@/teamcity/project-navigator');
-    const nav = new ProjectNavigator();
+    const { nav } = setupNavigator();
     const res = await nav.listProjects({ mode: 'hierarchy', rootProjectId: 'B', maxDepth: 3 });
     expect(res.success).toBe(true);
     expect(res.data?.maxDepthReached).toBe(false);
   });
 
   it('getDescendants handles cycles and maxDepth detection', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { ProjectNavigator } = require('@/teamcity/project-navigator');
-    const nav = new ProjectNavigator();
+    const { nav } = setupNavigator();
     const res = await nav.listProjects({ mode: 'descendants', projectId: 'Root', maxDepth: 1 });
     expect(res.success).toBe(true);
     const data = res.data as NonNullable<typeof res.data>;
-    // Should include A and B at level 1 (order not guaranteed)
     const ids = (data.descendants ?? []).map((d: { id: string }) => d.id);
     expect(new Set(ids)).toEqual(new Set(['A', 'B']));
     expect(data.maxDepthReached).toBe(true);
   });
 
   it('getHierarchy handles self-referential circular child gracefully', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { ProjectNavigator } = require('@/teamcity/project-navigator');
-    const nav = new ProjectNavigator();
+    const { nav } = setupNavigator();
     const res = await nav.listProjects({ mode: 'hierarchy', rootProjectId: 'C', maxDepth: 2 });
     expect(res.success).toBe(true);
     const hierarchy = (res.data as NonNullable<typeof res.data>).hierarchy as NonNullable<
       NonNullable<typeof res.data>['hierarchy']
     >;
-    // Self-referential child should not create infinite recursion; children array remains empty after transform
     expect(Array.isArray(hierarchy.children)).toBe(true);
     expect(hierarchy.children?.length).toBe(0);
   });

--- a/tests/unit/teamcity/project-navigator-more.test.ts
+++ b/tests/unit/teamcity/project-navigator-more.test.ts
@@ -1,19 +1,19 @@
 /** Additional tests for ProjectNavigator to raise branch coverage */
-import { TeamCityAPI } from '@/api-client';
 import type { Projects } from '@/teamcity-client/models/projects';
 import { ProjectNavigator } from '@/teamcity/project-navigator';
 
-jest.mock('@/api-client');
+import {
+  type MockTeamCityClient,
+  createMockTeamCityClient,
+} from '../../test-utils/mock-teamcity-client';
 
 describe('ProjectNavigator (more cases)', () => {
   let navigator: ProjectNavigator;
-  type MockClient = { projects: { getAllProjects: jest.Mock; getProject: jest.Mock } };
-  let mockClient: MockClient;
+  let mockClient: MockTeamCityClient;
 
   beforeEach(() => {
-    mockClient = { projects: { getAllProjects: jest.fn(), getProject: jest.fn() } };
-    (TeamCityAPI.getInstance as jest.Mock).mockReturnValue(mockClient);
-    navigator = new ProjectNavigator();
+    mockClient = createMockTeamCityClient();
+    navigator = new ProjectNavigator(mockClient);
   });
 
   it('list mode: hasMore is false when fewer items than pageSize', async () => {

--- a/tests/unit/teamcity/project-navigator.test.ts
+++ b/tests/unit/teamcity/project-navigator.test.ts
@@ -1,35 +1,24 @@
 /**
  * Tests for ProjectNavigator
  */
-import { TeamCityAPI } from '@/api-client';
 import type { Projects } from '@/teamcity-client/models/projects';
 import { ProjectNavigator } from '@/teamcity/project-navigator';
 
-// Mock the TeamCityAPI module
-jest.mock('@/api-client');
+import {
+  type MockTeamCityClient,
+  createMockTeamCityClient,
+} from '../../test-utils/mock-teamcity-client';
 
 describe('ProjectNavigator', () => {
   let navigator: ProjectNavigator;
-  type MockClient = {
-    projects: { getAllProjects: jest.Mock; getProject: jest.Mock };
-  };
-  let mockClient: MockClient;
+  let mockClient: MockTeamCityClient;
 
   beforeEach(() => {
     jest.useFakeTimers();
 
-    // Create mock TeamCity client
-    mockClient = {
-      projects: {
-        getAllProjects: jest.fn(),
-        getProject: jest.fn(),
-      },
-    };
+    mockClient = createMockTeamCityClient();
 
-    // Mock TeamCityAPI.getInstance() to return our mock client
-    (TeamCityAPI.getInstance as jest.Mock).mockReturnValue(mockClient);
-
-    navigator = new ProjectNavigator();
+    navigator = new ProjectNavigator(mockClient);
 
     // Clear cache before each test without using any
     type PrivateNav = { cache: Map<string, unknown> };


### PR DESCRIPTION
## Summary\n- accept a TeamCityClientAdapter in ProjectNavigator and replace direct singleton usage\n- update navigator-focused tests to rely on the unified mock client helpers\n\n## Testing\n- npm test -- project-navigator\n\nCloses #143