### PR TITLE
test(teamcity): align manager suites with unified client modules

### DIFF
--- a/src/teamcity/build-list-manager.ts
+++ b/src/teamcity/build-list-manager.ts
@@ -225,18 +225,13 @@ export class BuildListManager {
         .filter((part) => !part.startsWith('count:') && !part.startsWith('start:'))
         .join(',');
 
-      const response = await this.client.request((ctx) =>
-        ctx.axios.get<string>(`${ctx.baseUrl}/app/rest/builds/count`, {
-          params: countLocator ? { locator: countLocator } : undefined,
-          headers: {
-            Accept: 'text/plain',
-          },
-          responseType: 'text',
-          transformResponse: [(data) => data],
-        })
+      const response = await this.client.modules.builds.getAllBuilds(
+        countLocator || undefined,
+        'count'
       );
 
-      return parseInt(String(response.data), 10);
+      const total = response.data?.count;
+      return typeof total === 'number' ? total : Number.parseInt(String(total ?? 0), 10);
     } catch (error: unknown) {
       // Total count is optional, don't fail the main request
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/teamcity/build-step-manager.ts
+++ b/src/teamcity/build-step-manager.ts
@@ -8,6 +8,8 @@
  * - Delete build steps
  * - Reorder build steps
  */
+import type { Step } from '@/teamcity-client/models/step';
+import type { Steps } from '@/teamcity-client/models/steps';
 import {
   BuildConfigurationNotFoundError,
   BuildStepNotFoundError,
@@ -16,8 +18,6 @@ import {
   ValidationError,
 } from '@/teamcity/errors';
 
-import type { Step } from '@/teamcity-client/models/step';
-import type { Steps } from '@/teamcity-client/models/steps';
 import type { TeamCityClientAdapter } from './client-adapter';
 
 /**

--- a/src/teamcity/build-step-manager.ts
+++ b/src/teamcity/build-step-manager.ts
@@ -16,6 +16,8 @@ import {
   ValidationError,
 } from '@/teamcity/errors';
 
+import type { Step } from '@/teamcity-client/models/step';
+import type { Steps } from '@/teamcity-client/models/steps';
 import type { TeamCityClientAdapter } from './client-adapter';
 
 /**
@@ -133,39 +135,14 @@ const RUNNER_REQUIRED_PARAMS: Record<string, string[]> = {
 export class BuildStepManager {
   constructor(private readonly client: TeamCityClientAdapter) {}
 
-  private request<T>(
-    fn: (ctx: {
-      axios: ReturnType<TeamCityClientAdapter['getAxios']>;
-      baseUrl: string;
-    }) => Promise<T>
-  ): Promise<T> {
-    return this.client.request(fn);
-  }
-
-  private buildRestUrl(baseUrl: string, path: string): string {
-    const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-    if (path.startsWith('/')) {
-      return `${normalizedBase}${path}`;
-    }
-    return `${normalizedBase}/${path}`;
-  }
-
   /**
    * List all build steps in a configuration
    */
   async listBuildSteps(options: BuildStepManagerOptions): Promise<BuildStepListResult> {
     try {
-      const response = await this.request((ctx) =>
-        ctx.axios.get(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${options.configId}/steps`),
-          {
-            headers: { Accept: 'application/json' },
-            params: {
-              fields:
-                'count,step(id,name,type,disabled,properties(property(name,value)),parameters(property(name,value)))',
-            },
-          }
-        )
+      const response = await this.client.modules.buildTypes.getAllBuildSteps(
+        options.configId,
+        'count,step(id,name,type,disabled,properties(property(name,value)),parameters(property(name,value)))'
       );
 
       if (response.data == null) {
@@ -203,17 +180,10 @@ export class BuildStepManager {
     try {
       const stepData = this.buildStepData(options);
 
-      const response = await this.request((ctx) =>
-        ctx.axios.post(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${options.configId}/steps`),
-          stepData,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
-          }
-        )
+      const response = await this.client.modules.buildTypes.addBuildStepToBuildType(
+        options.configId,
+        undefined,
+        stepData as Step
       );
 
       const step = this.parseStep(response.data);
@@ -261,20 +231,11 @@ export class BuildStepManager {
         };
       }
 
-      const response = await this.request((ctx) =>
-        ctx.axios.put(
-          this.buildRestUrl(
-            ctx.baseUrl,
-            `/app/rest/buildTypes/${options.configId}/steps/${options.stepId}`
-          ),
-          updateData,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
-          }
-        )
+      const response = await this.client.modules.buildTypes.replaceBuildStep(
+        options.configId,
+        options.stepId,
+        undefined,
+        updateData as Step
       );
 
       const step = this.parseStep(response.data);
@@ -294,17 +255,7 @@ export class BuildStepManager {
    */
   async deleteBuildStep(options: BuildStepDeleteOptions): Promise<BuildStepOperationResult> {
     try {
-      await this.request((ctx) =>
-        ctx.axios.delete(
-          this.buildRestUrl(
-            ctx.baseUrl,
-            `/app/rest/buildTypes/${options.configId}/steps/${options.stepId}`
-          ),
-          {
-            headers: { Accept: 'application/json' },
-          }
-        )
-      );
+      await this.client.modules.buildTypes.deleteBuildStep(options.configId, options.stepId);
 
       return {
         success: true,
@@ -336,21 +287,15 @@ export class BuildStepManager {
       }
 
       // Build reorder request
-      const reorderData = {
+      const reorderData: Steps = {
         step: options.stepOrder.map((id) => ({ id })),
+        count: options.stepOrder.length,
       };
 
-      const response = await this.request((ctx) =>
-        ctx.axios.put(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${options.configId}/steps`),
-          reorderData,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
-          }
-        )
+      const response = await this.client.modules.buildTypes.replaceAllBuildSteps(
+        options.configId,
+        undefined,
+        reorderData
       );
 
       const steps = this.parseStepList(response.data);

--- a/src/teamcity/build-trigger-manager.ts
+++ b/src/teamcity/build-trigger-manager.ts
@@ -158,23 +158,6 @@ export interface ValidateTriggerResult {
 export class BuildTriggerManager {
   constructor(private readonly client: TeamCityClientAdapter) {}
 
-  private request<T>(
-    fn: (ctx: {
-      axios: ReturnType<TeamCityClientAdapter['getAxios']>;
-      baseUrl: string;
-    }) => Promise<T>
-  ): Promise<T> {
-    return this.client.request(fn);
-  }
-
-  private buildRestUrl(baseUrl: string, path: string): string {
-    const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-    if (path.startsWith('/')) {
-      return `${normalizedBase}${path}`;
-    }
-    return `${normalizedBase}/${path}`;
-  }
-
   /**
    * List all triggers for a build configuration
    */
@@ -184,17 +167,11 @@ export class BuildTriggerManager {
     try {
       debug('Listing triggers for build configuration', { configId });
 
-      const response = await this.request((ctx) =>
-        ctx.axios.get<TeamCityTriggersResponse>(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${configId}/triggers`),
-          {
-            headers: { Accept: 'application/json' },
-            params: fields ? { fields } : undefined,
-          }
-        )
-      );
+      const response = await this.client.modules.buildTypes.getAllTriggers(configId, fields);
 
-      const triggers = this.parseTriggerList(response.data);
+      const triggers = this.parseTriggerList(
+        response.data as unknown as TeamCityTriggersResponse
+      );
 
       return {
         success: true,
@@ -251,20 +228,13 @@ export class BuildTriggerManager {
 
       const triggerData = this.buildTriggerPayload(type, properties, !enabled);
 
-      const response = await this.request((ctx) =>
-        ctx.axios.post(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${configId}/triggers`),
-          triggerData,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
-          }
-        )
+      const response = await this.client.modules.buildTypes.addTriggerToBuildType(
+        configId,
+        undefined,
+        triggerData
       );
 
-      const trigger = this.parseTrigger(response.data);
+      const trigger = this.parseTrigger(response.data as unknown as TeamCityTriggerResponse);
 
       return {
         success: true,
@@ -295,16 +265,11 @@ export class BuildTriggerManager {
       debug('Updating trigger', { configId, triggerId });
 
       // Get existing trigger first
-      const existingResponse = await this.request((ctx) =>
-        ctx.axios.get(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${configId}/triggers/${triggerId}`),
-          {
-            headers: { Accept: 'application/json' },
-          }
-        )
-      );
+      const existingResponse = await this.client.modules.buildTypes.getTrigger(configId, triggerId);
 
-      const existingTrigger = this.parseTrigger(existingResponse.data);
+      const existingTrigger = this.parseTrigger(
+        existingResponse.data as unknown as TeamCityTriggerResponse
+      );
 
       // Merge properties
       const mergedProperties = properties
@@ -328,20 +293,14 @@ export class BuildTriggerManager {
         enabled !== undefined ? !enabled : !existingTrigger.enabled
       );
 
-      const response = await this.request((ctx) =>
-        ctx.axios.put(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${configId}/triggers/${triggerId}`),
-          triggerData,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
-          }
-        )
+      const response = await this.client.modules.buildTypes.replaceTrigger(
+        configId,
+        triggerId,
+        undefined,
+        triggerData
       );
 
-      const trigger = this.parseTrigger(response.data);
+      const trigger = this.parseTrigger(response.data as unknown as TeamCityTriggerResponse);
 
       return {
         success: true,
@@ -365,14 +324,7 @@ export class BuildTriggerManager {
     try {
       debug('Deleting trigger', { configId, triggerId });
 
-      await this.request((ctx) =>
-        ctx.axios.delete(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${configId}/triggers/${triggerId}`),
-          {
-            headers: { Accept: 'application/json' },
-          }
-        )
-      );
+      await this.client.modules.buildTypes.deleteTrigger(configId, triggerId);
 
       return {
         success: true,
@@ -464,7 +416,7 @@ export class BuildTriggerManager {
     const properties = propertiesToRecord(propsArray);
 
     const trigger: BuildTrigger = {
-      id: data.id,
+      id: data.id ?? '',
       type: data.type as TriggerType,
       enabled: data.disabled !== true,
       properties,
@@ -565,16 +517,12 @@ export class BuildTriggerManager {
   private async validateVcsRoot(configId: string, vcsRootId: string): Promise<void> {
     try {
       // Check if VCS root is attached to this build configuration
-      const response = await this.request((ctx) =>
-        ctx.axios.get<TeamCityVcsRootEntriesResponse>(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${configId}/vcs-root-entries`),
-          {
-            headers: { Accept: 'application/json' },
-          }
-        )
+      const response = await this.client.modules.buildTypes.getAllVcsRootsOfBuildType(
+        configId,
+        'vcs-root(id)'
       );
 
-      const rootEntries = normalizeVcsRootEntries(response.data);
+      const rootEntries = normalizeVcsRootEntries(response.data as TeamCityVcsRootEntriesResponse);
       const hasVcsRoot = rootEntries.some((entry) => entry['vcs-root']?.id === vcsRootId);
 
       if (!hasVcsRoot) {
@@ -598,16 +546,11 @@ export class BuildTriggerManager {
   private async checkCircularDependency(sourceConfig: string, targetConfig: string): Promise<void> {
     // Get triggers from target config
     try {
-      const response = await this.request((ctx) =>
-        ctx.axios.get(
-          this.buildRestUrl(ctx.baseUrl, `/app/rest/buildTypes/${targetConfig}/triggers`),
-          {
-            headers: { Accept: 'application/json' },
-          }
-        )
-      );
+      const response = await this.client.modules.buildTypes.getAllTriggers(targetConfig);
 
-      const triggers = this.parseTriggerList(response.data);
+      const triggers = this.parseTriggerList(
+        response.data as unknown as TeamCityTriggersResponse
+      );
 
       // Check if target already depends on source
       const hasCycle = triggers.some(

--- a/src/teamcity/build-trigger-manager.ts
+++ b/src/teamcity/build-trigger-manager.ts
@@ -169,9 +169,7 @@ export class BuildTriggerManager {
 
       const response = await this.client.modules.buildTypes.getAllTriggers(configId, fields);
 
-      const triggers = this.parseTriggerList(
-        response.data as unknown as TeamCityTriggersResponse
-      );
+      const triggers = this.parseTriggerList(response.data as unknown as TeamCityTriggersResponse);
 
       return {
         success: true,
@@ -548,9 +546,7 @@ export class BuildTriggerManager {
     try {
       const response = await this.client.modules.buildTypes.getAllTriggers(targetConfig);
 
-      const triggers = this.parseTriggerList(
-        response.data as unknown as TeamCityTriggersResponse
-      );
+      const triggers = this.parseTriggerList(response.data as unknown as TeamCityTriggersResponse);
 
       // Check if target already depends on source
       const hasCycle = triggers.some(

--- a/tests/test-utils/mock-teamcity-client.ts
+++ b/tests/test-utils/mock-teamcity-client.ts
@@ -33,6 +33,17 @@ export interface MockBuildTypeApi {
   setBuildTypeField: jest.Mock;
   deleteBuildParameterOfBuildType: jest.Mock;
   deleteBuildParameterOfBuildType_2: jest.Mock;
+  getAllBuildSteps: jest.Mock;
+  addBuildStepToBuildType: jest.Mock;
+  replaceBuildStep: jest.Mock;
+  deleteBuildStep: jest.Mock;
+  replaceAllBuildSteps: jest.Mock;
+  getAllTriggers: jest.Mock;
+  addTriggerToBuildType: jest.Mock;
+  getTrigger: jest.Mock;
+  replaceTrigger: jest.Mock;
+  deleteTrigger: jest.Mock;
+  getAllVcsRootsOfBuildType: jest.Mock;
 }
 
 /**
@@ -57,6 +68,9 @@ export interface MockBuildApi {
   getBuildProblems: jest.Mock;
   triggerBuild: jest.Mock;
   cancelBuild: jest.Mock;
+  getFilesListOfBuild: jest.Mock;
+  getFileMetadataOfBuild: jest.Mock;
+  downloadFileOfBuild: jest.Mock;
 }
 
 /**
@@ -87,6 +101,16 @@ export interface MockAgentApi {
   getAllAgents: jest.Mock;
 }
 
+export interface MockTestOccurrenceApi {
+  getAllTestOccurrences: jest.Mock;
+  getTestOccurrence: jest.Mock;
+}
+
+export interface MockProblemOccurrenceApi {
+  getAllBuildProblemOccurrences: jest.Mock;
+  getBuildProblemOccurrence: jest.Mock;
+}
+
 /**
  * Subset of modules that we actively mock for manager tests.
  */
@@ -97,6 +121,8 @@ export interface MockTeamCityModules {
   buildQueue: MockBuildQueueApi;
   vcsRoots: MockVcsRootApi;
   agents: MockAgentApi;
+  tests: MockTestOccurrenceApi;
+  problemOccurrences: MockProblemOccurrenceApi;
 }
 
 const DEFAULT_BASE_URL = 'https://teamcity.test.local';
@@ -182,6 +208,17 @@ export class MockTeamCityClient implements TeamCityClientAdapter {
         setBuildTypeField: jest.fn(),
         deleteBuildParameterOfBuildType: jest.fn(),
         deleteBuildParameterOfBuildType_2: jest.fn(),
+        getAllBuildSteps: jest.fn(),
+        addBuildStepToBuildType: jest.fn(),
+        replaceBuildStep: jest.fn(),
+        deleteBuildStep: jest.fn(),
+        replaceAllBuildSteps: jest.fn(),
+        getAllTriggers: jest.fn(),
+        addTriggerToBuildType: jest.fn(),
+        getTrigger: jest.fn(),
+        replaceTrigger: jest.fn(),
+        deleteTrigger: jest.fn(),
+        getAllVcsRootsOfBuildType: jest.fn(),
       },
       projects: {
         getAllProjects: jest.fn(),
@@ -198,6 +235,9 @@ export class MockTeamCityClient implements TeamCityClientAdapter {
         getBuildProblems: jest.fn(),
         triggerBuild: jest.fn(),
         cancelBuild: jest.fn(),
+        getFilesListOfBuild: jest.fn(),
+        getFileMetadataOfBuild: jest.fn(),
+        downloadFileOfBuild: jest.fn(),
       },
       buildQueue: {
         addBuildToQueue: jest.fn(),
@@ -215,6 +255,14 @@ export class MockTeamCityClient implements TeamCityClientAdapter {
       agents: {
         getAllAgents: jest.fn(),
       },
+      tests: {
+        getAllTestOccurrences: jest.fn(),
+        getTestOccurrence: jest.fn(),
+      },
+      problemOccurrences: {
+        getAllBuildProblemOccurrences: jest.fn(),
+        getBuildProblemOccurrence: jest.fn(),
+      },
       ...overrides,
     } as MockTeamCityModules;
 
@@ -225,6 +273,8 @@ export class MockTeamCityClient implements TeamCityClientAdapter {
     modules.buildQueue = this.mockModules.buildQueue as unknown as TeamCityApiSurface['buildQueue'];
     modules.vcsRoots = this.mockModules.vcsRoots as unknown as TeamCityApiSurface['vcsRoots'];
     modules.agents = this.mockModules.agents as unknown as TeamCityApiSurface['agents'];
+    modules.tests = this.mockModules.tests as unknown as TeamCityApiSurface['tests'];
+    modules.problemOccurrences = this.mockModules.problemOccurrences as unknown as TeamCityApiSurface['problemOccurrences'];
 
     this.modules = Object.freeze(modules);
 

--- a/tests/test-utils/mock-teamcity-client.ts
+++ b/tests/test-utils/mock-teamcity-client.ts
@@ -274,7 +274,8 @@ export class MockTeamCityClient implements TeamCityClientAdapter {
     modules.vcsRoots = this.mockModules.vcsRoots as unknown as TeamCityApiSurface['vcsRoots'];
     modules.agents = this.mockModules.agents as unknown as TeamCityApiSurface['agents'];
     modules.tests = this.mockModules.tests as unknown as TeamCityApiSurface['tests'];
-    modules.problemOccurrences = this.mockModules.problemOccurrences as unknown as TeamCityApiSurface['problemOccurrences'];
+    modules.problemOccurrences = this.mockModules
+      .problemOccurrences as unknown as TeamCityApiSurface['problemOccurrences'];
 
     this.modules = Object.freeze(modules);
 

--- a/tests/unit/teamcity/build-list-manager.test.ts
+++ b/tests/unit/teamcity/build-list-manager.test.ts
@@ -10,6 +10,7 @@ type StubClient = {
   client: TeamCityUnifiedClient;
   builds: {
     getMultipleBuilds: jest.Mock;
+    getAllBuilds: jest.Mock;
   };
   http: { get: jest.Mock };
   request: jest.Mock;
@@ -18,6 +19,7 @@ type StubClient = {
 const createStubClient = (): StubClient => {
   const builds = {
     getMultipleBuilds: jest.fn(),
+    getAllBuilds: jest.fn(),
   };
 
   const http = {
@@ -155,15 +157,11 @@ describe('BuildListManager', () => {
         },
       });
 
-      stub.http.get.mockResolvedValueOnce({ data: '42' });
+      stub.builds.getAllBuilds.mockResolvedValueOnce({ data: { count: 42 } });
 
       const result = await manager.listBuilds({ includeTotalCount: true });
 
-      expect(stub.request).toHaveBeenCalledWith(expect.any(Function));
-      expect(stub.http.get).toHaveBeenCalledWith(
-        `${BASE_URL}/app/rest/builds/count`,
-        expect.objectContaining({ headers: expect.any(Object) })
-      );
+      expect(stub.builds.getAllBuilds).toHaveBeenCalledWith(undefined, 'count');
       expect(result.metadata.totalCount).toBe(42);
     });
 
@@ -175,7 +173,7 @@ describe('BuildListManager', () => {
         },
       });
 
-      stub.http.get.mockRejectedValueOnce(new Error('count failed'));
+      stub.builds.getAllBuilds.mockRejectedValueOnce(new Error('count failed'));
 
       const result = await manager.listBuilds({ includeTotalCount: true });
       expect(result.metadata.totalCount).toBe(0);

--- a/tests/unit/teamcity/build-results-manager.test.ts
+++ b/tests/unit/teamcity/build-results-manager.test.ts
@@ -8,6 +8,7 @@ type StubbedModules = {
     getBuild: jest.Mock;
     getFilesListOfBuild: jest.Mock;
     getBuildStatisticValues: jest.Mock;
+    getAllBuilds: jest.Mock;
   };
   changes: {
     getAllChanges: jest.Mock;
@@ -27,6 +28,7 @@ const createStubClient = (): StubbedClient => {
       getBuild: jest.fn(),
       getFilesListOfBuild: jest.fn(),
       getBuildStatisticValues: jest.fn(),
+      getAllBuilds: jest.fn(),
     },
     changes: {
       getAllChanges: jest.fn(),
@@ -189,8 +191,8 @@ describe('BuildResultsManager', () => {
   });
 
   describe('fetchDependencies', () => {
-    it('uses shared axios request helper for snapshot dependencies', async () => {
-      stub.http.get.mockResolvedValueOnce({
+    it('fetches snapshot dependencies through the builds module API', async () => {
+      stub.modules.builds.getAllBuilds.mockResolvedValueOnce({
         data: {
           build: [
             { id: 1, number: '100', buildTypeId: 'Cfg_A', status: 'SUCCESS' },
@@ -206,9 +208,9 @@ describe('BuildResultsManager', () => {
         status: string;
       }>;
 
-      expect(stub.request).toHaveBeenCalledWith(expect.any(Function));
-      expect(stub.http.get).toHaveBeenCalledWith(
-        `${BASE_URL}/app/rest/builds/id:12345/snapshot-dependencies`
+      expect(stub.modules.builds.getAllBuilds).toHaveBeenCalledWith(
+        'snapshotDependency:(to:(id:12345))',
+        'build(id,number,buildTypeId,status)'
       );
       expect(dependencies).toEqual([
         { buildId: 1, buildNumber: '100', buildTypeId: 'Cfg_A', status: 'SUCCESS' },

--- a/tests/unit/teamcity/build-step-manager.test.ts
+++ b/tests/unit/teamcity/build-step-manager.test.ts
@@ -40,7 +40,9 @@ describe('BuildStepManager', () => {
     buildTypesApi = mockClient.mockModules.buildTypes;
     buildTypesApi.getAllBuildSteps.mockImplementation((configId: string, fields?: string) =>
       http.get(
-        fields ? `/app/rest/buildTypes/${configId}/steps?fields=${fields}` : `/app/rest/buildTypes/${configId}/steps`
+        fields
+          ? `/app/rest/buildTypes/${configId}/steps?fields=${fields}`
+          : `/app/rest/buildTypes/${configId}/steps`
       )
     );
     buildTypesApi.addBuildStepToBuildType.mockImplementation(

--- a/tests/unit/teamcity/build-step-manager.test.ts
+++ b/tests/unit/teamcity/build-step-manager.test.ts
@@ -19,6 +19,7 @@ import {
 } from '@/teamcity/errors';
 
 import {
+  type MockBuildTypeApi,
   type MockTeamCityClient,
   createMockTeamCityClient,
 } from '../../test-utils/mock-teamcity-client';
@@ -27,6 +28,7 @@ describe('BuildStepManager', () => {
   let manager: BuildStepManager;
   let mockClient: MockTeamCityClient;
   let http: jest.Mocked<ReturnType<MockTeamCityClient['getAxios']>>;
+  let buildTypesApi: MockBuildTypeApi;
 
   beforeEach(() => {
     mockClient = createMockTeamCityClient();
@@ -35,6 +37,27 @@ describe('BuildStepManager', () => {
     http.post.mockReset();
     http.put.mockReset();
     http.delete.mockReset();
+    buildTypesApi = mockClient.mockModules.buildTypes;
+    buildTypesApi.getAllBuildSteps.mockImplementation((configId: string, fields?: string) =>
+      http.get(
+        fields ? `/app/rest/buildTypes/${configId}/steps?fields=${fields}` : `/app/rest/buildTypes/${configId}/steps`
+      )
+    );
+    buildTypesApi.addBuildStepToBuildType.mockImplementation(
+      (configId: string, _fields?: string, body?: unknown) =>
+        http.post(`/app/rest/buildTypes/${configId}/steps`, body)
+    );
+    buildTypesApi.replaceBuildStep.mockImplementation(
+      (configId: string, stepId: string, _fields?: string, body?: unknown) =>
+        http.put(`/app/rest/buildTypes/${configId}/steps/${stepId}`, body)
+    );
+    buildTypesApi.deleteBuildStep.mockImplementation((configId: string, stepId: string) =>
+      http.delete(`/app/rest/buildTypes/${configId}/steps/${stepId}`)
+    );
+    buildTypesApi.replaceAllBuildSteps.mockImplementation(
+      (configId: string, _fields?: string, body?: unknown) =>
+        http.put(`/app/rest/buildTypes/${configId}/steps`, body)
+    );
     manager = new BuildStepManager(mockClient);
   });
 

--- a/tests/unit/teamcity/build-trigger-manager.test.ts
+++ b/tests/unit/teamcity/build-trigger-manager.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@/teamcity/errors';
 
 import {
+  type MockBuildTypeApi,
   type MockTeamCityClient,
   createMockTeamCityClient,
 } from '../../test-utils/mock-teamcity-client';
@@ -23,6 +24,7 @@ describe('BuildTriggerManager', () => {
   let manager: BuildTriggerManager;
   let mockClient: MockTeamCityClient;
   let http: jest.Mocked<ReturnType<MockTeamCityClient['getAxios']>>;
+  let buildTypesApi: MockBuildTypeApi;
 
   beforeEach(() => {
     mockClient = createMockTeamCityClient();
@@ -31,6 +33,34 @@ describe('BuildTriggerManager', () => {
     http.post.mockReset();
     http.put.mockReset();
     http.delete.mockReset();
+    buildTypesApi = mockClient.mockModules.buildTypes;
+    buildTypesApi.getAllTriggers.mockImplementation((configId: string, fields?: string) =>
+      fields
+        ? http.get(`/app/rest/buildTypes/${configId}/triggers?fields=${fields}`)
+        : http.get(`/app/rest/buildTypes/${configId}/triggers`)
+    );
+    buildTypesApi.addTriggerToBuildType.mockImplementation(
+      (configId: string, _fields?: string, body?: unknown) =>
+        http.post(`/app/rest/buildTypes/${configId}/triggers`, body)
+    );
+    buildTypesApi.getTrigger.mockImplementation(
+      (configId: string, triggerId: string, fields?: string) =>
+        fields
+          ? http.get(`/app/rest/buildTypes/${configId}/triggers/${triggerId}?fields=${fields}`)
+          : http.get(`/app/rest/buildTypes/${configId}/triggers/${triggerId}`)
+    );
+    buildTypesApi.replaceTrigger.mockImplementation(
+      (configId: string, triggerId: string, _fields?: string, body?: unknown) =>
+        http.put(`/app/rest/buildTypes/${configId}/triggers/${triggerId}`, body)
+    );
+    buildTypesApi.deleteTrigger.mockImplementation((configId: string, triggerId: string) =>
+      http.delete(`/app/rest/buildTypes/${configId}/triggers/${triggerId}`)
+    );
+    buildTypesApi.getAllVcsRootsOfBuildType.mockImplementation((configId: string, fields?: string) =>
+      fields
+        ? http.get(`/app/rest/buildTypes/${configId}/vcs-root-entries?fields=${fields}`)
+        : http.get(`/app/rest/buildTypes/${configId}/vcs-root-entries`)
+    );
     manager = new BuildTriggerManager(mockClient);
   });
 

--- a/tests/unit/teamcity/build-trigger-manager.test.ts
+++ b/tests/unit/teamcity/build-trigger-manager.test.ts
@@ -56,10 +56,11 @@ describe('BuildTriggerManager', () => {
     buildTypesApi.deleteTrigger.mockImplementation((configId: string, triggerId: string) =>
       http.delete(`/app/rest/buildTypes/${configId}/triggers/${triggerId}`)
     );
-    buildTypesApi.getAllVcsRootsOfBuildType.mockImplementation((configId: string, fields?: string) =>
-      fields
-        ? http.get(`/app/rest/buildTypes/${configId}/vcs-root-entries?fields=${fields}`)
-        : http.get(`/app/rest/buildTypes/${configId}/vcs-root-entries`)
+    buildTypesApi.getAllVcsRootsOfBuildType.mockImplementation(
+      (configId: string, fields?: string) =>
+        fields
+          ? http.get(`/app/rest/buildTypes/${configId}/vcs-root-entries?fields=${fields}`)
+          : http.get(`/app/rest/buildTypes/${configId}/vcs-root-entries`)
     );
     manager = new BuildTriggerManager(mockClient);
   });

--- a/tests/unit/teamcity/build-trigger-manager.test.ts
+++ b/tests/unit/teamcity/build-trigger-manager.test.ts
@@ -458,8 +458,7 @@ describe('BuildTriggerManager', () => {
                 expect.objectContaining({ name: 'timezone', value: 'Europe/London' }),
               ]),
             }),
-          }),
-          expect.any(Object)
+          })
         );
       });
 
@@ -528,8 +527,7 @@ describe('BuildTriggerManager', () => {
                 }),
               ]),
             }),
-          }),
-          expect.any(Object)
+          })
         );
       });
 

--- a/tests/unit/teamcity/test-problem-reporter-trend-patterns.test.ts
+++ b/tests/unit/teamcity/test-problem-reporter-trend-patterns.test.ts
@@ -7,14 +7,10 @@ import {
 
 describe('TestProblemReporter: trends and patterns', () => {
   let mockClient: MockTeamCityClient;
-  let http: jest.Mocked<ReturnType<MockTeamCityClient['getAxios']>>;
   const BASE_URL = 'http://localhost:8111';
 
   const configureClient = () => {
     mockClient = createMockTeamCityClient();
-    http = mockClient.http as jest.Mocked<ReturnType<MockTeamCityClient['getAxios']>>;
-    http.get.mockReset();
-    mockClient.request.mockImplementation(async (fn) => fn({ axios: http, baseUrl: BASE_URL }));
     mockClient.getApiConfig.mockReturnValue({
       baseUrl: BASE_URL,
       token: 'token',
@@ -32,17 +28,16 @@ describe('TestProblemReporter: trends and patterns', () => {
   beforeEach(() => configureClient());
 
   it('getTestTrend aggregates stats for recent builds', async () => {
-    // First call returns builds list
-    http.get.mockImplementation((path: string) => {
-      if (path.includes('/buildTypes/id:bt1/builds')) {
-        return Promise.resolve({ data: { build: [{ id: 'b1' }, { id: 'b2' }] } });
-      }
-      if (path.includes('/builds/id:b1')) {
+    mockClient.mockModules.builds.getAllBuilds.mockResolvedValue({
+      data: { build: [{ id: 'b1' }, { id: 'b2' }] },
+    });
+    mockClient.mockModules.builds.getBuild.mockImplementation((locator: string) => {
+      if (locator === 'id:b1') {
         return Promise.resolve({
           data: { id: 'b1', testOccurrences: { count: 10, passed: 8, failed: 2 } },
         });
       }
-      if (path.includes('/builds/id:b2')) {
+      if (locator === 'id:b2') {
         return Promise.resolve({
           data: { id: 'b2', testOccurrences: { count: 5, passed: 5, failed: 0 } },
         });
@@ -59,11 +54,11 @@ describe('TestProblemReporter: trends and patterns', () => {
 
   it('getFailurePatterns counts repeated failures across builds', async () => {
     // Return two failed builds
-    http.get.mockImplementation((path: string) => {
-      if (path.includes('/buildTypes/id:bt2/builds?locator=status:FAILURE')) {
-        return Promise.resolve({ data: { build: [{ id: 'b10' }, { id: 'b11' }] } });
-      }
-      if (path.includes('/testOccurrences?locator=status:FAILURE')) {
+    mockClient.mockModules.builds.getAllBuilds.mockResolvedValue({
+      data: { build: [{ id: 'b10' }, { id: 'b11' }] },
+    });
+    mockClient.mockModules.tests.getAllTestOccurrences.mockImplementation((locator: string) => {
+      if (locator.includes('build:(id:b10)')) {
         return Promise.resolve({
           data: {
             testOccurrence: [
@@ -73,13 +68,19 @@ describe('TestProblemReporter: trends and patterns', () => {
           },
         });
       }
-      if (path.includes('/builds/id:')) {
-        // getTestStatistics called inside getFailurePatterns via getFailedTests indirectly; ensure stats call is harmless
+      if (locator.includes('build:(id:b11)')) {
         return Promise.resolve({
-          data: { id: 'b', testOccurrences: { count: 2, passed: 0, failed: 2 } },
+          data: {
+            testOccurrence: [
+              { id: 't3', name: 'C', status: 'FAILURE', test: { className: 'D' } },
+            ],
+          },
         });
       }
       return Promise.resolve({ data: {} });
+    });
+    mockClient.mockModules.builds.getBuild.mockResolvedValue({
+      data: { id: 'b', testOccurrences: { count: 2, passed: 0, failed: 2 } },
     });
 
     const reporter = new TestProblemReporter(mockClient);

--- a/tests/unit/teamcity/test-problem-reporter-trend-patterns.test.ts
+++ b/tests/unit/teamcity/test-problem-reporter-trend-patterns.test.ts
@@ -71,9 +71,7 @@ describe('TestProblemReporter: trends and patterns', () => {
       if (locator.includes('build:(id:b11)')) {
         return Promise.resolve({
           data: {
-            testOccurrence: [
-              { id: 't3', name: 'C', status: 'FAILURE', test: { className: 'D' } },
-            ],
+            testOccurrence: [{ id: 't3', name: 'C', status: 'FAILURE', test: { className: 'D' } }],
           },
         });
       }

--- a/tests/unit/teamcity/test-problem-reporter.test.ts
+++ b/tests/unit/teamcity/test-problem-reporter.test.ts
@@ -320,7 +320,7 @@ describe('TestProblemReporter', () => {
 
       // Mock test statistics
       http.get.mockImplementation((path: string) => {
-        if (path.includes('/testOccurrences?locator=status:FAILURE')) {
+        if (path.includes(`/testOccurrences?locator=build:(id:${buildId}),status:FAILURE`)) {
           return Promise.resolve({
             data: {
               testOccurrence: [
@@ -445,7 +445,7 @@ describe('TestProblemReporter', () => {
       const buildId = '12357';
 
       http.get.mockImplementation((path: string) => {
-        if (path.includes('/testOccurrences?locator=status:FAILURE')) {
+        if (path.includes(`/testOccurrences?locator=build:(id:${buildId}),status:FAILURE`)) {
           return Promise.resolve({
             data: {
               testOccurrence: [
@@ -512,7 +512,7 @@ describe('TestProblemReporter', () => {
       }));
 
       http.get.mockImplementation((path: string) => {
-        if (path.includes('/testOccurrences?locator=status:FAILURE')) {
+        if (path.includes(`/testOccurrences?locator=build:(id:${buildId}),status:FAILURE`)) {
           return Promise.resolve({
             data: { testOccurrence: tests },
           });

--- a/tests/unit/teamcity/test-problem-reporter.test.ts
+++ b/tests/unit/teamcity/test-problem-reporter.test.ts
@@ -34,9 +34,7 @@ describe('TestProblemReporter', () => {
       http.get(`/app/rest/builds/${locator}`)
     );
     buildsApi.getAllBuilds.mockImplementation((locator?: string) =>
-      locator
-        ? http.get(`/app/rest/builds?locator=${locator}`)
-        : http.get('/app/rest/builds')
+      locator ? http.get(`/app/rest/builds?locator=${locator}`) : http.get('/app/rest/builds')
     );
     testsApi.getAllTestOccurrences.mockImplementation((locator?: string) =>
       locator


### PR DESCRIPTION
## Summary
- align build results, build list, trigger, and test reporter unit suites with the TeamCity client modules
- update mocks and expectations to cover module-based responses and locator formatting
- adjust trend/pattern helpers and total count coverage to use the new build APIs

## Testing
- npm run test:unit

Closes #144
