### PR TITLE
refactor(teamcity): replace unsafe response assertions

### DIFF
--- a/src/teamcity/api-types.ts
+++ b/src/teamcity/api-types.ts
@@ -279,8 +279,208 @@ export interface TeamCityErrorResponse {
 /**
  * Type guards for safe type checking
  */
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const isOptionalString = (value: unknown): value is string | undefined => {
+  return value === undefined || typeof value === 'string';
+};
+
 export const isTeamCityErrorResponse = (response: unknown): response is TeamCityErrorResponse => {
-  return typeof response === 'object' && response !== null && 'message' in response;
+  return isRecord(response) && 'message' in response;
+};
+
+export const isTeamCityProperty = (value: unknown): value is TeamCityProperty => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const {
+    name,
+    value: propertyValue,
+    inherited,
+    type,
+  } = value as {
+    name?: unknown;
+    value?: unknown;
+    inherited?: unknown;
+    type?: unknown;
+  };
+
+  if (typeof name !== 'string' || typeof propertyValue !== 'string') {
+    return false;
+  }
+
+  if (inherited !== undefined && typeof inherited !== 'boolean') {
+    return false;
+  }
+
+  if (type !== undefined && !isRecord(type)) {
+    return false;
+  }
+
+  return true;
+};
+
+export const isTeamCityProperties = (value: unknown): value is TeamCityProperties => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { count, property } = value as { count?: unknown; property?: unknown };
+
+  if (count !== undefined && typeof count !== 'number') {
+    return false;
+  }
+
+  if (property === undefined) {
+    return true;
+  }
+
+  if (Array.isArray(property)) {
+    return property.every(isTeamCityProperty);
+  }
+
+  return isTeamCityProperty(property);
+};
+
+export const isTeamCityTriggerResponse = (value: unknown): value is TeamCityTriggerResponse => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { id, type, disabled, inherited, properties } = value as {
+    id?: unknown;
+    type?: unknown;
+    disabled?: unknown;
+    inherited?: unknown;
+    properties?: unknown;
+  };
+
+  if (!isOptionalString(id) || !isOptionalString(type)) {
+    return false;
+  }
+
+  if (typeof type !== 'string') {
+    return false;
+  }
+
+  if (disabled !== undefined && typeof disabled !== 'boolean') {
+    return false;
+  }
+
+  if (inherited !== undefined && typeof inherited !== 'boolean') {
+    return false;
+  }
+
+  if (properties !== undefined && !isTeamCityProperties(properties)) {
+    return false;
+  }
+
+  return true;
+};
+
+export const isTeamCityTriggersResponse = (value: unknown): value is TeamCityTriggersResponse => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { count, trigger } = value as { count?: unknown; trigger?: unknown };
+
+  if (count !== undefined && typeof count !== 'number') {
+    return false;
+  }
+
+  if (trigger === undefined) {
+    return true;
+  }
+
+  if (Array.isArray(trigger)) {
+    return trigger.every(isTeamCityTriggerResponse);
+  }
+
+  return isTeamCityTriggerResponse(trigger);
+};
+
+const isTeamCityVcsRoot = (value: unknown): value is TeamCityVcsRootEntry['vcs-root'] => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { id, name, properties } = value as { id?: unknown; name?: unknown; properties?: unknown };
+
+  if (!isOptionalString(id) || !isOptionalString(name)) {
+    return false;
+  }
+
+  if (properties !== undefined && !isTeamCityProperties(properties)) {
+    return false;
+  }
+
+  return true;
+};
+
+export const isTeamCityVcsRootEntry = (value: unknown): value is TeamCityVcsRootEntry => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const {
+    id,
+    inherited,
+    'checkout-rules': checkoutRules,
+    'vcs-root': vcsRoot,
+  } = value as {
+    id?: unknown;
+    inherited?: unknown;
+    'checkout-rules'?: unknown;
+    'vcs-root'?: unknown;
+  };
+
+  if (!isOptionalString(id)) {
+    return false;
+  }
+
+  if (inherited !== undefined && typeof inherited !== 'boolean') {
+    return false;
+  }
+
+  if (!isOptionalString(checkoutRules)) {
+    return false;
+  }
+
+  if (vcsRoot !== undefined && !isTeamCityVcsRoot(vcsRoot)) {
+    return false;
+  }
+
+  return true;
+};
+
+export const isTeamCityVcsRootEntriesResponse = (
+  value: unknown
+): value is TeamCityVcsRootEntriesResponse => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { count, 'vcs-root-entry': entries } = value as {
+    count?: unknown;
+    'vcs-root-entry'?: unknown;
+  };
+
+  if (count !== undefined && typeof count !== 'number') {
+    return false;
+  }
+
+  if (entries === undefined) {
+    return true;
+  }
+
+  if (Array.isArray(entries)) {
+    return entries.every(isTeamCityVcsRootEntry);
+  }
+
+  return isTeamCityVcsRootEntry(entries);
 };
 
 export const isPropertyArray = (

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -725,9 +725,11 @@ const DEV_TOOLS: ToolDefinition[] = [
           const maxAttempts = typed.tail ? 5 : 3;
           for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
             try {
+              // eslint-disable-next-line no-await-in-loop -- sequential retry attempts require awaiting inside loop
               return await attemptFetch();
             } catch (error) {
               if (shouldRetry(error) && attempt < maxAttempts - 1) {
+                // eslint-disable-next-line no-await-in-loop -- intentional backoff between sequential retries
                 await wait(500 * (attempt + 1));
                 continue;
               }

--- a/tests/unit/teamcity/api-types.guards.test.ts
+++ b/tests/unit/teamcity/api-types.guards.test.ts
@@ -1,0 +1,80 @@
+import {
+  isTeamCityTriggerResponse,
+  isTeamCityTriggersResponse,
+  isTeamCityVcsRootEntriesResponse,
+} from '@/teamcity/api-types';
+
+describe('TeamCity API type guards', () => {
+  describe('isTeamCityTriggerResponse', () => {
+    it('accepts valid trigger payloads', () => {
+      const payload = {
+        id: 'TRIGGER_1',
+        type: 'vcsTrigger',
+        disabled: false,
+        properties: {
+          property: [{ name: 'branchFilter', value: '+:refs/heads/main' }],
+        },
+      };
+
+      expect(isTeamCityTriggerResponse(payload)).toBe(true);
+    });
+
+    it('rejects payloads without a string type', () => {
+      expect(
+        isTeamCityTriggerResponse({
+          id: 'TRIGGER_2',
+          type: 123,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('isTeamCityTriggersResponse', () => {
+    it('accepts collections with valid triggers', () => {
+      const payload = {
+        count: 1,
+        trigger: [
+          {
+            id: 'TRIGGER_1',
+            type: 'schedulingTrigger',
+            disabled: true,
+          },
+        ],
+      };
+
+      expect(isTeamCityTriggersResponse(payload)).toBe(true);
+    });
+
+    it('rejects collections containing invalid triggers', () => {
+      const payload = {
+        trigger: [{ id: 'TRIGGER_2', type: null }],
+      };
+
+      expect(isTeamCityTriggersResponse(payload)).toBe(false);
+    });
+  });
+
+  describe('isTeamCityVcsRootEntriesResponse', () => {
+    it('accepts valid VCS root entries payload', () => {
+      const payload = {
+        count: 1,
+        'vcs-root-entry': [
+          {
+            id: 'ENTRY_1',
+            'vcs-root': { id: 'VCS_ROOT' },
+          },
+        ],
+      };
+
+      expect(isTeamCityVcsRootEntriesResponse(payload)).toBe(true);
+    });
+
+    it('rejects payloads with malformed entries', () => {
+      const payload = {
+        'vcs-root-entry': [{ id: 'ENTRY_2', 'vcs-root': { id: 42 } }],
+      };
+
+      expect(isTeamCityVcsRootEntriesResponse(payload)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/teamcity/client-adapter.test.ts
+++ b/tests/unit/teamcity/client-adapter.test.ts
@@ -152,7 +152,7 @@ describe('createAdapterFromTeamCityAPI', () => {
     warnMock.mockReset();
   });
 
-  it('exposes unified surface and configuration helpers', () => {
+  it('exposes unified surface and configuration helpers', async () => {
     const adapter = createAdapterFromTeamCityAPI(apiMock, { apiConfig, fullConfig });
 
     expect(adapter.modules).toBe(modules);
@@ -161,7 +161,12 @@ describe('createAdapterFromTeamCityAPI', () => {
     expect(adapter.getConfig()).toBe(fullConfig);
     expect(adapter.getApiConfig()).toEqual(apiConfig);
     expect(adapter.baseUrl).toBe(baseUrl);
-    expect(adapter.builds).toBe(modules.builds);
+
+    const buildsMock = modules.builds.getAllBuilds as jest.Mock;
+    buildsMock.mockClear();
+    expect(typeof adapter.builds.getAllBuilds).toBe('function');
+    await adapter.builds.getAllBuilds('locator');
+    expect(buildsMock).toHaveBeenCalledWith('locator', undefined, undefined);
   });
 
   it('delegates helper methods to the underlying API', async () => {


### PR DESCRIPTION
## Summary
- replace double assertions in trigger/vcs response paths with type-guards and structured validation
- tighten artifact and build result managers to validate binary/text payloads before coercion
- add regression coverage for new guards and updated response handling

## Testing
- npm run typecheck
- npm run test:unit

Closes #148
