### PR TITLE
feat(teamcity): add streaming artifact downloads

### DIFF
--- a/docs/TEAMCITY_MCP_TOOLS_GUIDE.md
+++ b/docs/TEAMCITY_MCP_TOOLS_GUIDE.md
@@ -56,6 +56,7 @@ Complete infrastructure management including creation, modification, and deletio
 | `get_build_status`           | Get detailed build status and progress          |  ✅  |  ✅  |
 | `list_builds`                | Search and list builds with filtering           |  ✅  |  ✅  |
 | `get_build_results`          | Get detailed build results                |  ✅  |  ✅  |
+| `download_build_artifact`    | Download artifact content (base64/text/stream)  |  ✅  |  ✅  |
 | `fetch_build_log`            | Retrieve build logs                       |  ✅  |  ✅  |
 | `get_build_config`           | Get build configuration details                 |  ✅  |  ✅  |
 | `list_build_configs`         | List build configurations in project            |  ✅  |  ✅  |
@@ -181,6 +182,29 @@ Complete infrastructure management including creation, modification, and deletio
 - `includeTests`: Include test details
 - `includeProblems`: Include problems
 - `includeArtifacts`: Include artifacts
+
+#### `download_build_artifact`
+
+**Description**: Download a single artifact
+**Mode**: Dev
+**Key Capabilities**:
+
+- Return base64-encoded or plain-text content for small artifacts
+- Stream large artifacts directly to disk without buffering in memory
+- Enforce an optional maximum size before initiating the transfer
+
+**Parameters**:
+
+- `buildId` (required): Build identifier
+- `artifactPath` (required): Artifact path or name (as returned by artifact listings)
+- `encoding`: `'base64'` (default), `'text'`, or `'stream'`
+- `maxSize`: Abort download if artifact size exceeds this byte limit
+- `outputPath`: Absolute path to write streamed artifacts (defaults to a temp file when omitted)
+
+**Usage Notes**:
+
+- In `stream` mode the tool writes the artifact to disk and returns metadata (`outputPath`, `bytesWritten`).
+- Base64/text modes embed content directly in the JSON response for easy scripting.
 
 #### `fetch_build_log`
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -54,6 +54,8 @@ This document lists all Model Context Protocol (MCP) tools exposed by the TeamCi
   - Args: `buildId?: string`, `buildNumber?: string|number` (with optional `buildTypeId` to disambiguate), `buildTypeId?: string`, `page?: number`, `pageSize?: number`, `startLine?: number`, `lineCount?: number`, `tail?: boolean`
 - `get_build_results` — Rich results (tests, artifacts, stats, changes, deps)
   - Args: `buildId: string`, `includeArtifacts?: boolean`, `includeStatistics?: boolean`, `includeChanges?: boolean`, `includeDependencies?: boolean`, `artifactFilter?: string`, `maxArtifactSize?: number`
+- `download_build_artifact` — Download a single artifact (base64/text or stream-to-file)
+  - Args: `buildId: string`, `artifactPath: string`, `encoding?: 'base64'|'text'|'stream'`, `maxSize?: number`, `outputPath?: string`
 - `analyze_build_problems` — Problems + failing tests summary
   - Args: `buildId: string`
 

--- a/docs/teamcity-unified-client.md
+++ b/docs/teamcity-unified-client.md
@@ -90,6 +90,16 @@ When adding or updating a manager:
    payloads.
 5. Log recoverable failures with `warn`/`error` from `@/utils/logger`.
 
+### Artifact downloads
+
+- `ArtifactManager.downloadArtifact` now accepts `encoding: 'stream'` to return a Node
+  `Readable` without buffering the full payload. This is opt-in; the default path still
+  buffers responses as `Buffer`/`base64` to preserve existing behaviour.
+- Streaming is limited to single-artifact downloads. `downloadMultipleArtifacts` will throw when
+  `encoding: 'stream'` is requested so callers can fall back to sequential handling.
+- Consumers should document whether they expect buffered or streaming content when exposing the
+  option through new APIs or tools.
+
 ## Testing the Contract
 
 The `tests/test-utils/mock-teamcity-client.ts` helper provides a typed

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -2,7 +2,7 @@
  * Simple TeamCity API Client
  * Direct API wrapper without dependency injection or complex abstractions
  */
-import axios, { type AxiosInstance, type AxiosResponse } from 'axios';
+import axios, { type AxiosInstance, type AxiosResponse, type RawAxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';
 
 import { getTeamCityToken, getTeamCityUrl } from '@/config';
@@ -426,19 +426,24 @@ export class TeamCityAPI {
     );
   }
 
-  async downloadBuildArtifact(
+  async downloadBuildArtifact<T = ArrayBuffer>(
     buildId: string,
-    artifactPath: string
-  ): Promise<AxiosResponse<ArrayBuffer>> {
+    artifactPath: string,
+    options?: RawAxiosRequestConfig
+  ): Promise<AxiosResponse<T>> {
     const normalizedPath = artifactPath
       .split('/')
       .map((segment) => encodeURIComponent(segment))
       .join('/');
-    return this.axiosInstance.get(
+    const requestOptions = {
+      ...(options ?? {}),
+      responseType: (options?.responseType ??
+        'arraybuffer') as RawAxiosRequestConfig['responseType'],
+    } as RawAxiosRequestConfig<T>;
+
+    return this.axiosInstance.get<T>(
       `/app/rest/builds/id:${buildId}/artifacts/content/${normalizedPath}`,
-      {
-        responseType: 'arraybuffer',
-      }
+      requestOptions
     );
   }
 

--- a/src/teamcity/client-adapter.ts
+++ b/src/teamcity/client-adapter.ts
@@ -2,7 +2,7 @@
  * Lightweight adapter so managers can work with the unified TeamCityAPI
  * without depending on the legacy TeamCity client implementation.
  */
-import axios, { type AxiosInstance } from 'axios';
+import axios, { type AxiosInstance, type RawAxiosRequestConfig } from 'axios';
 
 import type { TeamCityAPI, TeamCityAPIClientConfig } from '@/api-client';
 import type { TeamCityFullConfig } from '@/teamcity/config';
@@ -152,8 +152,11 @@ export function createAdapterFromTeamCityAPI(
     listTestFailures: (buildId) => api.listTestFailures(buildId),
     builds: buildApi,
     listBuildArtifacts: (buildId, options) => api.listBuildArtifacts(buildId, options),
-    downloadArtifactContent: (buildId, artifactPath) =>
-      api.downloadBuildArtifact(buildId, artifactPath),
+    downloadArtifactContent: <T = ArrayBuffer>(
+      buildId: string,
+      artifactPath: string,
+      requestOptions?: RawAxiosRequestConfig
+    ) => api.downloadBuildArtifact<T>(buildId, artifactPath, requestOptions),
     getBuildStatistics: (buildId, fields) => api.getBuildStatistics(buildId, fields),
     listChangesForBuild: (buildId, fields) => api.listChangesForBuild(buildId, fields),
     listSnapshotDependencies: (buildId) => api.listSnapshotDependencies(buildId),

--- a/src/teamcity/types/client.ts
+++ b/src/teamcity/types/client.ts
@@ -148,10 +148,11 @@ export interface TeamCityClientAdapter extends TeamCityUnifiedClient {
       logBuildUsage?: boolean;
     }
   ) => Promise<AxiosResponse<unknown>>;
-  downloadArtifactContent: (
+  downloadArtifactContent: <T = ArrayBuffer>(
     buildId: string,
-    artifactPath: string
-  ) => Promise<AxiosResponse<ArrayBuffer>>;
+    artifactPath: string,
+    options?: RawAxiosRequestConfig
+  ) => Promise<AxiosResponse<T>>;
   getBuildStatistics: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
   listChangesForBuild: (buildId: string, fields?: string) => Promise<AxiosResponse<unknown>>;
   listSnapshotDependencies: (buildId: string) => Promise<AxiosResponse<unknown>>;

--- a/tests/integration/dev-tools-list.test.ts
+++ b/tests/integration/dev-tools-list.test.ts
@@ -22,6 +22,7 @@ const EXPECTED_DEV_TOOLS = new Set([
   'get_build_status',
   'fetch_build_log',
   'get_build_results',
+  'download_build_artifact',
   'analyze_build_problems',
   // Changes & diagnostics
   'list_changes',

--- a/tests/integration/download-artifact-streaming.test.ts
+++ b/tests/integration/download-artifact-streaming.test.ts
@@ -1,0 +1,230 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from '@jest/globals';
+
+import type { ActionResult, BuildRef, TriggerBuildResult } from '../types/tool-results';
+import { callTool, callToolsBatch } from './lib/mcp-runner';
+
+const hasTeamCityEnv = Boolean(
+  (process.env['TEAMCITY_URL'] ?? process.env['TEAMCITY_SERVER_URL']) &&
+    (process.env['TEAMCITY_TOKEN'] ?? process.env['TEAMCITY_API_TOKEN'])
+);
+
+const ts = Date.now();
+const PROJECT_ID = `E2E_ARTIFACT_${ts}`;
+const PROJECT_NAME = `E2E Artifact ${ts}`;
+const BT_ID = `E2E_ARTIFACT_BT_${ts}`;
+const BT_NAME = `E2E Artifact BuildType ${ts}`;
+
+let buildId: string | undefined;
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface DownloadArtifactResponse {
+  name?: string;
+  path?: string;
+  size?: number;
+  mimeType?: string;
+  encoding?: string;
+  content?: string;
+  outputPath?: string;
+  bytesWritten?: number;
+  success?: boolean;
+  error?: { message?: string } | string;
+}
+
+async function waitForBuildCompletion(id: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for build ${id} to finish`);
+    }
+
+    let status: { state?: string; status?: string } | null = null;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      status = await callTool<{ state?: string; status?: string }>('dev', 'get_build_status', {
+        buildId: id,
+        includeProblems: true,
+        includeTests: false,
+      });
+    } catch (error) {
+      // Allow transient errors (e.g., build yet to be registered) before timing out.
+      // eslint-disable-next-line no-console
+      console.warn(`Polling build status failed: ${error}`);
+    }
+
+    const state = String(status?.state ?? '');
+    if (state === 'finished') {
+      const outcome = String(status?.status ?? 'UNKNOWN');
+      if (outcome !== 'SUCCESS') {
+        throw new Error(`Build ${id} finished with status ${outcome}`);
+      }
+      return;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await wait(5_000);
+  }
+}
+
+describe('download_build_artifact tool (integration)', () => {
+  afterAll(async () => {
+    if (!hasTeamCityEnv) return;
+    try {
+      await callTool('full', 'delete_project', { projectId: PROJECT_ID });
+    } catch (_err) {
+      /* swallow cleanup errors */
+    }
+  });
+
+  it('creates project and build configuration (full)', async () => {
+    if (!hasTeamCityEnv) return expect(true).toBe(true);
+
+    const batch = await callToolsBatch('full', [
+      {
+        tool: 'create_project',
+        args: {
+          id: PROJECT_ID,
+          name: PROJECT_NAME,
+        },
+      },
+      {
+        tool: 'create_build_config',
+        args: {
+          projectId: PROJECT_ID,
+          id: BT_ID,
+          name: BT_NAME,
+          description: 'Integration scenario for artifact downloads',
+        },
+      },
+      {
+        tool: 'manage_build_steps',
+        args: {
+          buildTypeId: BT_ID,
+          action: 'add',
+          name: 'create-artifact',
+          type: 'simpleRunner',
+          properties: {
+            'script.content':
+              "echo artifact-content > artifact.txt && echo ##teamcity[publishArtifacts 'artifact.txt']",
+          },
+        },
+      },
+    ]);
+
+    expect(batch.completed).toBe(true);
+    expect(batch.results).toHaveLength(3);
+
+    const [projectStep, buildConfigStep, stepStep] = batch.results;
+    const project = projectStep?.result as ActionResult | undefined;
+    const buildConfig = buildConfigStep?.result as ActionResult | undefined;
+    const step = stepStep?.result as ActionResult | undefined;
+
+    expect(projectStep?.ok).toBe(true);
+    expect(project).toMatchObject({ success: true, action: 'create_project' });
+
+    expect(buildConfigStep?.ok).toBe(true);
+    expect(buildConfig).toMatchObject({ success: true, action: 'create_build_config' });
+
+    expect(stepStep?.ok).toBe(true);
+    expect(step).toMatchObject({ success: true, action: 'add_build_step' });
+
+    try {
+      const update = await callTool<ActionResult>('full', 'update_build_config', {
+        buildTypeId: BT_ID,
+        artifactRules: 'artifact.txt',
+      });
+      expect(update).toMatchObject({ success: true });
+    } catch (_err) {
+      // Some TeamCity servers restrict artifactRules updates; proceed if it fails.
+      expect(true).toBe(true);
+    }
+  }, 60_000);
+
+  it('runs build and waits for completion', async () => {
+    if (!hasTeamCityEnv) return expect(true).toBe(true);
+
+    const trigger = await callTool<TriggerBuildResult>('dev', 'trigger_build', {
+      buildTypeId: BT_ID,
+      comment: 'integration-download-artifact',
+    });
+    expect(trigger).toMatchObject({ success: true, action: 'trigger_build' });
+    buildId = trigger.buildId;
+    expect(typeof buildId).toBe('string');
+    if (!buildId) return expect(true).toBe(true);
+
+    // Ensure build number is fetched (also waits briefly before polling status)
+    const buildRef = await callTool<BuildRef>('dev', 'get_build', { buildId });
+    expect(buildRef.id ?? buildRef.number ?? buildId).toBeDefined();
+
+    await waitForBuildCompletion(buildId, 60_000);
+  }, 120_000);
+
+  it('downloads artifact as base64 payload (dev)', async () => {
+    if (!hasTeamCityEnv) return expect(true).toBe(true);
+    if (!buildId) return expect(true).toBe(true);
+
+    const result = await callTool<DownloadArtifactResponse>('dev', 'download_build_artifact', {
+      buildId,
+      artifactPath: 'artifact.txt',
+      encoding: 'base64',
+    });
+
+    if (result.success === false) {
+      const message =
+        typeof result.error === 'object' && result.error?.message
+          ? String(result.error.message)
+          : String(result.error ?? '');
+      if (message.includes('Artifact not found') || message.includes('Failed to fetch artifacts')) {
+        expect(true).toBe(true);
+        return;
+      }
+      throw new Error(`download_build_artifact (base64) failed: ${message}`);
+    }
+
+    expect(result.encoding).toBe('base64');
+    const content = String(result.content ?? '');
+    const decoded = Buffer.from(content, 'base64').toString('utf8').trim();
+    expect(decoded).toBe('artifact-content');
+  }, 60_000);
+
+  it('streams artifact to disk (dev)', async () => {
+    if (!hasTeamCityEnv) return expect(true).toBe(true);
+    if (!buildId) return expect(true).toBe(true);
+
+    const outputPath = join(tmpdir(), `artifact-download-${Date.now()}.txt`);
+
+    const result = await callTool<DownloadArtifactResponse>('dev', 'download_build_artifact', {
+      buildId,
+      artifactPath: 'artifact.txt',
+      encoding: 'stream',
+      outputPath,
+    });
+
+    if (result.success === false) {
+      const message =
+        typeof result.error === 'object' && result.error?.message
+          ? String(result.error.message)
+          : String(result.error ?? '');
+      if (message.includes('Artifact not found') || message.includes('Failed to fetch artifacts')) {
+        await fs.rm(outputPath, { force: true });
+        expect(true).toBe(true);
+        return;
+      }
+      await fs.rm(outputPath, { force: true });
+      throw new Error(`download_build_artifact (stream) failed: ${message}`);
+    }
+
+    expect(result.encoding).toBe('stream');
+    expect(result.outputPath).toBe(outputPath);
+
+    const written = await fs.readFile(outputPath, 'utf8');
+    expect(written.trim()).toBe('artifact-content');
+
+    await fs.rm(outputPath, { force: true });
+  }, 60_000);
+});

--- a/tests/test-utils/mock-teamcity-client.ts
+++ b/tests/test-utils/mock-teamcity-client.ts
@@ -188,14 +188,16 @@ export class MockTeamCityClient implements TeamCityClientAdapter {
   public readonly getBuildType: jest.Mock;
   public readonly listTestFailures: jest.Mock;
   public readonly listBuildArtifacts: jest.Mock;
-  public readonly downloadArtifactContent: jest.Mock;
+  public readonly downloadArtifactContent: jest.MockedFunction<
+    TeamCityClientAdapter['downloadArtifactContent']
+  >;
   public readonly getBuildStatistics: jest.Mock;
   public readonly listChangesForBuild: jest.Mock;
   public readonly listSnapshotDependencies: jest.Mock;
   public readonly listVcsRoots: jest.Mock;
   public readonly listAgents: jest.Mock;
   public readonly listAgentPools: jest.Mock;
-  private readonly adapterMockFns: jest.Mock[];
+  private readonly adapterMockFns: Array<{ mockReset: () => void; mockClear: () => void }>;
 
   constructor(overrides?: Partial<MockTeamCityModules>) {
     this.mockModules = {
@@ -291,7 +293,9 @@ export class MockTeamCityClient implements TeamCityClientAdapter {
     this.getBuildType = jest.fn();
     this.listTestFailures = jest.fn();
     this.listBuildArtifacts = jest.fn();
-    this.downloadArtifactContent = jest.fn();
+    this.downloadArtifactContent = jest.fn() as jest.MockedFunction<
+      TeamCityClientAdapter['downloadArtifactContent']
+    >;
     this.getBuildStatistics = jest.fn();
     this.listChangesForBuild = jest.fn();
     this.listSnapshotDependencies = jest.fn();

--- a/tests/unit/teamcity/client-adapter.test.ts
+++ b/tests/unit/teamcity/client-adapter.test.ts
@@ -176,7 +176,12 @@ describe('createAdapterFromTeamCityAPI', () => {
     expect(listBuildArtifacts).toHaveBeenCalledWith('42', undefined);
 
     await adapter.downloadArtifactContent('42', 'foo.zip');
-    expect(downloadBuildArtifact).toHaveBeenCalledWith('42', 'foo.zip');
+    expect(downloadBuildArtifact).toHaveBeenCalledWith('42', 'foo.zip', undefined);
+
+    await adapter.downloadArtifactContent('42', 'foo.zip', { responseType: 'stream' });
+    expect(downloadBuildArtifact).toHaveBeenCalledWith('42', 'foo.zip', {
+      responseType: 'stream',
+    });
 
     await adapter.getBuildStatistics('42', 'data');
     expect(getBuildStatistics).toHaveBeenCalledWith('42', 'data');

--- a/tests/unit/tools/download-artifact.test.ts
+++ b/tests/unit/tools/download-artifact.test.ts
@@ -1,0 +1,133 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+
+// Mock config to keep tools in dev mode without reading env
+jest.mock('@/config', () => ({
+  getTeamCityUrl: () => 'https://example.test',
+  getTeamCityToken: () => 'token',
+  getMCPMode: () => 'dev',
+}));
+
+jest.mock('@/utils/logger/index', () => ({
+  getLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    generateRequestId: () => 'test-request',
+    logToolExecution: jest.fn(),
+  }),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+describe('tools: download_build_artifact', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('returns base64 content when requested encoding is base64', async () => {
+    const downloadArtifact = jest.fn().mockResolvedValue({
+      name: 'artifact.bin',
+      path: 'artifact.bin',
+      size: 12,
+      content: Buffer.from('hello world!').toString('base64'),
+      mimeType: 'application/octet-stream',
+    });
+
+    const ArtifactManager = jest.fn().mockImplementation(() => ({ downloadArtifact }));
+    const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue({});
+    const getInstance = jest.fn().mockReturnValue({});
+
+    jest.doMock('@/teamcity/artifact-manager', () => ({ ArtifactManager }));
+    jest.doMock('@/teamcity/client-adapter', () => ({ createAdapterFromTeamCityAPI }));
+    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance } }));
+
+    let handler:
+      | ((args: unknown) => Promise<{ content?: Array<{ text?: string }>; success?: boolean }>)
+      | undefined;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getRequiredTool } = require('@/tools');
+      handler = getRequiredTool('download_build_artifact').handler;
+    });
+
+    if (!handler) {
+      throw new Error('download_build_artifact handler not found');
+    }
+
+    const response = await handler({
+      buildId: '123',
+      artifactPath: 'artifact.bin',
+      encoding: 'base64',
+    });
+
+    const payload = JSON.parse(response.content?.[0]?.text ?? '{}');
+    expect(payload.encoding).toBe('base64');
+    expect(payload.content).toBe(Buffer.from('hello world!').toString('base64'));
+    expect(downloadArtifact).toHaveBeenCalledWith('123', 'artifact.bin', {
+      encoding: 'base64',
+      maxSize: undefined,
+    });
+  });
+
+  it('streams artifact content to the requested output path', async () => {
+    const chunks = ['hello', ' ', 'mcp'];
+    const stream = Readable.from(chunks);
+    const downloadArtifact = jest.fn().mockResolvedValue({
+      name: 'logs/build.log',
+      path: 'logs/build.log',
+      size: 11,
+      content: stream,
+      mimeType: 'text/plain',
+    });
+
+    const ArtifactManager = jest.fn().mockImplementation(() => ({ downloadArtifact }));
+    const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue({});
+    const getInstance = jest.fn().mockReturnValue({});
+
+    jest.doMock('@/teamcity/artifact-manager', () => ({ ArtifactManager }));
+    jest.doMock('@/teamcity/client-adapter', () => ({ createAdapterFromTeamCityAPI }));
+    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance } }));
+
+    const targetPath = join(tmpdir(), `artifact-stream-${Date.now()}.log`);
+
+    let handler:
+      | ((args: unknown) => Promise<{ content?: Array<{ text?: string }>; success?: boolean }>)
+      | undefined;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getRequiredTool } = require('@/tools');
+      handler = getRequiredTool('download_build_artifact').handler;
+    });
+
+    if (!handler) {
+      throw new Error('download_build_artifact handler not found');
+    }
+
+    const response = await handler({
+      buildId: '456',
+      artifactPath: 'logs/build.log',
+      encoding: 'stream',
+      outputPath: targetPath,
+    });
+
+    const payload = JSON.parse(response.content?.[0]?.text ?? '{}');
+    expect(payload.encoding).toBe('stream');
+    expect(payload.outputPath).toBe(targetPath);
+    expect(downloadArtifact).toHaveBeenCalledWith('456', 'logs/build.log', {
+      encoding: 'stream',
+      maxSize: undefined,
+    });
+
+    const written = await fs.readFile(targetPath, 'utf8');
+    expect(written).toBe(chunks.join(''));
+
+    await fs.rm(targetPath, { force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add an opt-in streaming code path to `ArtifactManager.downloadArtifact` while keeping buffered responses as the default
- plumb raw axios options through the TeamCity client adapter so callers can request streamed artifacts without touching the http instance
- document usage expectations and extend unit coverage for the new streaming branch

## Testing
- npm run lint:check
- npm run test:unit -- --watch=false

Closes #151.
