### PR TITLE
feat(teamcity): add streaming artifact downloads

### DIFF
--- a/tests/integration/artifact-rules-update-scenario.test.ts
+++ b/tests/integration/artifact-rules-update-scenario.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import type { ActionResult } from '../types/tool-results';
-import { callTool } from './lib/mcp-runner';
+import { callTool, callToolsBatchExpect } from './lib/mcp-runner';
 
 const hasTeamCityEnv = Boolean(
   (process.env['TEAMCITY_URL'] ?? process.env['TEAMCITY_SERVER_URL']) &&
@@ -17,18 +17,30 @@ const BT_NAME = `E2E Artifact BuildType ${ts}`;
 describe('Artifact rules update (full) basic smoke', () => {
   it('creates project and build config (full)', async () => {
     if (!hasTeamCityEnv) return expect(true).toBe(true);
-    const cproj = await callTool<ActionResult>('full', 'create_project', {
-      id: PROJECT_ID,
-      name: PROJECT_NAME,
-    });
-    expect(cproj).toMatchObject({ success: true, action: 'create_project' });
-    const cbt = await callTool<ActionResult>('full', 'create_build_config', {
-      projectId: PROJECT_ID,
-      id: BT_ID,
-      name: BT_NAME,
-      description: 'Artifact rules scenario',
-    });
-    expect(cbt).toMatchObject({ success: true, action: 'create_build_config' });
+    const results = await callToolsBatchExpect('full', [
+      {
+        tool: 'create_project',
+        args: {
+          id: PROJECT_ID,
+          name: PROJECT_NAME,
+        },
+      },
+      {
+        tool: 'create_build_config',
+        args: {
+          projectId: PROJECT_ID,
+          id: BT_ID,
+          name: BT_NAME,
+          description: 'Artifact rules scenario',
+        },
+      },
+    ]);
+
+    const projectResult = results[0]?.result as ActionResult | undefined;
+    const buildConfigResult = results[1]?.result as ActionResult | undefined;
+
+    expect(projectResult).toMatchObject({ success: true, action: 'create_project' });
+    expect(buildConfigResult).toMatchObject({ success: true, action: 'create_build_config' });
   }, 60000);
 
   it('updates artifactRules (full) without error', async () => {

--- a/tests/integration/parameters-scenario.test.ts
+++ b/tests/integration/parameters-scenario.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import type { ActionResult } from '../types/tool-results';
-import { callTool } from './lib/mcp-runner';
+import { callTool, callToolsBatchExpect } from './lib/mcp-runner';
 
 const hasTeamCityEnv = Boolean(
   (process.env['TEAMCITY_URL'] ?? process.env['TEAMCITY_SERVER_URL']) &&
@@ -24,17 +24,29 @@ describe('Parameters lifecycle: full writes + dev reads', () => {
   });
   it('creates project and build config (full)', async () => {
     if (!hasTeamCityEnv) return expect(true).toBe(true);
-    const cproj = await callTool<ActionResult>('full', 'create_project', {
-      id: PROJECT_ID,
-      name: PROJECT_NAME,
-    });
-    expect(cproj).toMatchObject({ success: true, action: 'create_project' });
-    const cbt = await callTool<ActionResult>('full', 'create_build_config', {
-      projectId: PROJECT_ID,
-      id: BT_ID,
-      name: BT_NAME,
-    });
-    expect(cbt).toMatchObject({ success: true, action: 'create_build_config' });
+    const results = await callToolsBatchExpect('full', [
+      {
+        tool: 'create_project',
+        args: {
+          id: PROJECT_ID,
+          name: PROJECT_NAME,
+        },
+      },
+      {
+        tool: 'create_build_config',
+        args: {
+          projectId: PROJECT_ID,
+          id: BT_ID,
+          name: BT_NAME,
+        },
+      },
+    ]);
+
+    const projectResult = results[0]?.result as ActionResult | undefined;
+    const buildConfigResult = results[1]?.result as ActionResult | undefined;
+
+    expect(projectResult).toMatchObject({ success: true, action: 'create_project' });
+    expect(buildConfigResult).toMatchObject({ success: true, action: 'create_build_config' });
   }, 60000);
 
   it('lists parameters (dev) → smoke shape', async () => {

--- a/tests/integration/triggers-scenario.test.ts
+++ b/tests/integration/triggers-scenario.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import type { ActionResult, BuildTypeSummary, ListResult } from '../types/tool-results';
-import { callTool } from './lib/mcp-runner';
+import { callTool, callToolsBatchExpect } from './lib/mcp-runner';
 
 const ts = Date.now();
 const PROJECT_ID = `E2E_TRIG_${ts}`;
@@ -25,17 +25,22 @@ describe('Build triggers: add and delete (full) with dev verification', () => {
   });
   it('creates project and build config (full)', async () => {
     if (!hasTeamCityEnv) return expect(true).toBe(true);
-    const cproj = await callTool<ActionResult>('full', 'create_project', {
-      id: PROJECT_ID,
-      name: PROJECT_NAME,
-    });
-    expect(cproj).toMatchObject({ success: true, action: 'create_project' });
-    const cbt = await callTool<ActionResult>('full', 'create_build_config', {
-      projectId: PROJECT_ID,
-      id: BT_ID,
-      name: BT_NAME,
-    });
-    expect(cbt).toMatchObject({ success: true, action: 'create_build_config' });
+    const results = await callToolsBatchExpect('full', [
+      {
+        tool: 'create_project',
+        args: { id: PROJECT_ID, name: PROJECT_NAME },
+      },
+      {
+        tool: 'create_build_config',
+        args: { projectId: PROJECT_ID, id: BT_ID, name: BT_NAME },
+      },
+    ]);
+
+    const projectResult = results[0]?.result as ActionResult | undefined;
+    const buildConfigResult = results[1]?.result as ActionResult | undefined;
+
+    expect(projectResult).toMatchObject({ success: true, action: 'create_project' });
+    expect(buildConfigResult).toMatchObject({ success: true, action: 'create_build_config' });
   }, 60000);
 
   it('adds a vcs trigger (full) and verifies via list_build_configs (dev)', async () => {


### PR DESCRIPTION
## Summary
- Extend `ArtifactManager`/MCP toolchain with “stream” support, returning `Readable` streams while keeping buffered downloads as the default.
- Introduce `download_build_artifact`, document the streaming option, and cover it with targeted unit tests.
- Batch integration setup/teardown calls (project/build/step, etc.) to reuse a single MCP session, reducing runner spawn overhead.
- Harden integration scenarios (including streaming artifact download) with queue promotion, faster polling, and tolerant checks for optional APIs.

## Testing
- npm run lint:check
- npm run test:unit -- --watch=false
- npm run test:integration -- --watch=false

Closes #151.
