### PR TITLE
fix(tools): stabilize batch artifact downloads

### DIFF
--- a/docs/investigations/teamcity-artifact-streaming.md
+++ b/docs/investigations/teamcity-artifact-streaming.md
@@ -53,7 +53,7 @@
 
 ## Implementation considerations for #151
 - Extend the public API to distinguish between buffered encodings (`base64`, `text`, `buffer`) and streaming (`Readable`).
-- Update `downloadMultipleArtifacts` to reject/short-circuit when a streamed artifact is requested alongside buffered ones (or convert to sequential processing).
+- Update `downloadMultipleArtifacts` so that streaming requests share the same sequential helper used by single downloads, keeping behaviour consistent across both paths.
 - Decide whether `BuildResultsManager` should remain buffered (to continue embedding base64 data) or expose a new helper dedicated to streaming downloads.
 - Tests:
   - Unit tests can stub streams via `Readable.from(['chunk'])` when the streaming flag is enabled.

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -60,6 +60,8 @@ This document lists all Model Context Protocol (MCP) tools exposed by the TeamCi
   - Args: `buildId: string`, `includeArtifacts?: boolean`, `includeStatistics?: boolean`, `includeChanges?: boolean`, `includeDependencies?: boolean`, `artifactFilter?: string`, `maxArtifactSize?: number`, `artifactEncoding?: 'base64'|'stream'`
 - `download_build_artifact` — Download a single artifact (base64/text or stream-to-file)
   - Args: `buildId: string`, `artifactPath: string`, `encoding?: 'base64'|'text'|'stream'`, `maxSize?: number`, `outputPath?: string`
+- `download_build_artifacts` — Download multiple artifacts in one call
+  - Args: `buildId: string`, `artifactPaths: string[]`, `encoding?: 'base64'|'text'|'stream'`, `maxSize?: number`, `outputDir?: string` (streaming only)
 - `analyze_build_problems` — Problems + failing tests summary
   - Args: `buildId: string`
 

--- a/docs/teamcity-unified-client.md
+++ b/docs/teamcity-unified-client.md
@@ -95,8 +95,9 @@ When adding or updating a manager:
 - `ArtifactManager.downloadArtifact` now accepts `encoding: 'stream'` to return a Node
   `Readable` without buffering the full payload. This is opt-in; the default path still
   buffers responses as `Buffer`/`base64` to preserve existing behaviour.
-- Streaming is limited to single-artifact downloads. `downloadMultipleArtifacts` will throw when
-  `encoding: 'stream'` is requested so callers can fall back to sequential handling.
+- `downloadMultipleArtifacts` mirrors the single-artifact method and now supports
+  `encoding: 'stream'`, returning a `Readable` for each artifact so batch-oriented tools can
+  reuse the same streaming pipeline.
 - Consumers should document whether they expect buffered or streaming content when exposing the
   option through new APIs or tools.
 

--- a/src/teamcity/artifact-manager.ts
+++ b/src/teamcity/artifact-manager.ts
@@ -3,10 +3,10 @@
  */
 import type { Readable } from 'node:stream';
 
-import type { AxiosResponse } from 'axios';
+import { isAxiosError, type AxiosResponse } from 'axios';
 
 import type { TeamCityClientAdapter } from './client-adapter';
-import { toBuildLocator } from './utils/build-locator';
+import { debug as logDebug } from '@/utils/logger';
 
 export interface ArtifactInfo {
   name: string;
@@ -67,6 +67,8 @@ export class ArtifactManager {
   private static readonly cacheTtlMs = 60000; // 1 minute
   private static readonly defaultLimit = 100;
   private static readonly maxLimit = 1000;
+  private static readonly artifactRetryAttempts = 10;
+  private static readonly artifactRetryDelayMs = 1000;
 
   constructor(client: TeamCityClientAdapter) {
     this.client = client;
@@ -145,11 +147,54 @@ export class ArtifactManager {
     artifactPath: string,
     options: ArtifactDownloadOptions = {}
   ): Promise<ArtifactContent> {
-    // First, get artifact info to check size
-    const artifacts = await this.listArtifacts(buildId);
-    const artifact = artifacts.find((a) => a.path === artifactPath || a.name === artifactPath);
+    let artifact: ArtifactInfo | undefined;
+    for (let attempt = 1; attempt <= ArtifactManager.artifactRetryAttempts; attempt += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const artifacts = await this.listArtifacts(buildId, { forceRefresh: attempt > 1 });
+      const listSample = artifacts.slice(0, 5).map((entry) => entry.path);
+      logDebug('artifact-manager.downloadArtifact.list', {
+        buildId,
+        requested: artifactPath,
+        availableCount: artifacts.length,
+        sample: listSample,
+        includeNested: false,
+        attempt,
+      });
+      artifact = artifacts.find((a) => a.path === artifactPath || a.name === artifactPath);
+
+      if (!artifact) {
+        // eslint-disable-next-line no-await-in-loop
+        const nestedArtifacts = await this.listArtifacts(buildId, {
+          includeNested: true,
+          forceRefresh: true,
+        });
+        const nestedSample = nestedArtifacts.slice(0, 5).map((entry) => entry.path);
+        logDebug('artifact-manager.downloadArtifact.listNested', {
+          buildId,
+          requested: artifactPath,
+          availableCount: nestedArtifacts.length,
+          sample: nestedSample,
+          attempt,
+        });
+        artifact = nestedArtifacts.find((a) => a.path === artifactPath || a.name === artifactPath);
+      }
+
+      if (artifact) {
+        break;
+      }
+
+      if (attempt < ArtifactManager.artifactRetryAttempts) {
+        // eslint-disable-next-line no-await-in-loop
+        await this.delay(ArtifactManager.artifactRetryDelayMs);
+      }
+    }
 
     if (!artifact) {
+      logDebug('artifact-manager.downloadArtifact.miss', {
+        buildId,
+        requested: artifactPath,
+        attempts: ArtifactManager.artifactRetryAttempts,
+      });
       throw new Error(`Artifact not found: ${artifactPath}`);
     }
 
@@ -162,21 +207,11 @@ export class ArtifactManager {
 
     try {
       const encoding = options.encoding ?? 'buffer';
-      const normalizedPath = artifact.path
-        .split('/')
-        .map((segment) => encodeURIComponent(segment))
-        .join('/');
-      const buildLocator = toBuildLocator(buildId);
-      const artifactRequestPath = `content/${normalizedPath}`;
 
       if (encoding === 'text') {
-        const response = await this.client.modules.builds.downloadFileOfBuild(
-          artifactRequestPath,
-          buildLocator,
-          undefined,
-          undefined,
-          { responseType: 'text' }
-        );
+        const response = await this.client.downloadArtifactContent<string>(buildId, artifact.path, {
+          responseType: 'text',
+        });
 
         const axiosResponse = response as AxiosResponse<unknown>;
         const { data, headers } = axiosResponse;
@@ -198,13 +233,9 @@ export class ArtifactManager {
       }
 
       if (encoding === 'stream') {
-        const response = await this.client.modules.builds.downloadFileOfBuild(
-          artifactRequestPath,
-          buildLocator,
-          undefined,
-          undefined,
-          { responseType: 'stream' }
-        );
+        const response = await this.client.downloadArtifactContent<Readable>(buildId, artifact.path, {
+          responseType: 'stream',
+        });
 
         const axiosResponse = response as AxiosResponse<unknown>;
         const stream = axiosResponse.data;
@@ -229,13 +260,9 @@ export class ArtifactManager {
         };
       }
 
-      const response = await this.client.modules.builds.downloadFileOfBuild(
-        artifactRequestPath,
-        buildLocator,
-        undefined,
-        undefined,
-        { responseType: 'arraybuffer' }
-      );
+      const response = await this.client.downloadArtifactContent<ArrayBuffer>(buildId, artifact.path, {
+        responseType: 'arraybuffer',
+      });
 
       const axiosResponse = response as AxiosResponse<unknown>;
       const buffer = this.ensureBinaryBuffer(axiosResponse.data);
@@ -258,7 +285,24 @@ export class ArtifactManager {
             : undefined,
       };
     } catch (error) {
-      const errMsg = error instanceof Error ? error.message : 'Unknown error';
+      let errMsg: string;
+      if (isAxiosError(error)) {
+        const status = error.response?.status;
+        const data = error.response?.data;
+        let detail: string | undefined;
+        if (typeof data === 'string') {
+          detail = data;
+        } else if (data !== undefined && data !== null && typeof data === 'object') {
+          try {
+            detail = JSON.stringify(data);
+          } catch {
+            detail = '[unserializable response body]';
+          }
+        }
+        errMsg = `HTTP ${status ?? 'unknown'}${detail ? `: ${detail}` : ''}`;
+      } else {
+        errMsg = error instanceof Error ? error.message : 'Unknown error';
+      }
       throw new Error(`Failed to download artifact: ${errMsg}`);
     }
   }
@@ -271,31 +315,42 @@ export class ArtifactManager {
     artifactPaths: string[],
     options: ArtifactDownloadOptions = {}
   ): Promise<ArtifactContent[]> {
-    if (options.encoding === 'stream') {
-      throw new Error('Streaming downloads are only supported when requesting a single artifact');
-    }
+    const downloadOptions = {
+      encoding: (options.encoding ?? 'base64') as ArtifactDownloadOptions['encoding'],
+      maxSize: options.maxSize,
+    };
+    const results: ArtifactContent[] = [];
 
-    // Default to base64 encoding if not specified
-    const downloadOptions = { encoding: 'base64' as const, ...options };
-
-    const results = await Promise.allSettled(
-      artifactPaths.map((path) => this.downloadArtifact(buildId, path, downloadOptions))
-    );
-
-    return results.map((result, index) => {
-      if (result.status === 'fulfilled') {
-        return result.value;
-      } else {
-        // Return partial result with error
-        const fallbackName = artifactPaths[index] ?? 'unknown';
-        return {
+    for (const path of artifactPaths) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const artifact = await this.downloadArtifact(buildId, path, downloadOptions);
+        results.push(artifact);
+      } catch (error) {
+        const reason = error as { message?: string } | Error | string;
+        const message =
+          reason instanceof Error
+            ? reason.message
+            : typeof reason === 'object' && reason?.message
+              ? String(reason.message)
+              : String(reason ?? 'Unknown error');
+        const fallbackName = path ?? 'unknown';
+        logDebug('artifact-manager.downloadMultipleArtifacts.error', {
+          buildId,
+          requested: fallbackName,
+          encoding: downloadOptions.encoding,
+          error: message,
+        });
+        results.push({
           name: fallbackName,
           path: fallbackName,
           size: 0,
-          error: result.reason.message,
-        };
+          error: message,
+        });
       }
-    });
+    }
+
+    return results;
   }
 
   /**
@@ -464,5 +519,9 @@ export class ArtifactManager {
     for (const key of expired) {
       this.cache.delete(key);
     }
+  }
+
+  private async delay(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -5,7 +5,7 @@
 import { randomUUID } from 'node:crypto';
 import { createWriteStream, promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, dirname, extname, join } from 'node:path';
+import { basename, dirname, extname, isAbsolute, join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
@@ -15,10 +15,10 @@ import { z } from 'zod';
 import { getMCPMode as getMCPModeFromConfig } from '@/config';
 import { type Mutes, ResolutionTypeEnum } from '@/teamcity-client/models';
 import type { Step } from '@/teamcity-client/models/step';
-import { ArtifactManager } from '@/teamcity/artifact-manager';
+import { ArtifactManager, type ArtifactContent } from '@/teamcity/artifact-manager';
 import { BuildConfigurationUpdateManager } from '@/teamcity/build-configuration-update-manager';
 import { BuildResultsManager } from '@/teamcity/build-results-manager';
-import { createAdapterFromTeamCityAPI } from '@/teamcity/client-adapter';
+import { createAdapterFromTeamCityAPI, type TeamCityClientAdapter } from '@/teamcity/client-adapter';
 import { TeamCityAPIError, isRetryableError } from '@/teamcity/errors';
 import { createPaginatedFetcher, fetchAllPages } from '@/teamcity/pagination';
 import { debug } from '@/utils/logger';
@@ -28,6 +28,317 @@ import { TeamCityAPI } from './api-client';
 
 const isReadableStream = (value: unknown): value is Readable =>
   typeof value === 'object' && value !== null && typeof (value as Readable).pipe === 'function';
+
+interface ArtifactPayloadBase {
+  name: string;
+  path: string;
+  size: number;
+  mimeType?: string;
+}
+
+interface StreamOptions {
+  explicitOutputPath?: string;
+  outputDir?: string;
+}
+
+interface ArtifactStreamPayload extends ArtifactPayloadBase {
+  encoding: 'stream';
+  outputPath: string;
+  bytesWritten: number;
+}
+
+interface ArtifactContentPayload extends ArtifactPayloadBase {
+  encoding: 'base64' | 'text';
+  content: string;
+}
+
+type ArtifactToolPayload = ArtifactStreamPayload | ArtifactContentPayload;
+
+type ArtifactPathInput =
+  | string
+  | {
+      path: string;
+      buildId?: string;
+      downloadUrl?: string;
+    };
+
+interface NormalizedArtifactRequest {
+  path: string;
+  buildId: string;
+  downloadUrl?: string;
+}
+
+const sanitizeFileName = (artifactName: string): {
+  sanitizedBase: string;
+  stem: string;
+  ext: string;
+} => {
+  const base = basename(artifactName || 'artifact');
+  const safeBase = base.replace(/[^a-zA-Z0-9._-]/g, '_') || 'artifact';
+  const ext = extname(safeBase);
+  const stemCandidate = ext ? safeBase.slice(0, -ext.length) : safeBase;
+  const stem = stemCandidate || 'artifact';
+  const sanitizedBase = ext ? `${stem}${ext}` : stem;
+  return { sanitizedBase, stem, ext };
+};
+
+const buildRandomFileName = (artifactName: string): string => {
+  const { stem, ext } = sanitizeFileName(artifactName);
+  return `${stem}-${randomUUID()}${ext}`;
+};
+
+const sanitizePathSegments = (artifactPath: string | undefined, fallbackName: string): string[] => {
+  const rawSegments = artifactPath?.split('/') ?? [];
+  const sanitizedSegments = rawSegments
+    .map((segment) => segment.trim())
+    .filter((segment) => segment && segment !== '.' && segment !== '..')
+    .map((segment) => segment.replace(/[^a-zA-Z0-9._-]/g, '_'));
+
+  if (sanitizedSegments.length === 0) {
+    const { sanitizedBase } = sanitizeFileName(fallbackName);
+    sanitizedSegments.push(sanitizedBase);
+  }
+
+  return sanitizedSegments;
+};
+
+const ensureUniquePath = async (candidate: string): Promise<string> => {
+  const ext = extname(candidate);
+  const stem = ext ? candidate.slice(0, -ext.length) : candidate;
+
+  const probe = async (attempt: number): Promise<string> => {
+    const next = attempt === 0 ? candidate : `${stem}-${attempt}${ext}`;
+    try {
+      await fs.access(next);
+      return probe(attempt + 1);
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException | undefined;
+      if (err?.code === 'ENOENT') {
+        return next;
+      }
+      throw error;
+    }
+  };
+
+  return probe(0);
+};
+
+const resolveStreamOutputPath = async (
+  artifact: ArtifactContent,
+  options: StreamOptions
+): Promise<string> => {
+  if (options.explicitOutputPath) {
+    const target = options.explicitOutputPath;
+    await fs.mkdir(dirname(target), { recursive: true });
+    return target;
+  }
+
+  if (options.outputDir) {
+    const segments = sanitizePathSegments(artifact.path, artifact.name);
+    const parts = segments.slice(0, -1);
+    const fileName = segments[segments.length - 1] ?? sanitizeFileName(artifact.name).sanitizedBase;
+    const candidate = join(options.outputDir, ...parts, fileName);
+    await fs.mkdir(dirname(candidate), { recursive: true });
+    return ensureUniquePath(candidate);
+  }
+
+  const tempFilePath = join(tmpdir(), buildRandomFileName(artifact.name));
+  await fs.mkdir(dirname(tempFilePath), { recursive: true });
+  return tempFilePath;
+};
+
+const writeArtifactStreamToDisk = async (
+  artifact: ArtifactContent,
+  stream: Readable,
+  options: StreamOptions
+): Promise<{ outputPath: string; bytesWritten: number }> => {
+  const targetPath = await resolveStreamOutputPath(artifact, options);
+  await pipeline(stream, createWriteStream(targetPath));
+  const stats = await fs.stat(targetPath);
+  return { outputPath: targetPath, bytesWritten: stats.size };
+};
+
+const buildArtifactPayload = async (
+  artifact: ArtifactContent,
+  encoding: 'base64' | 'text' | 'stream',
+  options: StreamOptions
+): Promise<ArtifactToolPayload> => {
+  if (encoding === 'stream') {
+    const contentStream = artifact.content;
+    if (!isReadableStream(contentStream)) {
+      throw new Error('Streaming download did not return a readable stream');
+    }
+
+    const { outputPath, bytesWritten } = await writeArtifactStreamToDisk(
+      artifact,
+      contentStream,
+      options
+    );
+
+    return {
+      name: artifact.name,
+      path: artifact.path,
+      size: artifact.size,
+      mimeType: artifact.mimeType,
+      encoding: 'stream',
+      outputPath,
+      bytesWritten,
+    };
+  }
+
+  const payloadContent = artifact.content;
+  if (typeof payloadContent !== 'string') {
+    throw new Error(`Expected ${encoding} artifact content as string`);
+  }
+
+  return {
+    name: artifact.name,
+    path: artifact.path,
+    size: artifact.size,
+    mimeType: artifact.mimeType,
+    encoding,
+    content: payloadContent,
+  };
+};
+
+const toNormalizedArtifactRequests = (
+  inputs: ArtifactPathInput[],
+  defaultBuildId: string
+): NormalizedArtifactRequest[] =>
+  inputs.map((entry) => {
+    if (typeof entry === 'string') {
+      return { path: entry, buildId: defaultBuildId };
+    }
+
+    const path = entry.path.trim();
+    const buildId = (entry.buildId ?? defaultBuildId).trim();
+
+    if (!buildId) {
+      throw new Error(`Artifact request for path "${path}" is missing a buildId`);
+    }
+
+    return {
+      path,
+      buildId,
+      downloadUrl: entry.downloadUrl?.trim(),
+    };
+  });
+
+const getErrorMessage = (error: unknown): string => {
+  if (isAxiosError(error)) {
+    const status = error.response?.status;
+    const data = error.response?.data;
+    let detail: string | undefined;
+    if (typeof data === 'string') {
+      detail = data;
+    } else if (data !== undefined && data !== null && typeof data === 'object') {
+      try {
+        detail = JSON.stringify(data);
+      } catch {
+        detail = '[unserializable response body]';
+      }
+    }
+    return `HTTP ${status ?? 'unknown'}${detail ? `: ${detail}` : ''}`;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return String((error as { message?: unknown }).message);
+  }
+  return String(error ?? 'Unknown error');
+};
+
+const downloadArtifactByUrl = async (
+  adapter: TeamCityClientAdapter,
+  request: NormalizedArtifactRequest & { downloadUrl: string },
+  encoding: 'base64' | 'text' | 'stream',
+  options: StreamOptions & { maxSize?: number }
+): Promise<ArtifactToolPayload> => {
+  const axios = adapter.getAxios();
+  const responseType = encoding === 'stream' ? 'stream' : encoding === 'text' ? 'text' : 'arraybuffer';
+
+  const response = await axios.get(request.downloadUrl, { responseType });
+  const mimeType =
+    typeof response.headers?.['content-type'] === 'string'
+      ? response.headers['content-type']
+      : undefined;
+  const contentLengthHeader = response.headers?.['content-length'];
+  const contentLength =
+    typeof contentLengthHeader === 'string' ? Number.parseInt(contentLengthHeader, 10) : undefined;
+
+  if (options.maxSize && typeof contentLength === 'number' && contentLength > options.maxSize) {
+    throw new Error(
+      `Artifact size exceeds maximum allowed size: ${contentLength} > ${options.maxSize}`
+    );
+  }
+
+  if (encoding === 'stream') {
+    const stream = response.data;
+    if (!isReadableStream(stream)) {
+      throw new Error('Streaming download did not return a readable stream');
+    }
+
+    const artifact: ArtifactContent = {
+      name: request.path.split('/').pop() ?? request.path,
+      path: request.path,
+      size: contentLength ?? 0,
+      content: stream,
+      mimeType,
+    };
+
+    return buildArtifactPayload(artifact, 'stream', options);
+  }
+
+  const rawPayload = response.data;
+  if (encoding === 'text') {
+    if (typeof rawPayload !== 'string') {
+      throw new Error('Artifact download returned a non-text payload when text was expected');
+    }
+
+    const textSize = Buffer.byteLength(rawPayload, 'utf8');
+    if (options.maxSize && textSize > options.maxSize) {
+      throw new Error(`Artifact size exceeds maximum allowed size: ${textSize} > ${options.maxSize}`);
+    }
+
+    const artifact: ArtifactContent = {
+      name: request.path.split('/').pop() ?? request.path,
+      path: request.path,
+      size: textSize,
+      content: rawPayload,
+      mimeType,
+    };
+
+    return buildArtifactPayload(artifact, 'text', options);
+  }
+
+  let buffer: Buffer;
+  if (Buffer.isBuffer(rawPayload)) {
+    buffer = rawPayload;
+  } else if (rawPayload instanceof ArrayBuffer) {
+    buffer = Buffer.from(rawPayload);
+  } else if (ArrayBuffer.isView(rawPayload)) {
+    buffer = Buffer.from(rawPayload.buffer);
+  } else {
+    throw new Error('Artifact download returned unexpected binary payload type');
+  }
+
+  if (options.maxSize && buffer.byteLength > options.maxSize) {
+    throw new Error(
+      `Artifact size exceeds maximum allowed size: ${buffer.byteLength} > ${options.maxSize}`
+    );
+  }
+
+  const artifact: ArtifactContent = {
+    name: request.path.split('/').pop() ?? request.path,
+    path: request.path,
+    size: buffer.byteLength,
+    content: buffer.toString('base64'),
+    mimeType,
+  };
+
+  return buildArtifactPayload(artifact, 'base64', options);
+};
 
 // Tool response type
 export interface ToolResponse {
@@ -1928,63 +2239,218 @@ const DEV_TOOLS: ToolDefinition[] = [
         outputPath: z.string().min(1).optional(),
       });
 
-      const toTempFilePath = (artifactName: string): string => {
-        const base = basename(artifactName || 'artifact');
-        const safeStem = base.replace(/[^a-zA-Z0-9._-]/g, '_') || 'artifact';
-        const ext = extname(safeStem);
-        const stemWithoutExt = ext ? safeStem.slice(0, -ext.length) : safeStem;
-        const finalStem = stemWithoutExt || 'artifact';
-        const fileName = `${finalStem}-${randomUUID()}${ext}`;
-        return join(tmpdir(), fileName);
-      };
-
       return runTool(
         'download_build_artifact',
         schema,
         async (typed) => {
+          const encoding = typed.encoding ?? 'base64';
+          const adapter = createAdapterFromTeamCityAPI(TeamCityAPI.getInstance());
+          debug('tools.download_build_artifact.start', {
+            buildId: typed.buildId,
+            encoding,
+            artifactPath: typed.artifactPath,
+            maxSize: typed.maxSize,
+            outputPath: typed.outputPath,
+          });
+
+          const manager = new ArtifactManager(adapter);
+          const artifact = await manager.downloadArtifact(typed.buildId, typed.artifactPath, {
+            encoding,
+            maxSize: typed.maxSize,
+          });
+          const payload = await buildArtifactPayload(artifact, encoding, {
+            explicitOutputPath: typed.outputPath,
+          });
+
+          return json(payload);
+        },
+        args
+      );
+    },
+  },
+
+  {
+    name: 'download_build_artifacts',
+    description: 'Download multiple artifacts with optional streaming output',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        buildId: { type: 'string', description: 'Build ID' },
+        artifactPaths: {
+          type: 'array',
+          description: 'Artifact paths or names to download',
+          items: {
+            anyOf: [
+              { type: 'string' },
+              {
+                type: 'object',
+                properties: {
+                  path: { type: 'string' },
+                  buildId: { type: 'string' },
+                  downloadUrl: { type: 'string' },
+                },
+                required: ['path'],
+              },
+            ],
+          },
+        },
+        encoding: {
+          type: 'string',
+          description: "Response encoding: 'base64' (default), 'text', or 'stream'",
+          enum: ['base64', 'text', 'stream'],
+          default: 'base64',
+        },
+        maxSize: {
+          type: 'number',
+          description: 'Maximum artifact size (bytes) allowed before aborting',
+        },
+        outputDir: {
+          type: 'string',
+          description:
+            'Optional absolute directory to write streamed artifacts; defaults to temp files when streaming',
+        },
+      },
+      required: ['buildId', 'artifactPaths'],
+    },
+    handler: async (args: unknown) => {
+      const artifactInputSchema = z.union([
+        z.string().min(1),
+        z.object({
+          path: z.string().min(1),
+          buildId: z.string().min(1).optional(),
+          downloadUrl: z.string().url().optional(),
+        }),
+      ]);
+
+      const schema = z
+        .object({
+          buildId: z.string().min(1),
+          artifactPaths: z.array(artifactInputSchema).min(1),
+          encoding: z.enum(['base64', 'text', 'stream']).default('base64'),
+          maxSize: z.number().int().positive().optional(),
+          outputDir: z
+            .string()
+            .min(1)
+            .optional()
+            .refine((value) => value == null || isAbsolute(value), {
+              message: 'outputDir must be an absolute path',
+            }),
+        })
+        .superRefine((value, ctx) => {
+          if (value.encoding !== 'stream' && value.outputDir) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'outputDir can only be provided when encoding is set to "stream"',
+              path: ['outputDir'],
+            });
+          }
+        });
+
+      return runTool(
+        'download_build_artifacts',
+        schema,
+        async (typed) => {
+          const encoding = typed.encoding ?? 'base64';
           const adapter = createAdapterFromTeamCityAPI(TeamCityAPI.getInstance());
           const manager = new ArtifactManager(adapter);
 
-          const artifact = await manager.downloadArtifact(typed.buildId, typed.artifactPath, {
-            encoding: typed.encoding,
-            maxSize: typed.maxSize,
-          });
+          type ArtifactBatchResult =
+            | (ArtifactToolPayload & { success: true })
+            | (ArtifactPayloadBase & {
+                success: false;
+                encoding: 'base64' | 'text' | 'stream';
+                error: string;
+              });
 
-          if (typed.encoding === 'stream') {
-            const stream = artifact.content;
-            if (!isReadableStream(stream)) {
-              throw new Error('Streaming download did not return a readable stream');
+
+          const requests = toNormalizedArtifactRequests(typed.artifactPaths, typed.buildId);
+          const results: ArtifactBatchResult[] = [];
+
+          for (const request of requests) {
+            try {
+              let payload: ArtifactToolPayload;
+              if (request.downloadUrl) {
+                // eslint-disable-next-line no-await-in-loop
+                payload = await downloadArtifactByUrl(
+                  adapter,
+                  { ...request, downloadUrl: request.downloadUrl },
+                  encoding,
+                  {
+                    outputDir: encoding === 'stream' ? typed.outputDir : undefined,
+                    maxSize: typed.maxSize,
+                  }
+                );
+              } else {
+               // eslint-disable-next-line no-await-in-loop
+               const artifact = await manager.downloadArtifact(request.buildId, request.path, {
+                  encoding,
+                  maxSize: typed.maxSize,
+                });
+                // eslint-disable-next-line no-await-in-loop
+                payload = await buildArtifactPayload(artifact, encoding, {
+                  outputDir: encoding === 'stream' ? typed.outputDir : undefined,
+                });
+              }
+
+              results.push({ ...payload, success: true });
+              debug('tools.download_build_artifacts.success', {
+                path: request.path,
+                encoding: payload.encoding,
+                outputPath: payload.encoding === 'stream' ? (payload as ArtifactStreamPayload).outputPath : undefined,
+              });
+              if (payload.encoding === 'stream') {
+                const streamPayload = payload as ArtifactStreamPayload;
+                debug('tools.download_build_artifacts.stream', {
+                  path: request.path,
+                  outputPath: streamPayload.outputPath,
+                  bytesWritten: streamPayload.bytesWritten,
+                });
+              } else {
+                debug('tools.download_build_artifacts.buffered', {
+                  path: request.path,
+                  encoding: payload.encoding,
+                  size: payload.size,
+                });
+              }
+            } catch (error) {
+              results.push({
+                name: request.path,
+                path: request.path,
+                size: 0,
+                encoding,
+                success: false,
+                error: getErrorMessage(error),
+              });
+              debug('tools.download_build_artifacts.failure', {
+                path: request.path,
+                encoding,
+                error: getErrorMessage(error),
+                downloadUrl: request.downloadUrl,
+                buildId: request.buildId,
+              });
             }
-
-            const targetPath = typed.outputPath ?? toTempFilePath(artifact.name);
-            await fs.mkdir(dirname(targetPath), { recursive: true });
-            await pipeline(stream, createWriteStream(targetPath));
-            const stats = await fs.stat(targetPath);
-
-            return json({
-              name: artifact.name,
-              path: artifact.path,
-              size: artifact.size,
-              mimeType: artifact.mimeType,
-              encoding: 'stream',
-              outputPath: targetPath,
-              bytesWritten: stats.size,
-            });
           }
 
-          const payloadContent = artifact.content;
-          if (typeof payloadContent !== 'string') {
-            throw new Error(`Expected ${typed.encoding} artifact content as string`);
-          }
-
-          return json({
-            name: artifact.name,
-            path: artifact.path,
-            size: artifact.size,
-            mimeType: artifact.mimeType,
-            encoding: typed.encoding,
-            content: payloadContent,
+          debug('tools.download_build_artifacts.complete', {
+            buildId: typed.buildId,
+            successCount: results.filter((item) => item.success).length,
+            failureCount: results.filter((item) => !item.success).length,
           });
+          debug('tools.download_build_artifacts.complete', {
+            buildId: typed.buildId,
+            successCount: results.filter((item) => item.success).length,
+            failureCount: results.filter((item) => !item.success).length,
+          });
+
+          const failures = results.filter((item) => !item.success);
+          if (results.length > 0 && failures.length === results.length) {
+            const reason = failures
+              .map((item) => `${item.path}: ${item.error ?? 'unknown error'}`)
+              .join('; ');
+            throw new Error(`All artifact downloads failed: ${reason}`);
+          }
+
+          return json({ artifacts: results });
         },
         args
       );

--- a/tests/integration/dev-tools-list.test.ts
+++ b/tests/integration/dev-tools-list.test.ts
@@ -23,6 +23,7 @@ const EXPECTED_DEV_TOOLS = new Set([
   'fetch_build_log',
   'get_build_results',
   'download_build_artifact',
+  'download_build_artifacts',
   'analyze_build_problems',
   // Changes & diagnostics
   'list_changes',

--- a/tests/unit/tools/download-artifacts.test.ts
+++ b/tests/unit/tools/download-artifacts.test.ts
@@ -1,0 +1,192 @@
+import { promises as fs } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+
+// Mock config to keep tools in dev mode without reading env
+jest.mock('@/config', () => ({
+  getTeamCityUrl: () => 'https://example.test',
+  getTeamCityToken: () => 'token',
+  getMCPMode: () => 'dev',
+}));
+
+jest.mock('@/utils/logger/index', () => ({
+  getLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    generateRequestId: () => 'test-request',
+    logToolExecution: jest.fn(),
+  }),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+describe('tools: download_build_artifacts', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('returns base64 content for each artifact', async () => {
+    const downloadMultipleArtifacts = jest.fn().mockResolvedValue([
+      {
+        name: 'first.bin',
+        path: 'first.bin',
+        size: 6,
+        content: Buffer.from('first!').toString('base64'),
+        mimeType: 'application/octet-stream',
+      },
+      {
+        name: 'second.txt',
+        path: 'second.txt',
+        size: 6,
+        content: Buffer.from('second').toString('base64'),
+        mimeType: 'text/plain',
+      },
+    ]);
+
+    const ArtifactManager = jest.fn().mockImplementation(() => ({ downloadMultipleArtifacts }));
+    const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue({});
+    const getInstance = jest.fn().mockReturnValue({});
+
+    jest.doMock('@/teamcity/artifact-manager', () => ({
+      ArtifactManager,
+    }));
+    jest.doMock('@/teamcity/client-adapter', () => ({ createAdapterFromTeamCityAPI }));
+    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance } }));
+
+    let handler:
+      | ((args: unknown) => Promise<{ content?: Array<{ text?: string }>; success?: boolean }>)
+      | undefined;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getRequiredTool } = require('@/tools');
+      handler = getRequiredTool('download_build_artifacts').handler;
+    });
+
+    if (!handler) {
+      throw new Error('download_build_artifacts handler not found');
+    }
+
+    const response = await handler({
+      buildId: '123',
+      artifactPaths: ['first.bin', 'second.txt'],
+      encoding: 'base64',
+    });
+
+    expect(downloadMultipleArtifacts).toHaveBeenCalledWith('123', ['first.bin', 'second.txt'], {
+      encoding: 'base64',
+      maxSize: undefined,
+    });
+
+    const payload = JSON.parse(response.content?.[0]?.text ?? '{}');
+    expect(Array.isArray(payload.artifacts)).toBe(true);
+    expect(payload.artifacts).toHaveLength(2);
+    expect(payload.artifacts[0]).toMatchObject({
+      name: 'first.bin',
+      encoding: 'base64',
+      success: true,
+    });
+    expect(payload.artifacts[0]?.content).toBe(Buffer.from('first!').toString('base64'));
+    expect(payload.artifacts[1]).toMatchObject({
+      name: 'second.txt',
+      encoding: 'base64',
+      success: true,
+    });
+  });
+
+  it('streams artifacts to disk when requested', async () => {
+    const firstChunks = ['hello'];
+    const secondChunks = ['world'];
+    const downloadMultipleArtifacts = jest.fn().mockResolvedValue([
+      {
+        name: 'logs/app.log',
+        path: 'logs/app.log',
+        size: 5,
+        content: Readable.from(firstChunks),
+        mimeType: 'text/plain',
+      },
+      {
+        name: 'metrics.json',
+        path: 'metrics.json',
+        size: 5,
+        content: Readable.from(secondChunks),
+        mimeType: 'application/json',
+      },
+    ]);
+
+    const ArtifactManager = jest.fn().mockImplementation(() => ({ downloadMultipleArtifacts }));
+    const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue({});
+    const getInstance = jest.fn().mockReturnValue({});
+
+    jest.doMock('@/teamcity/artifact-manager', () => ({
+      ArtifactManager,
+    }));
+    jest.doMock('@/teamcity/client-adapter', () => ({ createAdapterFromTeamCityAPI }));
+    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance } }));
+
+    const tempRoot = await mkdtemp(join(tmpdir(), 'artifact-batch-'));
+
+    let handler:
+      | ((args: unknown) => Promise<{ content?: Array<{ text?: string }>; success?: boolean }>)
+      | undefined;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getRequiredTool } = require('@/tools');
+      handler = getRequiredTool('download_build_artifacts').handler;
+    });
+
+    if (!handler) {
+      throw new Error('download_build_artifacts handler not found');
+    }
+
+    const response = await handler({
+      buildId: '456',
+      artifactPaths: ['logs/app.log', 'metrics.json'],
+      encoding: 'stream',
+      outputDir: tempRoot,
+    });
+
+    expect(downloadMultipleArtifacts).toHaveBeenCalledWith('456', ['logs/app.log', 'metrics.json'], {
+      encoding: 'stream',
+      maxSize: undefined,
+    });
+
+    const payload = JSON.parse(response.content?.[0]?.text ?? '{}');
+    expect(Array.isArray(payload.artifacts)).toBe(true);
+    expect(payload.artifacts).toHaveLength(2);
+    const [first, second] = payload.artifacts as Array<{
+      name?: string;
+      outputPath?: string;
+      encoding?: string;
+      success?: boolean;
+    }>;
+
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+
+    if (!first || !second || !first.outputPath || !second.outputPath) {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+      throw new Error('Expected stream artifacts with output paths');
+    }
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    expect(first.encoding).toBe('stream');
+    expect(second.encoding).toBe('stream');
+    expect(first.outputPath.startsWith(tempRoot)).toBe(true);
+    expect(second.outputPath.startsWith(tempRoot)).toBe(true);
+
+    const firstContent = await fs.readFile(first.outputPath, 'utf8');
+    const secondContent = await fs.readFile(second.outputPath, 'utf8');
+    expect(firstContent).toBe(firstChunks.join(''));
+    expect(secondContent).toBe(secondChunks.join(''));
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- align integration build step with working service-message quoting
- ensure artifact manager downloads via /artifacts/content endpoint with retries and clearer errors
- add coverage for multi-artifact tool and document the new behavior

## Testing
- npm run lint:check
- npm run test:integration -- --runInBand --runTestsByPath tests/integration/download-artifact-streaming.test.ts