### PR TITLE
fix(teamcity): restore artifact rules update compatibility

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -16,7 +16,10 @@ import { getMCPMode as getMCPModeFromConfig } from '@/config';
 import { type Mutes, ResolutionTypeEnum } from '@/teamcity-client/models';
 import type { Step } from '@/teamcity-client/models/step';
 import { type ArtifactContent, ArtifactManager } from '@/teamcity/artifact-manager';
-import { BuildConfigurationUpdateManager } from '@/teamcity/build-configuration-update-manager';
+import {
+  BuildConfigurationUpdateManager,
+  setArtifactRulesWithFallback,
+} from '@/teamcity/build-configuration-update-manager';
 import { BuildResultsManager } from '@/teamcity/build-results-manager';
 import {
   type TeamCityClientAdapter,
@@ -3500,9 +3503,9 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
             );
           }
           if (typedArgs.artifactRules !== undefined) {
-            await adapter.modules.buildTypes.setBuildTypeField(
+            await setArtifactRulesWithFallback(
+              adapter.modules.buildTypes,
               typedArgs.buildTypeId,
-              'settings/artifactRules',
               typedArgs.artifactRules
             );
           }
@@ -3524,9 +3527,9 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
           );
         }
         if (typedArgs.artifactRules !== undefined) {
-          await adapter.modules.buildTypes.setBuildTypeField(
+          await setArtifactRulesWithFallback(
+            adapter.modules.buildTypes,
             typedArgs.buildTypeId,
-            'settings/artifactRules',
             typedArgs.artifactRules
           );
         }


### PR DESCRIPTION
## Summary
- add a reusable helper that retries artifact rules updates via the legacy endpoint when the settings path 400s
- wire the update_build_config tool to the helper so both code paths benefit
- extend unit and tool tests to cover the fallback behaviour

## Testing
- npm test -- tests/tools.update-build-config.test.ts
- npm test -- tests/unit/teamcity/build-configuration-update-manager.test.ts
- npm run lint:check

Closes #184
