### PR TITLE
fix(tools): resolve build results by number (GH-198)

### DIFF
--- a/tests/unit/teamcity/build-results-manager.test.ts
+++ b/tests/unit/teamcity/build-results-manager.test.ts
@@ -106,6 +106,24 @@ describe('BuildResultsManager', () => {
       expect(result.changes).toBeUndefined();
       expect(result.dependencies).toBeUndefined();
     });
+
+    it('throws TeamCityNotFoundError with locator context on 404', async () => {
+      const { TeamCityAPIError, TeamCityNotFoundError } = await import('@/teamcity/errors');
+      const notFound = new TeamCityAPIError('HTTP 404', 'HTTP_404', 404);
+      stub.modules.builds.getBuild.mockRejectedValue(notFound);
+
+      let captured: unknown;
+      try {
+        await manager.getBuildResults('987654');
+      } catch (err) {
+        captured = err;
+      }
+
+      expect(captured).toBeInstanceOf(TeamCityNotFoundError);
+      const error = captured as Error;
+      expect(error.message).toContain("'987654'");
+      expect((captured as { code?: string }).code).toBe('NOT_FOUND');
+    });
   });
 
   describe('fetchArtifacts', () => {


### PR DESCRIPTION
## Summary
- allow `get_build_results` to accept either a raw buildId or a buildTypeId+buildNumber locator and surface clearer 404 errors
- teach BuildResultsManager to translate TeamCity 404s into structured not-found errors that bubble up with context
- extend unit and integration coverage (including the build-results scenario) to cover the new locator path and friendly messaging

## Testing
- npm run test:unit -- --runTestsByPath tests/unit/tools/get-status-and-results.test.ts tests/unit/teamcity/build-results-manager.test.ts
- npm run test:unit
- npm run test:integration *(download-artifact streaming scenario needed one rerun to pass)*
- npm run test:integration -- --runTestsByPath tests/integration/download-artifact-streaming.test.ts

Closes #198
