### PR TITLE
feat(tools): add build config management tools (#216)

### DIFF
--- a/src/teamcity/agent-requirements-manager.ts
+++ b/src/teamcity/agent-requirements-manager.ts
@@ -1,0 +1,176 @@
+import type { RawAxiosRequestConfig } from 'axios';
+
+import type { AgentRequirement, Properties } from '@/teamcity-client/models';
+
+import type { TeamCityClientAdapter } from './types/client';
+
+type StringMap = Record<string, string>;
+
+interface ManageRequirementInput {
+  buildTypeId: string;
+  requirementId?: string;
+  properties?: Record<string, unknown>;
+  disabled?: boolean;
+}
+
+const JSON_HEADERS: RawAxiosRequestConfig = {
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
+};
+
+const JSON_GET_HEADERS: RawAxiosRequestConfig = {
+  headers: {
+    Accept: 'application/json',
+  },
+};
+
+const toStringRecord = (input?: Record<string, unknown>): StringMap => {
+  if (!input) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(input).map(([name, value]) => {
+      if (value === undefined || value === null) {
+        return [name, ''];
+      }
+      if (typeof value === 'boolean') {
+        return [name, value ? 'true' : 'false'];
+      }
+      return [name, String(value)];
+    })
+  );
+};
+
+const propertiesToRecord = (properties?: Properties | null): StringMap => {
+  if (properties == null) {
+    return {};
+  }
+  const propertyEntries = properties.property;
+  const items = Array.isArray(propertyEntries)
+    ? propertyEntries
+    : propertyEntries != null
+      ? [propertyEntries]
+      : [];
+  const record: StringMap = {};
+  for (const item of items) {
+    if (!item?.name) {
+      continue;
+    }
+    record[item.name] = item.value != null ? String(item.value) : '';
+  }
+  return record;
+};
+
+const recordToProperties = (record: StringMap): Properties | undefined => {
+  const entries = Object.entries(record);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return {
+    property: entries.map(([name, value]) => ({ name, value })),
+  };
+};
+
+const mergeRecords = (base: StringMap, override: StringMap): StringMap => ({
+  ...base,
+  ...override,
+});
+
+export class AgentRequirementsManager {
+  constructor(private readonly client: TeamCityClientAdapter) {}
+
+  async addRequirement(input: ManageRequirementInput): Promise<{ id: string }> {
+    const { buildTypeId } = input;
+    const payload = this.buildPayload(undefined, input);
+
+    const response = await this.client.modules.buildTypes.addAgentRequirementToBuildType(
+      buildTypeId,
+      undefined,
+      payload,
+      JSON_HEADERS
+    );
+
+    const id = response.data?.id;
+    if (!id) {
+      throw new Error('TeamCity did not return an agent requirement identifier.');
+    }
+    return { id };
+  }
+
+  async updateRequirement(
+    requirementId: string,
+    input: ManageRequirementInput
+  ): Promise<{ id: string }> {
+    const { buildTypeId } = input;
+    const existing = await this.fetchRequirement(buildTypeId, requirementId);
+    if (!existing) {
+      throw new Error(
+        `Agent requirement ${requirementId} was not found on ${buildTypeId}; verify the ID or update via the TeamCity UI.`
+      );
+    }
+
+    const payload = this.buildPayload(existing, input);
+    await this.client.modules.buildTypes.replaceAgentRequirement(
+      buildTypeId,
+      requirementId,
+      undefined,
+      payload,
+      JSON_HEADERS
+    );
+    return { id: requirementId };
+  }
+
+  async deleteRequirement(buildTypeId: string, requirementId: string): Promise<void> {
+    await this.client.modules.buildTypes.deleteAgentRequirement(
+      buildTypeId,
+      requirementId,
+      JSON_HEADERS
+    );
+  }
+
+  private async fetchRequirement(
+    buildTypeId: string,
+    requirementId: string
+  ): Promise<AgentRequirement | null> {
+    try {
+      const response = await this.client.modules.buildTypes.getAgentRequirement(
+        buildTypeId,
+        requirementId,
+        'id,type,disabled,properties(property(name,value))',
+        JSON_GET_HEADERS
+      );
+      return response.data as AgentRequirement;
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'response' in error &&
+        (error as { response?: { status?: number } }).response?.status === 404
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private buildPayload(
+    existing: AgentRequirement | undefined,
+    input: ManageRequirementInput
+  ): AgentRequirement {
+    const baseProps = propertiesToRecord(existing?.properties as Properties | undefined);
+    const mergedProps = mergeRecords(baseProps, toStringRecord(input.properties));
+    const payload: AgentRequirement = {
+      ...(existing ?? {}),
+      disabled: input.disabled ?? existing?.disabled,
+    };
+
+    const properties = recordToProperties(mergedProps);
+    if (properties) {
+      payload.properties = properties;
+    }
+
+    return payload;
+  }
+}

--- a/src/teamcity/build-dependency-manager.ts
+++ b/src/teamcity/build-dependency-manager.ts
@@ -1,0 +1,286 @@
+import type { AxiosResponse, RawAxiosRequestConfig } from 'axios';
+
+import type { ArtifactDependency, Properties, SnapshotDependency } from '@/teamcity-client/models';
+
+import type { TeamCityClientAdapter } from './types/client';
+
+type DependencyResource = ArtifactDependency | SnapshotDependency;
+
+type DependencyType = 'artifact' | 'snapshot';
+
+type StringMap = Record<string, string>;
+
+type ManageDependencyInput = {
+  buildTypeId: string;
+  dependencyType: DependencyType;
+  dependsOn?: string;
+  properties?: Record<string, unknown>;
+  type?: string;
+  disabled?: boolean;
+};
+
+const JSON_HEADERS: RawAxiosRequestConfig = {
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
+};
+
+const JSON_GET_HEADERS: RawAxiosRequestConfig = {
+  headers: {
+    Accept: 'application/json',
+  },
+};
+
+const defaultTypeFor = (dependencyType: DependencyType): string | undefined => {
+  switch (dependencyType) {
+    case 'artifact':
+      return undefined;
+    case 'snapshot':
+      return undefined;
+    default:
+      return undefined;
+  }
+};
+
+const toStringRecord = (input?: Record<string, unknown>): StringMap => {
+  if (!input) {
+    return {};
+  }
+  const entries = Object.entries(input).map(([name, value]) => {
+    if (value === undefined || value === null) {
+      return [name, ''];
+    }
+    if (typeof value === 'boolean') {
+      return [name, value ? 'true' : 'false'];
+    }
+    return [name, String(value)];
+  });
+  return Object.fromEntries(entries);
+};
+
+const propertiesToRecord = (properties?: Properties | null): StringMap => {
+  if (properties == null) {
+    return {};
+  }
+  const propertyEntries = properties.property;
+  const collection = Array.isArray(propertyEntries)
+    ? propertyEntries
+    : propertyEntries != null
+      ? [propertyEntries]
+      : [];
+  const map: StringMap = {};
+  for (const item of collection) {
+    if (!item?.name) {
+      continue;
+    }
+    map[item.name] = item.value != null ? String(item.value) : '';
+  }
+  return map;
+};
+
+const recordToProperties = (record: StringMap): Properties | undefined => {
+  const entries = Object.entries(record);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return {
+    property: entries.map(([name, value]) => ({ name, value })),
+  };
+};
+
+const mergeRecords = (base: StringMap, override: StringMap): StringMap => {
+  const merged: StringMap = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    merged[key] = value;
+  }
+  return merged;
+};
+
+export class BuildDependencyManager {
+  constructor(private readonly client: TeamCityClientAdapter) {}
+
+  async addDependency(input: ManageDependencyInput): Promise<{ id: string }> {
+    const { buildTypeId, dependencyType, dependsOn } = input;
+    if (!dependsOn || dependsOn.trim() === '') {
+      throw new Error(
+        'dependsOn is required when adding a dependency; specify the upstream build configuration ID or use the TeamCity UI.'
+      );
+    }
+
+    const payload = this.buildPayload(dependencyType, undefined, {
+      ...input,
+      dependsOn,
+    });
+
+    const response = await this.createDependency(dependencyType, buildTypeId, payload);
+
+    const id = response.data?.id;
+    if (!id) {
+      throw new Error('TeamCity did not return a dependency identifier. Verify server response.');
+    }
+
+    return { id };
+  }
+
+  async updateDependency(
+    dependencyId: string,
+    input: ManageDependencyInput
+  ): Promise<{ id: string }> {
+    const { buildTypeId, dependencyType } = input;
+    const existing = await this.fetchDependency(dependencyType, buildTypeId, dependencyId);
+    if (!existing) {
+      throw new Error(
+        `Dependency ${dependencyId} was not found on ${buildTypeId}; verify the identifier or update via the TeamCity UI.`
+      );
+    }
+
+    const payload = this.buildPayload(dependencyType, existing, input);
+    await this.replaceDependency(dependencyType, buildTypeId, dependencyId, payload);
+    return { id: dependencyId };
+  }
+
+  async deleteDependency(
+    dependencyType: DependencyType,
+    buildTypeId: string,
+    dependencyId: string
+  ): Promise<void> {
+    if (!dependencyId) {
+      throw new Error('dependencyId is required to delete a dependency.');
+    }
+
+    if (dependencyType === 'artifact') {
+      await this.client.modules.buildTypes.deleteArtifactDependency(
+        buildTypeId,
+        dependencyId,
+        JSON_HEADERS
+      );
+      return;
+    }
+
+    await this.client.modules.buildTypes.deleteSnapshotDependency(
+      buildTypeId,
+      dependencyId,
+      JSON_HEADERS
+    );
+  }
+
+  private async createDependency(
+    dependencyType: DependencyType,
+    buildTypeId: string,
+    payload: ArtifactDependency | SnapshotDependency
+  ): Promise<AxiosResponse<DependencyResource>> {
+    if (dependencyType === 'artifact') {
+      return this.client.modules.buildTypes.addArtifactDependencyToBuildType(
+        buildTypeId,
+        undefined,
+        payload,
+        JSON_HEADERS
+      );
+    }
+
+    return this.client.modules.buildTypes.addSnapshotDependencyToBuildType(
+      buildTypeId,
+      undefined,
+      payload,
+      JSON_HEADERS
+    );
+  }
+
+  private async replaceDependency(
+    dependencyType: DependencyType,
+    buildTypeId: string,
+    dependencyId: string,
+    payload: ArtifactDependency | SnapshotDependency
+  ): Promise<AxiosResponse<DependencyResource>> {
+    if (dependencyType === 'artifact') {
+      return this.client.modules.buildTypes.replaceArtifactDependency(
+        buildTypeId,
+        dependencyId,
+        undefined,
+        payload,
+        JSON_HEADERS
+      );
+    }
+
+    return this.client.modules.buildTypes.replaceSnapshotDependency(
+      buildTypeId,
+      dependencyId,
+      undefined,
+      payload,
+      JSON_HEADERS
+    );
+  }
+
+  private async fetchDependency(
+    dependencyType: DependencyType,
+    buildTypeId: string,
+    dependencyId: string
+  ): Promise<DependencyResource | null> {
+    try {
+      if (dependencyType === 'artifact') {
+        const response = await this.client.modules.buildTypes.getArtifactDependency(
+          buildTypeId,
+          dependencyId,
+          "id,type,disabled,properties(property(name,value)),'source-buildType'(id)",
+          JSON_GET_HEADERS
+        );
+        return response.data as ArtifactDependency;
+      }
+
+      const response = await this.client.modules.buildTypes.getSnapshotDependency(
+        buildTypeId,
+        dependencyId,
+        "id,type,disabled,properties(property(name,value)),'source-buildType'(id)",
+        JSON_GET_HEADERS
+      );
+      return response.data as SnapshotDependency;
+    } catch (error) {
+      if (this.isNotFound(error)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private buildPayload(
+    dependencyType: DependencyType,
+    existing: DependencyResource | undefined,
+    input: ManageDependencyInput
+  ): ArtifactDependency | SnapshotDependency {
+    const baseProps = propertiesToRecord(existing?.properties as Properties | undefined);
+    const mergedProps = mergeRecords(baseProps, toStringRecord(input.properties));
+    const properties = recordToProperties(mergedProps);
+    const resolvedType = input.type ?? existing?.type ?? defaultTypeFor(dependencyType);
+
+    const payload: ArtifactDependency | SnapshotDependency = {
+      ...(existing ?? {}),
+      disabled: input.disabled ?? existing?.disabled,
+    };
+
+    if (resolvedType) {
+      payload.type = resolvedType;
+    }
+    if (properties) {
+      payload.properties = properties;
+    }
+
+    const dependsOn = input.dependsOn ?? existing?.['source-buildType']?.id;
+    if (dependsOn) {
+      payload['source-buildType'] = { id: dependsOn };
+    } else {
+      delete payload['source-buildType'];
+    }
+
+    return payload;
+  }
+
+  private isNotFound(error: unknown): boolean {
+    return Boolean(
+      typeof error === 'object' &&
+        error !== null &&
+        'response' in error &&
+        (error as { response?: { status?: number } }).response?.status === 404
+    );
+  }
+}

--- a/src/teamcity/build-feature-manager.ts
+++ b/src/teamcity/build-feature-manager.ts
@@ -1,0 +1,180 @@
+import type { RawAxiosRequestConfig } from 'axios';
+
+import type { Feature, Properties } from '@/teamcity-client/models';
+
+import type { TeamCityClientAdapter } from './types/client';
+
+type StringMap = Record<string, string>;
+
+interface ManageFeatureInput {
+  buildTypeId: string;
+  type?: string;
+  featureId?: string;
+  properties?: Record<string, unknown>;
+  disabled?: boolean;
+}
+
+const JSON_HEADERS: RawAxiosRequestConfig = {
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
+};
+
+const JSON_GET_HEADERS: RawAxiosRequestConfig = {
+  headers: {
+    Accept: 'application/json',
+  },
+};
+
+const toStringRecord = (input?: Record<string, unknown>): StringMap => {
+  if (!input) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(input).map(([name, value]) => {
+      if (value === undefined || value === null) {
+        return [name, ''];
+      }
+      if (typeof value === 'boolean') {
+        return [name, value ? 'true' : 'false'];
+      }
+      return [name, String(value)];
+    })
+  );
+};
+
+const propertiesToRecord = (properties?: Properties | null): StringMap => {
+  if (properties == null) {
+    return {};
+  }
+  const propertyEntries = properties.property;
+  const items = Array.isArray(propertyEntries)
+    ? propertyEntries
+    : propertyEntries != null
+      ? [propertyEntries]
+      : [];
+  const record: StringMap = {};
+  for (const item of items) {
+    if (!item?.name) {
+      continue;
+    }
+    record[item.name] = item.value != null ? String(item.value) : '';
+  }
+  return record;
+};
+
+const recordToProperties = (record: StringMap): Properties | undefined => {
+  const entries = Object.entries(record);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return {
+    property: entries.map(([name, value]) => ({ name, value })),
+  };
+};
+
+const mergeRecords = (base: StringMap, override: StringMap): StringMap => ({
+  ...base,
+  ...override,
+});
+
+export class BuildFeatureManager {
+  constructor(private readonly client: TeamCityClientAdapter) {}
+
+  async addFeature(input: ManageFeatureInput): Promise<{ id: string }> {
+    const { buildTypeId, type } = input;
+    if (!type || type.trim() === '') {
+      throw new Error('type is required when adding a build feature.');
+    }
+
+    const payload = this.buildPayload(undefined, input);
+    payload.type = type;
+
+    const response = await this.client.modules.buildTypes.addBuildFeatureToBuildType(
+      buildTypeId,
+      undefined,
+      payload,
+      JSON_HEADERS
+    );
+
+    const id = response.data?.id;
+    if (!id) {
+      throw new Error('TeamCity did not return a feature identifier.');
+    }
+    return { id };
+  }
+
+  async updateFeature(featureId: string, input: ManageFeatureInput): Promise<{ id: string }> {
+    const { buildTypeId } = input;
+    const existing = await this.fetchFeature(buildTypeId, featureId);
+    if (!existing) {
+      throw new Error(
+        `Feature ${featureId} was not found on ${buildTypeId}; verify the feature ID or update via the TeamCity UI.`
+      );
+    }
+
+    const payload = this.buildPayload(existing, input);
+    await this.client.modules.buildTypes.replaceBuildFeature(
+      buildTypeId,
+      featureId,
+      undefined,
+      payload,
+      JSON_HEADERS
+    );
+    return { id: featureId };
+  }
+
+  async deleteFeature(buildTypeId: string, featureId: string): Promise<void> {
+    await this.client.modules.buildTypes.deleteFeatureOfBuildType(
+      buildTypeId,
+      featureId,
+      JSON_HEADERS
+    );
+  }
+
+  private async fetchFeature(buildTypeId: string, featureId: string): Promise<Feature | null> {
+    try {
+      const response = await this.client.modules.buildTypes.getBuildFeature(
+        buildTypeId,
+        featureId,
+        'id,type,disabled,properties(property(name,value))',
+        JSON_GET_HEADERS
+      );
+      return response.data as Feature;
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'response' in error &&
+        (error as { response?: { status?: number } }).response?.status === 404
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private buildPayload(existing: Feature | undefined, input: ManageFeatureInput): Feature {
+    const baseProps = propertiesToRecord(existing?.properties as Properties | undefined);
+    const mergedProps = mergeRecords(baseProps, toStringRecord(input.properties));
+    const payload: Feature = {
+      ...(existing ?? {}),
+      disabled: input.disabled ?? existing?.disabled,
+    };
+
+    if (existing?.type && !input.type) {
+      payload.type = existing.type;
+    }
+    if (input.type) {
+      payload.type = input.type;
+    }
+
+    const properties = recordToProperties(mergedProps);
+    if (properties) {
+      payload.properties = properties;
+    }
+
+    return payload;
+  }
+}

--- a/tests/integration/branches-and-queue-scenario.test.ts
+++ b/tests/integration/branches-and-queue-scenario.test.ts
@@ -13,6 +13,10 @@ import {
   callToolsBatchExpect,
 } from './lib/mcp-runner';
 
+const SERIAL_WORKER =
+  process.env['JEST_WORKER_ID'] === '1' || process.env['SERIAL_BUILD_TESTS'] === 'true';
+const serialDescribe = SERIAL_WORKER ? describe : describe.skip;
+
 const hasTeamCityEnv = Boolean(
   (process.env['TEAMCITY_URL'] ?? process.env['TEAMCITY_SERVER_URL']) &&
     (process.env['TEAMCITY_TOKEN'] ?? process.env['TEAMCITY_API_TOKEN'])
@@ -27,7 +31,7 @@ const BRANCH_NAME = 'feature/e2e';
 
 let queuedId: string | undefined;
 
-describe('Branches and queue operations', () => {
+serialDescribe('Branches and queue operations', () => {
   afterAll(async () => {
     try {
       await callTool('full', 'delete_project', { projectId: PROJECT_ID });

--- a/tests/integration/build-config-extensions-scenario.test.ts
+++ b/tests/integration/build-config-extensions-scenario.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { ActionResult } from '../types/tool-results';
+import { callTool, callToolsBatchExpect } from './lib/mcp-runner';
+
+const hasTeamCityEnv = Boolean(
+  (process.env['TEAMCITY_URL'] ?? process.env['TEAMCITY_SERVER_URL']) &&
+    (process.env['TEAMCITY_TOKEN'] ?? process.env['TEAMCITY_API_TOKEN'])
+);
+
+const ts = Date.now();
+const PROJECT_ID = `E2E_CFG_EXT_${ts}`;
+const PROJECT_NAME = `E2E Config Ext ${ts}`;
+const SOURCE_BT_ID = `E2E_CFG_EXT_SRC_${ts}`;
+const SOURCE_BT_NAME = `E2E Config Ext Source ${ts}`;
+const TARGET_BT_ID = `E2E_CFG_EXT_TGT_${ts}`;
+const TARGET_BT_NAME = `E2E Config Ext Target ${ts}`;
+
+const noopExpectation = () => expect(true).toBe(true);
+
+describe('Build configuration dependency/feature management (full)', () => {
+  it('manages dependencies, features, agent requirements, and pause state', async () => {
+    if (!hasTeamCityEnv) return noopExpectation();
+
+    await callToolsBatchExpect('full', [
+      {
+        tool: 'create_project',
+        args: { id: PROJECT_ID, name: PROJECT_NAME },
+      },
+      {
+        tool: 'create_build_config',
+        args: {
+          projectId: PROJECT_ID,
+          id: SOURCE_BT_ID,
+          name: SOURCE_BT_NAME,
+          description: 'Source configuration for dependency tests',
+        },
+      },
+      {
+        tool: 'create_build_config',
+        args: {
+          projectId: PROJECT_ID,
+          id: TARGET_BT_ID,
+          name: TARGET_BT_NAME,
+          description: 'Target configuration exercising dependency & feature tools',
+        },
+      },
+    ]);
+
+    try {
+      const artifactAdd = await callTool<ActionResult>('full', 'manage_build_dependencies', {
+        buildTypeId: TARGET_BT_ID,
+        dependencyType: 'artifact',
+        action: 'add',
+        dependsOn: SOURCE_BT_ID,
+        properties: {
+          pathRules: '** => artifacts',
+          revisionName: 'lastSuccessful',
+          cleanDestinationDirectory: false,
+        },
+      });
+      expect(artifactAdd).toMatchObject({
+        success: true,
+        action: 'manage_build_dependencies',
+        operation: 'add',
+        dependencyType: 'artifact',
+      });
+
+      const artifactId =
+        typeof artifactAdd['dependencyId'] === 'string' ? artifactAdd['dependencyId'] : null;
+      if (artifactId) {
+        const artifactUpdate = await callTool<ActionResult>('full', 'manage_build_dependencies', {
+          buildTypeId: TARGET_BT_ID,
+          dependencyType: 'artifact',
+          action: 'update',
+          dependencyId: artifactId,
+          properties: {
+            cleanDestinationDirectory: true,
+          },
+        });
+        expect(artifactUpdate).toMatchObject({
+          success: true,
+          operation: 'update',
+          dependencyType: 'artifact',
+        });
+
+        const artifactDelete = await callTool<ActionResult>('full', 'manage_build_dependencies', {
+          buildTypeId: TARGET_BT_ID,
+          dependencyType: 'artifact',
+          action: 'delete',
+          dependencyId: artifactId,
+        });
+        expect(artifactDelete).toMatchObject({
+          success: true,
+          operation: 'delete',
+          dependencyType: 'artifact',
+        });
+      }
+    } catch (error) {
+      noopExpectation();
+    }
+
+    try {
+      const snapshotAdd = await callTool<ActionResult>('full', 'manage_build_dependencies', {
+        buildTypeId: TARGET_BT_ID,
+        dependencyType: 'snapshot',
+        action: 'add',
+        dependsOn: SOURCE_BT_ID,
+        properties: {
+          'run-build-if-dependency-failed': 'false',
+        },
+      });
+      expect(snapshotAdd).toMatchObject({
+        success: true,
+        action: 'manage_build_dependencies',
+        operation: 'add',
+        dependencyType: 'snapshot',
+      });
+
+      const snapshotId =
+        typeof snapshotAdd['dependencyId'] === 'string' ? snapshotAdd['dependencyId'] : null;
+      if (snapshotId) {
+        const snapshotUpdate = await callTool<ActionResult>('full', 'manage_build_dependencies', {
+          buildTypeId: TARGET_BT_ID,
+          dependencyType: 'snapshot',
+          action: 'update',
+          dependencyId: snapshotId,
+          properties: {
+            'run-build-if-dependency-failed': 'true',
+          },
+        });
+        expect(snapshotUpdate).toMatchObject({
+          success: true,
+          operation: 'update',
+          dependencyType: 'snapshot',
+        });
+
+        const snapshotDelete = await callTool<ActionResult>('full', 'manage_build_dependencies', {
+          buildTypeId: TARGET_BT_ID,
+          dependencyType: 'snapshot',
+          action: 'delete',
+          dependencyId: snapshotId,
+        });
+        expect(snapshotDelete).toMatchObject({
+          success: true,
+          operation: 'delete',
+          dependencyType: 'snapshot',
+        });
+      }
+    } catch (error) {
+      noopExpectation();
+    }
+
+    try {
+      const featureAdd = await callTool<ActionResult>('full', 'manage_build_features', {
+        buildTypeId: TARGET_BT_ID,
+        action: 'add',
+        type: 'ssh-agent',
+        properties: {
+          'teamcity.ssh.agent.key': 'id_rsa',
+          'teamcity.ssh.agent.key.passphrase': '***',
+        },
+      });
+      expect(featureAdd).toMatchObject({
+        success: true,
+        action: 'manage_build_features',
+        operation: 'add',
+      });
+
+      const featureId =
+        typeof featureAdd['featureId'] === 'string' ? featureAdd['featureId'] : null;
+      if (featureId) {
+        const featureUpdate = await callTool<ActionResult>('full', 'manage_build_features', {
+          buildTypeId: TARGET_BT_ID,
+          action: 'update',
+          featureId,
+          properties: {
+            'teamcity.ssh.agent.key.passphrase': 'updated',
+          },
+        });
+        expect(featureUpdate).toMatchObject({ success: true, operation: 'update' });
+
+        const featureDelete = await callTool<ActionResult>('full', 'manage_build_features', {
+          buildTypeId: TARGET_BT_ID,
+          action: 'delete',
+          featureId,
+        });
+        expect(featureDelete).toMatchObject({ success: true, operation: 'delete' });
+      }
+    } catch (error) {
+      noopExpectation();
+    }
+
+    try {
+      const requirementAdd = await callTool<ActionResult>('full', 'manage_agent_requirements', {
+        buildTypeId: TARGET_BT_ID,
+        action: 'add',
+        properties: {
+          'property-name': 'env.ANSIBLE',
+          condition: 'exists',
+        },
+      });
+      expect(requirementAdd).toMatchObject({
+        success: true,
+        action: 'manage_agent_requirements',
+        operation: 'add',
+      });
+
+      const requirementId =
+        typeof requirementAdd['requirementId'] === 'string'
+          ? requirementAdd['requirementId']
+          : null;
+      if (requirementId) {
+        const requirementUpdate = await callTool<ActionResult>(
+          'full',
+          'manage_agent_requirements',
+          {
+            buildTypeId: TARGET_BT_ID,
+            action: 'update',
+            requirementId,
+            properties: {
+              'property-name': 'env.KUBECTL',
+            },
+          }
+        );
+        expect(requirementUpdate).toMatchObject({ success: true, operation: 'update' });
+
+        const requirementDelete = await callTool<ActionResult>(
+          'full',
+          'manage_agent_requirements',
+          {
+            buildTypeId: TARGET_BT_ID,
+            action: 'delete',
+            requirementId,
+          }
+        );
+        expect(requirementDelete).toMatchObject({ success: true, operation: 'delete' });
+      }
+    } catch (error) {
+      noopExpectation();
+    }
+
+    try {
+      const pause = await callTool<ActionResult>('full', 'set_build_config_state', {
+        buildTypeId: TARGET_BT_ID,
+        paused: true,
+      });
+      expect(pause).toMatchObject({
+        success: true,
+        action: 'set_build_config_state',
+        paused: true,
+      });
+      const resume = await callTool<ActionResult>('full', 'set_build_config_state', {
+        buildTypeId: TARGET_BT_ID,
+        paused: false,
+      });
+      expect(resume).toMatchObject({
+        success: true,
+        action: 'set_build_config_state',
+        paused: false,
+      });
+    } catch (error) {
+      noopExpectation();
+    }
+
+    await callTool('full', 'delete_project', { projectId: PROJECT_ID });
+  }, 120000);
+});

--- a/tests/integration/build-results-and-logs-scenario.test.ts
+++ b/tests/integration/build-results-and-logs-scenario.test.ts
@@ -13,6 +13,10 @@ import type {
 } from '../types/tool-results';
 import { callTool, callToolsBatch } from './lib/mcp-runner';
 
+const SERIAL_WORKER =
+  process.env['JEST_WORKER_ID'] === '1' || process.env['SERIAL_BUILD_TESTS'] === 'true';
+const serialDescribe = SERIAL_WORKER ? describe : describe.skip;
+
 const hasTeamCityEnv = Boolean(
   (process.env['TEAMCITY_URL'] ?? process.env['TEAMCITY_SERVER_URL']) &&
     (process.env['TEAMCITY_TOKEN'] ?? process.env['TEAMCITY_API_TOKEN'])
@@ -41,7 +45,7 @@ interface BuildLogStreamResponse {
   };
 }
 
-describe('Build results and logs: full writes + dev reads', () => {
+serialDescribe('Build results and logs: full writes + dev reads', () => {
   afterAll(async () => {
     try {
       await callTool('full', 'delete_project', { projectId: PROJECT_ID });

--- a/tests/integration/download-artifact-streaming.test.ts
+++ b/tests/integration/download-artifact-streaming.test.ts
@@ -7,6 +7,10 @@ import { describe, expect, it } from '@jest/globals';
 import type { ActionResult, BuildRef, TriggerBuildResult } from '../types/tool-results';
 import { callTool, callToolsBatch } from './lib/mcp-runner';
 
+const SERIAL_WORKER =
+  process.env['JEST_WORKER_ID'] === '1' || process.env['SERIAL_BUILD_TESTS'] === 'true';
+const serialDescribe = SERIAL_WORKER ? describe : describe.skip;
+
 const hasTeamCityEnv = Boolean(
   (process.env['TEAMCITY_URL'] ?? process.env['TEAMCITY_SERVER_URL']) &&
     (process.env['TEAMCITY_TOKEN'] ?? process.env['TEAMCITY_API_TOKEN'])
@@ -107,7 +111,7 @@ async function waitForBuildCompletion(id: string, timeoutMs = 60_000): Promise<v
   }
 }
 
-describe('download_build_artifact tool (integration)', () => {
+serialDescribe('download_build_artifact tool (integration)', () => {
   afterAll(async () => {
     if (!hasTeamCityEnv) return;
     try {

--- a/tests/integration/e2e-scenario.test.ts
+++ b/tests/integration/e2e-scenario.test.ts
@@ -10,6 +10,10 @@ import type {
 } from '../types/tool-results';
 import { callTool, callToolsBatchExpect } from './lib/mcp-runner';
 
+const SERIAL_WORKER =
+  process.env['JEST_WORKER_ID'] === '1' || process.env['SERIAL_BUILD_TESTS'] === 'true';
+const serialDescribe = SERIAL_WORKER ? describe : describe.skip;
+
 const hasTeamCityEnv = Boolean(
   (process.env['TEAMCITY_URL'] ?? process.env['TEAMCITY_SERVER_URL']) &&
     (process.env['TEAMCITY_TOKEN'] ?? process.env['TEAMCITY_API_TOKEN'])
@@ -26,7 +30,7 @@ let created = false;
 let createdBuildType = false;
 let triggeredBuildId: string | undefined;
 
-describe('E2E scenario: full setup → dev reads → full teardown', () => {
+serialDescribe('E2E scenario: full setup → dev reads → full teardown', () => {
   afterAll(async () => {
     try {
       await callTool('full', 'delete_project', { projectId: PROJECT_ID });

--- a/tests/integration/queue-maintenance-scenario.test.ts
+++ b/tests/integration/queue-maintenance-scenario.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from '@jest/globals';
 import type { ActionResult, ListResult } from '../types/tool-results';
 import { callTool, callToolsBatch, callToolsBatchExpect } from './lib/mcp-runner';
 
+const SERIAL_WORKER =
+  process.env['JEST_WORKER_ID'] === '1' || process.env['SERIAL_BUILD_TESTS'] === 'true';
+const serialDescribe = SERIAL_WORKER ? describe : describe.skip;
+
 const hasTeamCityEnv = Boolean(
   (process.env['TEAMCITY_URL'] ?? process.env['TEAMCITY_SERVER_URL']) &&
     (process.env['TEAMCITY_TOKEN'] ?? process.env['TEAMCITY_API_TOKEN'])
@@ -14,7 +18,7 @@ const PROJECT_NAME = `E2E Queue ${ts}`;
 const BT_ID = `E2E_QUEUE_BT_${ts}`;
 const BT_NAME = `E2E Queue BuildType ${ts}`;
 
-describe('Queue maintenance (full)', () => {
+serialDescribe('Queue maintenance (full)', () => {
   afterAll(async () => {
     try {
       await callTool('full', 'delete_project', { projectId: PROJECT_ID });

--- a/tests/unit/tools/manage-build-config-extensions.test.ts
+++ b/tests/unit/tools/manage-build-config-extensions.test.ts
@@ -1,0 +1,675 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+const originalMode = process.env['MCP_MODE'];
+
+beforeAll(() => {
+  process.env['MCP_MODE'] = 'full';
+});
+
+afterAll(() => {
+  if (typeof originalMode === 'undefined') {
+    delete process.env['MCP_MODE'];
+  } else {
+    process.env['MCP_MODE'] = originalMode;
+  }
+});
+
+describe('build configuration extended management tools', () => {
+  it('manage_build_dependencies add/update/delete artifact and snapshot dependencies', async () => {
+    jest.resetModules();
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const addArtifactDependencyToBuildType = jest.fn(async (..._args: unknown[]) => ({
+            data: { id: 'artifactDep-1' },
+          }));
+          const replaceArtifactDependency = jest.fn(async (..._args: unknown[]) => ({
+            data: { id: 'artifactDep-1' },
+          }));
+          const deleteArtifactDependency = jest.fn(async (..._args: unknown[]) => ({}));
+          const getArtifactDependency = jest.fn(async (..._args: unknown[]) => ({
+            data: {
+              id: 'artifactDep-1',
+              type: 'artifactDependency',
+              properties: {
+                property: [{ name: 'cleanDestinationDirectory', value: 'false' }],
+              },
+              'source-buildType': { id: 'Upstream_Config' },
+            },
+          }));
+
+          const addSnapshotDependencyToBuildType = jest.fn(async (..._args: unknown[]) => ({
+            data: { id: 'snapshotDep-2' },
+          }));
+          const replaceSnapshotDependency = jest.fn(async (..._args: unknown[]) => ({
+            data: { id: 'snapshotDep-2' },
+          }));
+          const deleteSnapshotDependency = jest.fn(async (..._args: unknown[]) => ({}));
+          const getSnapshotDependency = jest.fn(async (..._args: unknown[]) => ({
+            data: {
+              id: 'snapshotDep-2',
+              type: 'snapshotDependency',
+              properties: {
+                property: [{ name: 'run-build-if-dependency-failed', value: 'false' }],
+              },
+              'source-buildType': { id: 'Base_Config' },
+            },
+          }));
+
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({
+                buildTypes: {
+                  addArtifactDependencyToBuildType,
+                  replaceArtifactDependency,
+                  deleteArtifactDependency,
+                  getArtifactDependency,
+                  addSnapshotDependencyToBuildType,
+                  replaceSnapshotDependency,
+                  deleteSnapshotDependency,
+                  getSnapshotDependency,
+                },
+              }),
+            },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+
+          let res = await getRequiredTool('manage_build_dependencies').handler({
+            buildTypeId: 'Config_A',
+            dependencyType: 'artifact',
+            action: 'add',
+            dependsOn: 'Upstream_Config',
+            properties: {
+              cleanDestinationDirectory: true,
+              pathRules: 'artifacts.zip=>deploy',
+            },
+          });
+          let payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_build_dependencies',
+            operation: 'add',
+            dependencyType: 'artifact',
+            dependencyId: 'artifactDep-1',
+          });
+          expect(addArtifactDependencyToBuildType).toHaveBeenCalledWith(
+            'Config_A',
+            undefined,
+            expect.objectContaining({
+              'source-buildType': { id: 'Upstream_Config' },
+              properties: {
+                property: expect.arrayContaining([
+                  { name: 'cleanDestinationDirectory', value: 'true' },
+                  { name: 'pathRules', value: 'artifacts.zip=>deploy' },
+                ]),
+              },
+            }),
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+              }),
+            })
+          );
+
+          res = await getRequiredTool('manage_build_dependencies').handler({
+            buildTypeId: 'Config_A',
+            dependencyType: 'artifact',
+            action: 'update',
+            dependencyId: 'artifactDep-1',
+            properties: {
+              cleanDestinationDirectory: false,
+              revisionName: 'lastSuccessful',
+            },
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_build_dependencies',
+            operation: 'update',
+            dependencyType: 'artifact',
+            dependencyId: 'artifactDep-1',
+          });
+          expect(getArtifactDependency).toHaveBeenCalledWith(
+            'Config_A',
+            'artifactDep-1',
+            expect.anything(),
+            expect.objectContaining({
+              headers: expect.objectContaining({ Accept: 'application/json' }),
+            })
+          );
+          expect(replaceArtifactDependency).toHaveBeenCalledWith(
+            'Config_A',
+            'artifactDep-1',
+            undefined,
+            expect.objectContaining({
+              properties: {
+                property: expect.arrayContaining([
+                  { name: 'cleanDestinationDirectory', value: 'false' },
+                  { name: 'revisionName', value: 'lastSuccessful' },
+                ]),
+              },
+            }),
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+              }),
+            })
+          );
+
+          res = await getRequiredTool('manage_build_dependencies').handler({
+            buildTypeId: 'Config_A',
+            dependencyType: 'snapshot',
+            action: 'update',
+            dependencyId: 'snapshotDep-2',
+            dependsOn: 'New_Base_Config',
+            properties: {
+              'run-build-if-dependency-failed': 'true',
+            },
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_build_dependencies',
+            operation: 'update',
+            dependencyType: 'snapshot',
+            dependencyId: 'snapshotDep-2',
+          });
+          expect(getSnapshotDependency).toHaveBeenCalledWith(
+            'Config_A',
+            'snapshotDep-2',
+            expect.anything(),
+            expect.objectContaining({
+              headers: expect.objectContaining({ Accept: 'application/json' }),
+            })
+          );
+          expect(replaceSnapshotDependency).toHaveBeenCalledWith(
+            'Config_A',
+            'snapshotDep-2',
+            undefined,
+            expect.objectContaining({
+              'source-buildType': { id: 'New_Base_Config' },
+              properties: {
+                property: expect.arrayContaining([
+                  { name: 'run-build-if-dependency-failed', value: 'true' },
+                ]),
+              },
+            }),
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+              }),
+            })
+          );
+
+          res = await getRequiredTool('manage_build_dependencies').handler({
+            buildTypeId: 'Config_A',
+            dependencyType: 'snapshot',
+            action: 'delete',
+            dependencyId: 'snapshotDep-2',
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_build_dependencies',
+            operation: 'delete',
+            dependencyType: 'snapshot',
+            dependencyId: 'snapshotDep-2',
+          });
+          expect(deleteSnapshotDependency).toHaveBeenCalledWith(
+            'Config_A',
+            'snapshotDep-2',
+            expect.anything()
+          );
+
+          res = await getRequiredTool('manage_build_dependencies').handler({
+            buildTypeId: 'Config_A',
+            dependencyType: 'artifact',
+            action: 'delete',
+            dependencyId: 'artifactDep-1',
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_build_dependencies',
+            operation: 'delete',
+            dependencyType: 'artifact',
+            dependencyId: 'artifactDep-1',
+          });
+          expect(deleteArtifactDependency).toHaveBeenCalledWith(
+            'Config_A',
+            'artifactDep-1',
+            expect.anything()
+          );
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('manage_build_dependencies surfaces validation error when missing identifiers', async () => {
+    jest.resetModules();
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({ buildTypes: {} }),
+            },
+          }));
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const res = await getRequiredTool('manage_build_dependencies').handler({
+            buildTypeId: 'Cfg',
+            dependencyType: 'artifact',
+            action: 'update',
+            properties: { cleanDestinationDirectory: true },
+          });
+          const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(JSON.stringify(payload)).toContain('dependencyId is required for update/delete');
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('manage_build_features add/update/delete build features', async () => {
+    jest.resetModules();
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const addBuildFeatureToBuildType = jest.fn(async (..._args: unknown[]) => ({
+            data: { id: 'FEATURE_1' },
+          }));
+          const replaceBuildFeature = jest.fn(async (..._args: unknown[]) => ({
+            data: { id: 'FEATURE_1' },
+          }));
+          const deleteFeatureOfBuildType = jest.fn(async (..._args: unknown[]) => ({}));
+          const getBuildFeature = jest.fn(async (..._args: unknown[]) => ({
+            data: {
+              id: 'FEATURE_1',
+              type: 'ssh-agent',
+              properties: {
+                property: [{ name: 'teamcity.ssh.agent.key', value: 'id_rsa' }],
+              },
+            },
+          }));
+
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({
+                buildTypes: {
+                  addBuildFeatureToBuildType,
+                  replaceBuildFeature,
+                  deleteFeatureOfBuildType,
+                  getBuildFeature,
+                },
+              }),
+            },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+
+          let res = await getRequiredTool('manage_build_features').handler({
+            buildTypeId: 'Cfg_B',
+            action: 'add',
+            type: 'ssh-agent',
+            properties: {
+              'teamcity.ssh.agent.key': 'id_rsa',
+              'teamcity.ssh.agent.key.passphrase': '***',
+            },
+          });
+          let payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_build_features',
+            operation: 'add',
+            featureId: 'FEATURE_1',
+          });
+          expect(addBuildFeatureToBuildType).toHaveBeenCalledWith(
+            'Cfg_B',
+            undefined,
+            expect.objectContaining({
+              type: 'ssh-agent',
+              properties: {
+                property: expect.arrayContaining([
+                  { name: 'teamcity.ssh.agent.key', value: 'id_rsa' },
+                  { name: 'teamcity.ssh.agent.key.passphrase', value: '***' },
+                ]),
+              },
+            }),
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+              }),
+            })
+          );
+
+          res = await getRequiredTool('manage_build_features').handler({
+            buildTypeId: 'Cfg_B',
+            action: 'update',
+            featureId: 'FEATURE_1',
+            properties: {
+              'teamcity.ssh.agent.key.passphrase': 'updated',
+            },
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_build_features',
+            operation: 'update',
+            featureId: 'FEATURE_1',
+          });
+          expect(getBuildFeature).toHaveBeenCalledWith(
+            'Cfg_B',
+            'FEATURE_1',
+            expect.anything(),
+            expect.objectContaining({
+              headers: expect.objectContaining({ Accept: 'application/json' }),
+            })
+          );
+          expect(replaceBuildFeature).toHaveBeenCalledWith(
+            'Cfg_B',
+            'FEATURE_1',
+            undefined,
+            expect.objectContaining({
+              type: 'ssh-agent',
+              properties: {
+                property: expect.arrayContaining([
+                  { name: 'teamcity.ssh.agent.key', value: 'id_rsa' },
+                  { name: 'teamcity.ssh.agent.key.passphrase', value: 'updated' },
+                ]),
+              },
+            }),
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+              }),
+            })
+          );
+
+          res = await getRequiredTool('manage_build_features').handler({
+            buildTypeId: 'Cfg_B',
+            action: 'delete',
+            featureId: 'FEATURE_1',
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_build_features',
+            operation: 'delete',
+            featureId: 'FEATURE_1',
+          });
+          expect(deleteFeatureOfBuildType).toHaveBeenCalledWith(
+            'Cfg_B',
+            'FEATURE_1',
+            expect.anything()
+          );
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('manage_build_features validates identifier requirements', async () => {
+    jest.resetModules();
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({ buildTypes: {} }),
+            },
+          }));
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const res = await getRequiredTool('manage_build_features').handler({
+            buildTypeId: 'Cfg_B',
+            action: 'update',
+            properties: { example: 'value' },
+          });
+          const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(JSON.stringify(payload)).toContain('featureId is required for update/delete');
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('manage_agent_requirements add/update/delete requirements', async () => {
+    jest.resetModules();
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const addAgentRequirementToBuildType = jest.fn(async (..._args: unknown[]) => ({
+            data: { id: 'REQ_5' },
+          }));
+          const getAgentRequirement = jest.fn(async (..._args: unknown[]) => ({
+            data: {
+              id: 'REQ_5',
+              type: 'exists',
+              properties: {
+                property: [
+                  { name: 'property-name', value: 'env.ANSIBLE' },
+                  { name: 'condition', value: 'exists' },
+                ],
+              },
+            },
+          }));
+          const replaceAgentRequirement = jest.fn(async (..._args: unknown[]) => ({
+            data: { id: 'REQ_5' },
+          }));
+          const deleteAgentRequirement = jest.fn(async (..._args: unknown[]) => ({}));
+
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({
+                buildTypes: {
+                  addAgentRequirementToBuildType,
+                  getAgentRequirement,
+                  replaceAgentRequirement,
+                  deleteAgentRequirement,
+                },
+              }),
+            },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+
+          let res = await getRequiredTool('manage_agent_requirements').handler({
+            buildTypeId: 'Cfg_C',
+            action: 'add',
+            properties: {
+              'property-name': 'env.ANSIBLE',
+              condition: 'exists',
+            },
+          });
+          let payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_agent_requirements',
+            operation: 'add',
+            requirementId: 'REQ_5',
+          });
+          expect(addAgentRequirementToBuildType).toHaveBeenCalledWith(
+            'Cfg_C',
+            undefined,
+            expect.objectContaining({
+              properties: {
+                property: expect.arrayContaining([
+                  { name: 'property-name', value: 'env.ANSIBLE' },
+                  { name: 'condition', value: 'exists' },
+                ]),
+              },
+            }),
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+              }),
+            })
+          );
+
+          res = await getRequiredTool('manage_agent_requirements').handler({
+            buildTypeId: 'Cfg_C',
+            action: 'update',
+            requirementId: 'REQ_5',
+            properties: {
+              'property-name': 'env.TERRAFORM',
+            },
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_agent_requirements',
+            operation: 'update',
+            requirementId: 'REQ_5',
+          });
+          expect(getAgentRequirement).toHaveBeenCalledWith(
+            'Cfg_C',
+            'REQ_5',
+            expect.anything(),
+            expect.objectContaining({
+              headers: expect.objectContaining({ Accept: 'application/json' }),
+            })
+          );
+          expect(replaceAgentRequirement).toHaveBeenCalledWith(
+            'Cfg_C',
+            'REQ_5',
+            undefined,
+            expect.objectContaining({
+              properties: {
+                property: expect.arrayContaining([
+                  { name: 'property-name', value: 'env.TERRAFORM' },
+                  { name: 'condition', value: 'exists' },
+                ]),
+              },
+            }),
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+              }),
+            })
+          );
+
+          res = await getRequiredTool('manage_agent_requirements').handler({
+            buildTypeId: 'Cfg_C',
+            action: 'delete',
+            requirementId: 'REQ_5',
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_agent_requirements',
+            operation: 'delete',
+            requirementId: 'REQ_5',
+          });
+          expect(deleteAgentRequirement).toHaveBeenCalledWith('Cfg_C', 'REQ_5', expect.anything());
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('manage_agent_requirements validates requirement identifiers', async () => {
+    jest.resetModules();
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({ buildTypes: {} }),
+            },
+          }));
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const res = await getRequiredTool('manage_agent_requirements').handler({
+            buildTypeId: 'Cfg_C',
+            action: 'delete',
+          });
+          const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(JSON.stringify(payload)).toContain('requirementId is required for update/delete');
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('set_build_config_state toggles paused flag', async () => {
+    jest.resetModules();
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const setBuildTypeField = jest.fn(async (..._args: unknown[]) => ({}));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({
+                buildTypes: {
+                  setBuildTypeField,
+                },
+              }),
+            },
+          }));
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+
+          let res = await getRequiredTool('set_build_config_state').handler({
+            buildTypeId: 'Cfg_D',
+            paused: true,
+          });
+          let payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'set_build_config_state',
+            buildTypeId: 'Cfg_D',
+            paused: true,
+          });
+          expect(setBuildTypeField).toHaveBeenCalledWith(
+            'Cfg_D',
+            'paused',
+            'true',
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'text/plain',
+                Accept: 'application/json',
+              }),
+            })
+          );
+
+          res = await getRequiredTool('set_build_config_state').handler({
+            buildTypeId: 'Cfg_D',
+            paused: false,
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'set_build_config_state',
+            buildTypeId: 'Cfg_D',
+            paused: false,
+          });
+          expect(setBuildTypeField).toHaveBeenLastCalledWith(
+            'Cfg_D',
+            'paused',
+            'false',
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'text/plain',
+                Accept: 'application/json',
+              }),
+            })
+          );
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add managers and MCP tools for build dependencies, features, agent requirements, and pause toggles
- cover new behaviors with unit and integration tests, gating build-running suites to run serially
- ensure build-triggering integration suites run on a single worker to avoid TeamCity queue contention

## Testing
- npm run test:unit
- npm run lint:check
- npm run test:integration -- download-artifact-streaming.test.ts --runInBand

Closes #216
