### PR TITLE
fix(tools): honor trigger_build branch overrides (210)

### DIFF
--- a/tests/integration/branches-and-queue-scenario.test.ts
+++ b/tests/integration/branches-and-queue-scenario.test.ts
@@ -85,6 +85,20 @@ serialDescribe('Branches and queue operations', () => {
       branchName: BRANCH_NAME,
     });
     expect(trig).toMatchObject({ success: true, action: 'trigger_build' });
+    expect(trig.branchName).toBe(BRANCH_NAME);
+  }, 90000);
+
+  it('triggers a build using teamcity.build.branch property (dev)', async () => {
+    if (!hasTeamCityEnv) return expect(true).toBe(true);
+    const trig = await callTool<TriggerBuildResult>('dev', 'trigger_build', {
+      buildTypeId: BT_ID,
+      properties: {
+        'teamcity.build.branch': `${BRANCH_NAME}-prop`,
+        'env.CUSTOM_FLAG': 'true',
+      },
+    });
+    expect(trig).toMatchObject({ success: true, action: 'trigger_build' });
+    expect(trig.branchName).toBe(`${BRANCH_NAME}-prop`);
   }, 90000);
 
   it('lists branches for project and build type (dev)', async () => {

--- a/tests/types/tool-results.ts
+++ b/tests/types/tool-results.ts
@@ -29,6 +29,7 @@ export interface TriggerBuildResult extends ActionResult<'trigger_build'> {
   buildId: string;
   state?: string;
   status?: string;
+  branchName?: string;
 }
 
 export interface BuildRef {


### PR DESCRIPTION
## Summary
- allow `trigger_build` to accept branch overrides via either `branchName` or `properties.teamcity.build.branch`, normalize conflicts, and forward overrides to the TeamCity queue request (with XML fallback)
- include the effective branch in tool responses and guard against conflicting overrides, while ensuring optional build parameters still flow through
- extend unit and integration suites to cover branch propagation and property-driven overrides, plus expose `branchName` on shared trigger result types

## Testing
- npm run test:unit -- --runTestsByPath tests/unit/tools/build-actions-and-status.test.ts
- npm run test:integration -- --runTestsByPath tests/integration/branches-and-queue-scenario.test.ts
- npm run typecheck
- npm run lint:check

## Checklist
- [x] Closes #210
- [x] Tests pass locally
- [x] Lint/format applied where needed
