### PR TITLE
fix(teamcity): set dependency types when adding via tool

### DIFF
--- a/src/teamcity/build-dependency-manager.ts
+++ b/src/teamcity/build-dependency-manager.ts
@@ -35,9 +35,9 @@ const JSON_GET_HEADERS: RawAxiosRequestConfig = {
 const defaultTypeFor = (dependencyType: DependencyType): string | undefined => {
   switch (dependencyType) {
     case 'artifact':
-      return undefined;
+      return 'artifactDependency';
     case 'snapshot':
-      return undefined;
+      return 'snapshotDependency';
     default:
       return undefined;
   }

--- a/tests/unit/tools/manage-build-config-extensions.test.ts
+++ b/tests/unit/tools/manage-build-config-extensions.test.ts
@@ -116,6 +116,35 @@ describe('build configuration extended management tools', () => {
 
           res = await getRequiredTool('manage_build_dependencies').handler({
             buildTypeId: 'Config_A',
+            dependencyType: 'snapshot',
+            action: 'add',
+            dependsOn: 'Base_Config',
+          });
+          payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({
+            success: true,
+            action: 'manage_build_dependencies',
+            operation: 'add',
+            dependencyType: 'snapshot',
+            dependencyId: 'snapshotDep-2',
+          });
+          expect(addSnapshotDependencyToBuildType).toHaveBeenCalledWith(
+            'Config_A',
+            undefined,
+            expect.objectContaining({
+              'source-buildType': { id: 'Base_Config' },
+              type: 'snapshotDependency',
+            }),
+            expect.objectContaining({
+              headers: expect.objectContaining({
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+              }),
+            })
+          );
+
+          res = await getRequiredTool('manage_build_dependencies').handler({
+            buildTypeId: 'Config_A',
             dependencyType: 'artifact',
             action: 'update',
             dependencyId: 'artifactDep-1',


### PR DESCRIPTION
## Summary
- default dependency payload types to match artifact/snapshot expectations
- cover snapshot add path to ensure type field is applied when using the MCP tool

Closes #226.

## Testing
- npm test -- --runTestsByPath tests/unit/tools/manage-build-config-extensions.test.ts
- npm run lint:check
- npm run test:coverage *(jest completed; CLI timeout after report, coverage-summary.json shows lines 87.06%, branches 69.67%)*
