### PR TITLE
fix(teamcity): send snapshot options separately (238)

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3872,6 +3872,10 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
           type: 'object',
           description: 'Dependency properties (e.g. cleanDestinationDirectory, pathRules)',
         },
+        options: {
+          type: 'object',
+          description: 'Snapshot dependency options (e.g. run-build-on-the-same-agent)',
+        },
         type: {
           type: 'string',
           description: 'Override dependency type value sent to TeamCity',
@@ -3890,6 +3894,7 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
           dependencyId: z.string().min(1).optional(),
           dependsOn: z.string().min(1).optional(),
           properties: z.record(z.string(), propertyValue).optional(),
+          options: z.record(z.string(), propertyValue).optional(),
           type: z.string().min(1).optional(),
           disabled: z.boolean().optional(),
         })
@@ -3925,6 +3930,7 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
                 dependencyType: typed.dependencyType,
                 dependsOn: typed.dependsOn,
                 properties: typed.properties,
+                options: typed.options,
                 type: typed.type,
                 disabled: typed.disabled,
               });
@@ -3943,6 +3949,7 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
                 dependencyType: typed.dependencyType,
                 dependsOn: typed.dependsOn,
                 properties: typed.properties,
+                options: typed.options,
                 type: typed.type,
                 disabled: typed.disabled,
               });

--- a/tests/unit/tools/manage-build-config-extensions.test.ts
+++ b/tests/unit/tools/manage-build-config-extensions.test.ts
@@ -52,6 +52,9 @@ describe('build configuration extended management tools', () => {
               properties: {
                 property: [{ name: 'run-build-if-dependency-failed', value: 'false' }],
               },
+              options: {
+                option: [{ name: 'run-build-on-the-same-agent', value: 'false' }],
+              },
               'source-buildType': { id: 'Base_Config' },
             },
           }));
@@ -197,6 +200,7 @@ describe('build configuration extended management tools', () => {
             dependsOn: 'New_Base_Config',
             properties: {
               'run-build-if-dependency-failed': 'true',
+              'run-build-on-the-same-agent': true,
             },
           });
           payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
@@ -230,8 +234,12 @@ describe('build configuration extended management tools', () => {
           expect(replaceSnapshotDependency.mock.calls[0]?.[3]).toContain(
             '<source-buildType id="New_Base_Config"/>'
           );
-          expect(replaceSnapshotDependency.mock.calls[0]?.[3]).toContain(
+          const updateSnapshotXml = replaceSnapshotDependency.mock.calls[0]?.[3] as string;
+          expect(updateSnapshotXml).toContain(
             '<properties><property name="run-build-if-dependency-failed" value="true"/></properties>'
+          );
+          expect(updateSnapshotXml).toContain(
+            '<options><option name="run-build-on-the-same-agent" value="true"/></options>'
           );
 
           res = await getRequiredTool('manage_build_dependencies').handler({


### PR DESCRIPTION
## Summary
- send snapshot dependency options (e.g. run-build-on-the-same-agent) in the dedicated `<options>` block so TeamCity accepts updates
- accept an `options` object in `manage_build_dependencies` and merge it alongside properties
- tighten unit coverage around snapshot updates; integration scenario stays green

Closes #238.

## Testing
- npm run test:unit
- npm run test:integration

## Checklist
- [x] Ready for review
- [x] Added issue link
