### PR TITLE
fix(server): keep stdio transport alive (247)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,50 @@
  * Simple TeamCity MCP Server Entry Point
  * Minimal implementation without complex DI or abstractions
  */
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import * as dotenv from 'dotenv';
 
 import { getTeamCityToken, getTeamCityUrl } from '@/config';
+import { startServerLifecycle } from '@/server-runner';
 
 import { createSimpleServer } from './server';
 
 // Load environment variables
 dotenv.config();
+
+let activeServer: Server | null = null;
+let lifecyclePromise: Promise<void> | null = null;
+let shuttingDown = false;
+
+const clearServerState = () => {
+  activeServer = null;
+  lifecyclePromise = null;
+};
+
+async function shutdown(exitCode: number): Promise<never> {
+  if (shuttingDown) {
+    process.exit(exitCode);
+  }
+  shuttingDown = true;
+
+  process.stderr.write('\nShutting down TeamCity MCP Server...\n');
+
+  try {
+    const serverToClose = activeServer;
+    const lifecycleToAwait = lifecyclePromise;
+
+    await serverToClose?.close();
+    await lifecycleToAwait;
+  } catch (error) {
+    process.stderr.write(
+      `Error while closing server: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+  } finally {
+    clearServerState();
+    process.exit(exitCode);
+  }
+}
 
 async function main() {
   try {
@@ -33,10 +68,17 @@ async function main() {
     // Create and start server
     const server = createSimpleServer();
     const transport = new StdioServerTransport();
+    const lifecycle = startServerLifecycle(server, transport);
 
-    await server.connect(transport);
+    activeServer = server;
+    lifecyclePromise = lifecycle;
     process.stderr.write('TeamCity MCP Server is running and ready to accept connections\n');
+
+    await lifecycle;
+    clearServerState();
+    process.stderr.write('TeamCity MCP Server connection closed\n');
   } catch (error) {
+    clearServerState();
     process.stderr.write(`Failed to start server: ${error}\n`);
     process.exit(1);
   }
@@ -44,13 +86,11 @@ async function main() {
 
 // Handle graceful shutdown
 process.on('SIGINT', () => {
-  process.stderr.write('\nShutting down TeamCity MCP Server...\n');
-  process.exit(0);
+  void shutdown(0);
 });
 
 process.on('SIGTERM', () => {
-  process.stderr.write('\nShutting down TeamCity MCP Server...\n');
-  process.exit(0);
+  void shutdown(0);
 });
 
 // Start the server

--- a/src/server-runner.ts
+++ b/src/server-runner.ts
@@ -1,0 +1,58 @@
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+export type LifecycleTransport = {
+  close?: () => Promise<void> | void;
+};
+
+/**
+ * Connects the provided MCP server to the given transport and keeps the process
+ * alive until the server closes or reports an unrecoverable error.
+ */
+export async function startServerLifecycle(
+  server: Server,
+  transport: LifecycleTransport
+): Promise<void> {
+  await server.connect(transport as never);
+
+  return new Promise<void>((resolve, reject) => {
+    const previousOnClose = server.onclose;
+    const previousOnError = server.onerror;
+
+    const cleanup = () => {
+      server.onclose = previousOnClose;
+      server.onerror = previousOnError;
+    };
+
+    server.onclose = () => {
+      previousOnClose?.();
+      cleanup();
+      resolve();
+    };
+
+    server.onerror = (rawError) => {
+      previousOnError?.(rawError);
+
+      const error = rawError instanceof Error ? rawError : new Error(String(rawError));
+
+      const closeTransport = () => {
+        if (!transport.close) {
+          return Promise.resolve();
+        }
+        try {
+          return Promise.resolve(transport.close());
+        } catch (closeError) {
+          return Promise.reject(closeError);
+        }
+      };
+
+      void closeTransport()
+        .catch(() => {
+          // Ignore secondary close failures; the original error is what matters.
+        })
+        .finally(() => {
+          cleanup();
+          reject(error);
+        });
+    };
+  });
+}

--- a/tests/unit/server-runner.test.ts
+++ b/tests/unit/server-runner.test.ts
@@ -1,0 +1,76 @@
+import { startServerLifecycle } from '@/server-runner';
+
+class MockTransport {
+  public started = false;
+  public closed = false;
+
+  async start(): Promise<void> {
+    this.started = true;
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+class MockServer {
+  public connectCalls = 0;
+  public closeCalls = 0;
+  public onclose?: () => void;
+  public onerror?: (error: unknown) => void;
+
+  async connect(_transport: MockTransport): Promise<void> {
+    this.connectCalls += 1;
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+  }
+
+  triggerClose(): void {
+    this.onclose?.();
+  }
+
+  triggerError(error: unknown): void {
+    this.onerror?.(error);
+  }
+}
+
+const flushPromises = async () => new Promise(process.nextTick);
+
+describe('startServerLifecycle', () => {
+  it('waits for server close before resolving', async () => {
+    const server = new MockServer();
+    const transport = new MockTransport();
+    const lifecycle = startServerLifecycle(server as never, transport as never);
+
+    await flushPromises();
+
+    let resolved = false;
+    void lifecycle.then(() => {
+      resolved = true;
+    });
+
+    await flushPromises();
+    expect(resolved).toBe(false);
+
+    server.triggerClose();
+
+    await expect(lifecycle).resolves.toBeUndefined();
+    expect(resolved).toBe(true);
+  });
+
+  it('rejects when the server reports an error and closes the transport', async () => {
+    const server = new MockServer();
+    const transport = new MockTransport();
+    const lifecycle = startServerLifecycle(server as never, transport as never);
+
+    await flushPromises();
+
+    const error = new Error('boom');
+    server.triggerError(error);
+
+    await expect(lifecycle).rejects.toThrow(error);
+    expect(transport.closed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- keep the MCP STDIO transport open until the client closes or an error occurs via a new server lifecycle helper
- reuse the helper in the entrypoint so the Codex handshake completes and signals now produce graceful shutdown
- cover lifecycle behavior with new unit tests and ensure lint passes

## Testing
- npm run lint:check
- npm run test:unit -- tests/unit/server-runner.test.ts
- npm run test:integration

## Checklist
- [x] Closes #247
- [x] Tests written or updated
- [x] Linting run
- [x] Ready for review
