### PR TITLE
Debug and fix server issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,13 @@ async function main() {
 
     await server.connect(transport);
     process.stderr.write('TeamCity MCP Server is running and ready to accept connections\n');
+
+    // Keep the server running until explicitly terminated
+    // The server will handle requests over stdio and only exit on SIGINT/SIGTERM
+    await new Promise(() => {
+      // This promise never resolves, keeping the process alive
+      // The process will only exit via the signal handlers above
+    });
   } catch (error) {
     process.stderr.write(`Failed to start server: ${error}\n`);
     process.exit(1);


### PR DESCRIPTION
The server was exiting immediately after calling server.connect() because the main() function would complete and Node.js would find no pending work in the event loop. This caused the process to exit before the MCP client could send the initialize request.

The fix adds an indefinitely-pending promise after the connection is established, keeping the process alive to handle incoming MCP requests over stdio. The server will only exit when it receives SIGINT or SIGTERM signals (which are already handled).

This resolves the handshake failure when invoked from the Codex CLI or other MCP clients.

Fixes: #<issue-number>