### PR TITLE
Add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 TeamCity MCP contributors
+Copyright (c) 2025 Daghis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-


### PR DESCRIPTION
## Summary
- Adds a LICENSE file to the repository root so GitHub properly recognizes the project's MIT license

This addresses the comment on PR #258 about the missing license file.

## Test plan
- [x] Verify LICENSE file contains correct MIT license text
- [ ] Verify GitHub displays the license badge after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)