### PR TITLE
ci(publish): switch to npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,10 +69,8 @@ jobs:
       - name: Publish to npm
         if: steps.exists.outputs.exists == 'false'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
-        run: |
-          npm publish --access public --provenance
+        run: npm publish --access public --provenance
 
       - name: Install MCP Publisher
         if: steps.exists.outputs.exists == 'false' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_registry == 'true')


### PR DESCRIPTION
## Summary
- Remove NPM_TOKEN secret usage from publish workflow
- Rely on OIDC trusted publishing instead (already configured on npm)

This provides better security by eliminating stored credentials. The npm package has a trusted publisher configured for `daghis/teamcity-mcp` with `publish.yml`.

## Test plan
- [ ] Merge and trigger a release to verify OIDC publishing works
- [ ] After successful publish, delete the `NPM_TOKEN` secret from GitHub repository settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)