### PR TITLE
chore(deps): remove unused @eslint/compat dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
       "devDependencies": {
         "@codecov/bundler-plugin-core": "^1.9.1",
         "@esbuild-plugins/tsconfig-paths": "^0.1.2",
-        "@eslint/compat": "^1.4.1",
         "@trivago/prettier-plugin-sort-imports": "^6.0.0",
         "@types/ajv": "^1.0.4",
         "@types/express": "^5.0.5",
@@ -1198,27 +1197,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz",
-      "integrity": "sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.40 || 9"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/config-array": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   },
   "devDependencies": {
     "@codecov/bundler-plugin-core": "^1.9.1",
-    "@eslint/compat": "^1.4.1",
     "@esbuild-plugins/tsconfig-paths": "^0.1.2",
     "@trivago/prettier-plugin-sort-imports": "^6.0.0",
     "@types/ajv": "^1.0.4",


### PR DESCRIPTION
## Summary
- Remove `@eslint/compat` from devDependencies
- This package was never imported or used anywhere in the codebase

## Context
Dependabot opened PR #266 to upgrade `@eslint/compat` from 1.4.1 to 2.0.0. Upon investigation, this dependency is not actually used—`eslint.config.cjs` does not import it. 

Rather than upgrading an unused dependency, this PR removes it entirely.

## Test plan
- [x] `npm run lint:check` passes
- [x] `npm run typecheck` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)