### PR TITLE
fix(publish): clarify id-token permission for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # for npm provenance
+  id-token: write # for npm trusted publishing (OIDC) and provenance
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
Update workflow comment to clarify that `id-token: write` permission is used for both:
- npm trusted publishing (OIDC authentication)
- Provenance attestation

This is a documentation fix to trigger a release and verify the new trusted publishing flow works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)