### PR TITLE
fix(publish): update npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           scope: '@daghis'
+
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Add `npm install -g npm@latest` step before publishing
- Reverts Node.js back to 20.x (as shown in npm docs)

npm trusted publishing requires npm >= 11.5.1 for OIDC support. Node 20.x ships with npm 10.x, so we need to explicitly update npm before publishing. This follows the [npm trusted publishing documentation](https://docs.npmjs.com/trusted-publishers/) exactly.

## Note on the failure
The v1.11.3 publish showed that provenance signing via OIDC succeeded:
```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log
```

But then failed with "Access token expired or revoked". This suggests either:
1. The npm version was too old for full OIDC publish support (this PR fixes that)
2. The trusted publisher configuration on npm may not match exactly

Please verify on npm that the trusted publisher is configured with:
- Repository: `Daghis/teamcity-mcp`
- Workflow filename: `publish.yml` (exact match required)

## Test plan
- [ ] CI passes
- [ ] Once merged, v1.11.4 release should publish successfully via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)