### PR TITLE
fix(publish): clear NODE_AUTH_TOKEN for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,7 @@ jobs:
         if: steps.exists.outputs.exists == 'false'
         env:
           NPM_CONFIG_PROVENANCE: 'true'
+          NODE_AUTH_TOKEN: ''  # Clear placeholder set by setup-node to enable OIDC
         run: npm publish --access public --provenance
 
       - name: Install MCP Publisher


### PR DESCRIPTION
## Summary
Clear the `NODE_AUTH_TOKEN` environment variable when publishing to enable npm OIDC trusted publishing.

## Root Cause
`actions/setup-node` automatically sets `NODE_AUTH_TOKEN` to a placeholder value (`XXXXX-XXXXX-XXXXX-XXXXX`) when you specify `registry-url`. This causes npm to attempt token-based authentication with the invalid placeholder instead of using OIDC.

This is a known issue: https://github.com/actions/setup-node/issues/1440

## Fix
Set `NODE_AUTH_TOKEN: ''` in the publish step's environment to clear the placeholder and allow npm to use OIDC authentication.

## Evidence
In previous failed publish runs, we observed:
- ✅ Provenance signing via OIDC succeeded
- ❌ Publish failed with "Access token expired or revoked"

This pattern matches the reported behavior where the placeholder token interferes with OIDC.

## Test plan
- [ ] CI passes
- [ ] v1.11.5 publishes successfully via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)