### PR TITLE
fix(publish): remove registry-url to enable npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.x
-          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
-          scope: '@daghis'
+          # Note: registry-url is intentionally omitted to enable OIDC trusted publishing
+          # See: https://github.com/actions/setup-node/issues/1440
 
       - name: Update npm for OIDC trusted publishing
         run: npm install -g npm@latest
@@ -71,9 +71,6 @@ jobs:
 
       - name: Publish to npm
         if: steps.exists.outputs.exists == 'false'
-        env:
-          NPM_CONFIG_PROVENANCE: 'true'
-          NODE_AUTH_TOKEN: ''  # Clear placeholder set by setup-node to enable OIDC
         run: npm publish --access public --provenance
 
       - name: Install MCP Publisher


### PR DESCRIPTION
## Summary
Remove `registry-url` and `scope` from `actions/setup-node` configuration to enable npm OIDC trusted publishing.

## Root Cause
When `actions/setup-node` is configured with `registry-url`, it creates an `.npmrc` file that expects `NODE_AUTH_TOKEN`. Even when clearing that token, npm still tries to use token-based authentication because the `.npmrc` file structure expects it.

## Fix
By omitting `registry-url` entirely, we:
1. Prevent setup-node from creating an `.npmrc` that expects a token
2. Allow npm to detect the OIDC environment and use it for authentication
3. Follow the pattern used by successful OIDC publishing workflows

This matches the working example from [this discussion](https://github.com/orgs/community/discussions/176761#discussioncomment-15066288).

## Previous Attempts
- v1.11.3: Failed with placeholder token interference
- v1.11.4: Failed with same error (Node 20 + npm update)
- v1.11.5: Failed with ENEEDAUTH (cleared token but .npmrc still expected it)

## Test plan
- [ ] CI passes
- [ ] v1.11.6 publishes successfully via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)