### PR TITLE
fix(publish): clear NODE_AUTH_TOKEN via GITHUB_ENV for OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,24 @@ jobs:
         with:
           node-version: 20.x
           cache: 'npm'
-          # Note: registry-url is intentionally omitted to enable OIDC trusted publishing
-          # See: https://github.com/actions/setup-node/issues/1440
+
+      - name: Clear NODE_AUTH_TOKEN for OIDC
+        # actions/setup-node sets a placeholder NODE_AUTH_TOKEN that blocks OIDC
+        # See: https://github.com/actions/setup-node/issues/1440
+        run: echo "NODE_AUTH_TOKEN=" >> $GITHUB_ENV
 
       - name: Update npm for OIDC trusted publishing
         run: npm install -g npm@latest
+
+      - name: Configure npm registry
+        run: npm config set registry https://registry.npmjs.org/
+
+      - name: Verify npm configuration
+        run: |
+          echo "npm version: $(npm --version)"
+          echo "node version: $(node --version)"
+          echo "NODE_AUTH_TOKEN is set: $([[ -n \"$NODE_AUTH_TOKEN\" ]] && echo 'yes' || echo 'no')"
+          npm config list
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Clear NODE_AUTH_TOKEN via `$GITHUB_ENV` to properly disable the placeholder token
- Explicitly configure npm registry
- Add debug output to verify configuration

## Root Cause
`actions/setup-node` sets a placeholder `NODE_AUTH_TOKEN` that blocks npm's OIDC authentication. Our previous attempts failed because:
- PR #275: Set `NODE_AUTH_TOKEN: ''` in step env block - didn't work
- PR #277: Removed `registry-url` - didn't work

The fix is to clear the token via `$GITHUB_ENV` which properly persists across steps.

## References
- Working example: https://github.com/Workday/canvas-kit/blob/master/.github/workflows/release.yml
- GitHub discussion: https://github.com/orgs/community/discussions/176761
- setup-node issue: https://github.com/actions/setup-node/issues/1440

## Test plan
- [ ] Merge this PR
- [ ] Release-please creates v1.11.7 release PR
- [ ] Merge release PR
- [ ] Verify publish workflow succeeds with OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)