### PR TITLE
fix(publish): remove .npmrc files that block OIDC authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,12 @@ jobs:
       - name: Clear NODE_AUTH_TOKEN for OIDC
         # actions/setup-node sets a placeholder NODE_AUTH_TOKEN that blocks OIDC
         # See: https://github.com/actions/setup-node/issues/1440
-        run: echo "NODE_AUTH_TOKEN=" >> $GITHUB_ENV
+        run: |
+          # Unset the environment variable
+          echo "NODE_AUTH_TOKEN=" >> $GITHUB_ENV
+          # Remove any .npmrc files that might contain auth token references
+          rm -f ~/.npmrc
+          rm -f .npmrc
 
       - name: Update npm for OIDC trusted publishing
         run: npm install -g npm@latest
@@ -51,7 +56,12 @@ jobs:
         run: |
           echo "npm version: $(npm --version)"
           echo "node version: $(node --version)"
-          echo "NODE_AUTH_TOKEN is set: $([[ -n \"$NODE_AUTH_TOKEN\" ]] && echo 'yes' || echo 'no')"
+          echo "NODE_AUTH_TOKEN value: '${NODE_AUTH_TOKEN}'"
+          echo "--- ~/.npmrc ---"
+          cat ~/.npmrc 2>/dev/null || echo "(no ~/.npmrc)"
+          echo "--- .npmrc ---"
+          cat .npmrc 2>/dev/null || echo "(no .npmrc)"
+          echo "--- npm config ---"
           npm config list
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Remove any `.npmrc` files that might contain auth token references
- Add detailed debugging output to diagnose what's being configured

## Root Cause
Even when `NODE_AUTH_TOKEN` is cleared via `$GITHUB_ENV`, there may be `.npmrc` files with `${NODE_AUTH_TOKEN}` that npm tries to expand, causing authentication failures.

## Test plan
- [ ] Merge this PR
- [ ] Wait for v1.11.8 release
- [ ] Verify publish succeeds or check debug output for clues

🤖 Generated with [Claude Code](https://claude.com/claude-code)