### PR TITLE
fix(publish): simplify OIDC workflow to match npm docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,24 +35,10 @@ jobs:
         with:
           node-version: 20.x
           cache: 'npm'
-
-      - name: Clear NODE_AUTH_TOKEN for OIDC
-        # actions/setup-node sets a placeholder NODE_AUTH_TOKEN that blocks OIDC
-        # See: https://github.com/actions/setup-node/issues/1440
-        run: echo "NODE_AUTH_TOKEN=" >> $GITHUB_ENV
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for OIDC trusted publishing
         run: npm install -g npm@latest
-
-      - name: Configure npm registry
-        run: npm config set registry https://registry.npmjs.org/
-
-      - name: Verify npm configuration
-        run: |
-          echo "npm version: $(npm --version)"
-          echo "node version: $(node --version)"
-          echo "NODE_AUTH_TOKEN is set: $([[ -n \"$NODE_AUTH_TOKEN\" ]] && echo 'yes' || echo 'no')"
-          npm config list
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
Reverts debugging attempts and simplifies the workflow to match the official npm docs example.

## Root Cause
The actual issue was **case sensitivity** in the npm trusted publisher configuration:
- npm had: `daghis` (lowercase)
- GitHub has: `Daghis` (capitalized)

## Changes
- Removes debugging/workaround steps added during investigation
- Adds `registry-url` back (per npm docs)
- Clean, minimal workflow matching npm trusted publishing docs

## Test plan
- [ ] Verify npm trusted publisher config now has correct case: `Daghis`
- [ ] Merge this PR
- [ ] v1.11.8 release should publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)