### PR TITLE
fix(publish): update mcp-publisher to v1.3.10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,8 @@ jobs:
       - name: Install MCP Publisher
         if: steps.exists.outputs.exists == 'false' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_registry == 'true')
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+          VERSION="1.3.10"
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v${VERSION}/mcp-publisher_${VERSION}_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
             | tar xz mcp-publisher
 
       - name: Login to MCP Registry


### PR DESCRIPTION
## Summary
Updates mcp-publisher from v1.0.0 to v1.3.10

## Problem
The MCP Registry publish step was failing with:
```
Error: publish failed: server returned status 422: {"title":"Unprocessable Entity","status":422,"detail":"validation failed","errors":[{"message":"expected required property registryType to be present"...
```

The old v1.0.0 publisher wasn't properly reading the `registryType` field from `server.json`.

## Test plan
- [ ] Merge this PR
- [ ] Trigger workflow_dispatch with `publish_to_registry: true` to test MCP Registry publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)