### PR TITLE
fix(publish): correct mcp-publisher download URL format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,8 +75,7 @@ jobs:
       - name: Install MCP Publisher
         if: steps.exists.outputs.exists == 'false' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_registry == 'true')
         run: |
-          VERSION="1.3.10"
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v${VERSION}/mcp-publisher_${VERSION}_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.3.10/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
             | tar xz mcp-publisher
 
       - name: Login to MCP Registry


### PR DESCRIPTION
## Summary
Fixes the mcp-publisher download URL to match the v1.3.10 release format.

## Problem
The v1.3.10 release uses a different filename format:
- Old (v1.0.0): `mcp-publisher_1.0.0_linux_amd64.tar.gz`
- New (v1.3.10): `mcp-publisher_linux_amd64.tar.gz`

## Test plan
- [ ] Merge this PR
- [ ] Trigger workflow_dispatch with `publish_to_registry: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)