### PR TITLE
fix: update MCP server schema to 2025-09-29

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.daghis/teamcity",
   "description": "MCP server exposing JetBrains TeamCity CI/CD workflows to AI coding assistants",
   "repository": {


### PR DESCRIPTION
## Summary
Updates the server.json schema from 2025-09-16 to 2025-09-29.

## Problem
mcp-publisher v1.3.10 rejects the old schema:
```
Error: deprecated schema detected: https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)