### PR TITLE
fix: update MCP registry schema to 2025-10-17

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.daghis/teamcity",
   "description": "MCP server exposing JetBrains TeamCity CI/CD workflows to AI coding assistants",
   "repository": {


### PR DESCRIPTION
## Summary
- Updates server.json schema from deprecated 2025-09-29 to current 2025-10-17

This should fix MCP Registry publishing which was failing with:
> server.json uses deprecated schema version 2025-09-29

## Test plan
- [ ] CI passes
- [ ] After merge, verify MCP Registry publish succeeds in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)