### PR TITLE
fix: correct MCP name case to match GitHub username

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@daghis/teamcity-mcp",
   "version": "1.11.12",
   "description": "Model Control Protocol server for TeamCity CI/CD integration with AI coding assistants",
-  "mcpName": "io.github.daghis/teamcity",
+  "mcpName": "io.github.Daghis/teamcity",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-  "name": "io.github.daghis/teamcity",
+  "name": "io.github.Daghis/teamcity",
   "description": "MCP server exposing JetBrains TeamCity CI/CD workflows to AI coding assistants",
   "repository": {
     "url": "https://github.com/Daghis/teamcity-mcp",


### PR DESCRIPTION
## Summary
- Changes `io.github.daghis/teamcity` → `io.github.Daghis/teamcity` in both `server.json` and `package.json`

The MCP Registry uses GitHub OIDC which is case-sensitive. Error was:
> You have permission to publish: io.github.Daghis/*. Attempting to publish: io.github.daghis/teamcity

## Test plan
- [ ] CI passes
- [ ] After merge, verify MCP Registry publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)