### PR TITLE
fix: tune codecov PR comment behavior

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,7 @@ coverage:
 
 comment:
   layout: "reach,diff,flags,files"
-  behavior: default
+  behavior: once
   require_changes: true
   hide_project_coverage: false
+  hide_unchanged_files: true


### PR DESCRIPTION
## Summary

- Change `behavior` from `default` to `once` - posts one comment per PR and updates it
- Add `hide_unchanged_files: true` to reduce noise in PR comments

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)