### PR TITLE
feat!: reduce dev mode tool surface

### DIFF
--- a/docs/mcp-tools-mode-matrix.md
+++ b/docs/mcp-tools-mode-matrix.md
@@ -36,27 +36,27 @@ Legend: Dev = developer-focused (PRs/builds/logs/trigger, read-only config). Ful
 | Parameters | `add_parameter` | No | Yes |
 | Parameters | `update_parameter` | No | Yes |
 | Parameters | `delete_parameter` | No | Yes |
-| VCS | `list_vcs_roots` | Yes | Yes |
-| VCS | `get_vcs_root` | Yes | Yes |
-| VCS | `get_versioned_settings_status` | Yes | Yes |
+| VCS | `list_vcs_roots` | No | Yes |
+| VCS | `get_vcs_root` | No | Yes |
+| VCS | `get_versioned_settings_status` | No | Yes |
 | VCS | `create_vcs_root` | No | Yes |
 | VCS | `add_vcs_root_to_build` | No | Yes |
 | VCS | `set_vcs_root_property` | No | Yes |
 | VCS | `delete_vcs_root_property` | No | Yes |
 | VCS | `update_vcs_root_properties` | No | Yes |
-| Agents | `list_agents` | Yes | Yes |
-| Agents | `list_agent_pools` | Yes | Yes |
-| Agents | `get_agent_enabled_info` | Yes | Yes |
+| Agents | `list_agents` | No | Yes |
+| Agents | `list_agent_pools` | No | Yes |
+| Agents | `get_agent_enabled_info` | No | Yes |
 | Agents | `authorize_agent` | No | Yes |
 | Agents | `assign_agent_to_pool` | No | Yes |
 | Agents | `set_agent_enabled` | No | Yes |
 | Agents | `bulk_set_agents_enabled` | No | Yes |
 | Agents | `manage_agent_requirements` | No | Yes |
-| Compatibility | `get_compatible_agents_for_build_type` | Yes | Yes |
-| Compatibility | `count_compatible_agents_for_build_type` | Yes | Yes |
-| Compatibility | `get_compatible_agents_for_queued_build` | Yes | Yes |
-| Compatibility | `get_compatible_build_types_for_agent` | Yes | Yes |
-| Compatibility | `get_incompatible_build_types_for_agent` | Yes | Yes |
+| Compatibility | `get_compatible_agents_for_build_type` | No | Yes |
+| Compatibility | `count_compatible_agents_for_build_type` | No | Yes |
+| Compatibility | `get_compatible_agents_for_queued_build` | No | Yes |
+| Compatibility | `get_compatible_build_types_for_agent` | No | Yes |
+| Compatibility | `get_incompatible_build_types_for_agent` | No | Yes |
 | Queue | `list_queued_builds` | Yes | Yes |
 | Queue | `move_queued_build_to_top` | No | Yes |
 | Queue | `reorder_queued_builds` | No | Yes |
@@ -65,8 +65,8 @@ Legend: Dev = developer-focused (PRs/builds/logs/trigger, read-only config). Ful
 | Queue | `pause_queue_for_pool` | No | Yes |
 | Queue | `resume_queue_for_pool` | No | Yes |
 | Server | `get_server_info` | Yes | Yes |
-| Server | `check_teamcity_connection` | Yes | Yes |
-| Server | `check_availability_guard` | Yes | Yes |
+| Server | `check_teamcity_connection` | No | Yes |
+| Server | `check_availability_guard` | No | Yes |
 | Server | `get_server_metrics` | No | Yes |
 | Server | `list_server_health_items` | No | Yes |
 | Server | `get_server_health_item` | No | Yes |
@@ -79,10 +79,11 @@ Legend: Dev = developer-focused (PRs/builds/logs/trigger, read-only config). Ful
 | Problems | `list_problem_occurrences` | Yes | Yes |
 | Investigations | `list_investigations` | Yes | Yes |
 | Branches | `list_branches` | Yes | Yes |
-| Users & Roles | `list_users` | Yes | Yes |
-| Users & Roles | `list_roles` | Yes | Yes |
+| Users & Roles | `list_users` | No | Yes |
+| Users & Roles | `list_roles` | No | Yes |
 
-**Summary:** 77 tools total — 42 available in Dev mode, 35 Full-only.
+**Summary:** 77 tools total — 27 available in Dev mode, 50 Full-only.
 
 Notes:
-- Dev mode excludes TeamCity administration and agent/pool management tools to reduce surface and context size, while keeping all read operations and developer workflows (including `trigger_build`).
+- Dev mode focuses on developer workflows (builds, tests, logs) and excludes infrastructure/admin tools to reduce context size (~4-5k tokens saved).
+- Admin tools (agents, VCS roots, users, compatibility checks) require Full mode.

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1585,6 +1585,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
 
   {
@@ -1619,6 +1620,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
 
   {
@@ -2019,6 +2021,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
 
   // === Agent Compatibility (read-only lookups) ===
@@ -2043,6 +2046,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
   {
     name: 'get_incompatible_build_types_for_agent',
@@ -2065,6 +2069,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
   {
     name: 'get_agent_enabled_info',
@@ -2087,6 +2092,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
   {
     name: 'get_compatible_agents_for_build_type',
@@ -2121,6 +2127,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
   {
     name: 'count_compatible_agents_for_build_type',
@@ -2156,6 +2163,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
   {
     name: 'get_compatible_agents_for_queued_build',
@@ -2194,6 +2202,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
   {
     name: 'check_teamcity_connection',
@@ -2204,6 +2213,7 @@ const DEV_TOOLS: ToolDefinition[] = [
       const ok = await adapter.testConnection();
       return json({ ok });
     },
+    mode: 'full',
   },
 
   // === Agent Tools ===
@@ -2269,6 +2279,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
 
   {
@@ -2333,6 +2344,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
 
   // === Additional Tools from Complex Implementation ===
@@ -3232,6 +3244,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
 
   {
@@ -3301,6 +3314,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
 
   {
@@ -3329,6 +3343,7 @@ const DEV_TOOLS: ToolDefinition[] = [
         args
       );
     },
+    mode: 'full',
   },
 
   {

--- a/tests/integration/dev-tools-list.test.ts
+++ b/tests/integration/dev-tools-list.test.ts
@@ -8,6 +8,7 @@ const hasTeamCityEnv = Boolean(
 );
 
 // Expected dev-mode tools as per docs/mcp-tools-mode-matrix.md
+// Note: 27 dev-mode tools focused on developer workflows; admin/infrastructure tools moved to full mode
 const EXPECTED_DEV_TOOLS = new Set([
   'ping',
   // Projects
@@ -31,35 +32,16 @@ const EXPECTED_DEV_TOOLS = new Set([
   'list_problem_occurrences',
   'list_investigations',
   'list_muted_tests',
-  'get_versioned_settings_status',
   // Build Configs
   'list_build_configs',
   'get_build_config',
   // Tests
   'list_test_failures',
   'get_test_details',
-  // VCS
-  'list_vcs_roots',
-  'get_vcs_root',
   // Queue
   'list_queued_builds',
   // Server
   'get_server_info',
-  'check_teamcity_connection',
-  'check_availability_guard',
-  // Agents (read-only)
-  'list_agents',
-  'list_agent_pools',
-  'get_agent_enabled_info',
-  // Users & roles
-  'list_users',
-  'list_roles',
-  // Compatibility (read-only)
-  'get_compatible_build_types_for_agent',
-  'get_incompatible_build_types_for_agent',
-  'get_compatible_agents_for_build_type',
-  'count_compatible_agents_for_build_type',
-  'get_compatible_agents_for_queued_build',
   // Branches & Params
   'list_branches',
   'list_parameters',

--- a/tests/integration/e2e-scenario.test.ts
+++ b/tests/integration/e2e-scenario.test.ts
@@ -108,10 +108,11 @@ serialDescribe('E2E scenario: full setup → dev reads → full teardown', () =>
     }
   }, 90_000);
 
-  it('lists agents and compatibility (dev)', async () => {
+  it('lists agents and compatibility (full)', async () => {
     if (!hasTeamCityEnv || !fixture) return expect(true).toBe(true);
 
-    const agentResults = await callToolsBatchExpect('dev', [
+    // Agent and compatibility tools are now full-only
+    const agentResults = await callToolsBatchExpect('full', [
       { tool: 'list_agents', args: { pageSize: 10 } },
       { tool: 'get_compatible_agents_for_build_type', args: { buildTypeId: fixture.buildTypeId } },
       {

--- a/tests/integration/server-health-scenario.test.ts
+++ b/tests/integration/server-health-scenario.test.ts
@@ -8,9 +8,10 @@ const hasTeamCityEnv = Boolean(
 );
 
 describe('Server env and health checks', () => {
-  it('get_server_info and check_teamcity_connection (dev)', async () => {
+  it('get_server_info (dev) and check_teamcity_connection (full)', async () => {
     if (!hasTeamCityEnv) return expect(true).toBe(true);
-    const results = await callToolsBatchExpect('dev', [
+    // get_server_info is dev-mode, check_teamcity_connection is full-only
+    const results = await callToolsBatchExpect('full', [
       { tool: 'get_server_info', args: {} },
       { tool: 'check_teamcity_connection', args: {} },
     ]);
@@ -22,9 +23,10 @@ describe('Server env and health checks', () => {
     expect(conn).toHaveProperty('ok');
   }, 30000);
 
-  it('check_availability_guard (dev)', async () => {
+  it('check_availability_guard (full)', async () => {
     if (!hasTeamCityEnv) return expect(true).toBe(true);
-    const results = await callToolsBatchExpect('dev', [
+    // check_availability_guard is full-only
+    const results = await callToolsBatchExpect('full', [
       { tool: 'check_availability_guard', args: {} },
       { tool: 'check_availability_guard', args: { failOnWarning: true } },
     ]);

--- a/tests/integration/vcs-properties-update-scenario.test.ts
+++ b/tests/integration/vcs-properties-update-scenario.test.ts
@@ -4,7 +4,7 @@ import type { ActionResult, ListResult } from '../types/tool-results';
 import { callTool, callToolsBatch, callToolsBatchExpect } from './lib/mcp-runner';
 import { hasTeamCityEnv, teardownProjectFixture } from './lib/test-fixtures';
 
-describe('VCS root property updates: full writes + dev reads', () => {
+describe('VCS root property updates: full mode', () => {
   const ts = Date.now();
   const projectId = `E2E_VCS_PROPS_${ts}`;
   const vcsId = `E2E_VCS_ROOT_PROPS_${ts}`;
@@ -48,7 +48,7 @@ describe('VCS root property updates: full writes + dev reads', () => {
     }
   });
 
-  it('updates branch and branchSpec via MCP and verifies with dev', async () => {
+  it('updates branch and branchSpec via MCP and verifies', async () => {
     if (!hasTeamCityEnv || !created) return expect(true).toBe(true);
 
     const update = await callTool<ActionResult>('full', 'update_vcs_root_properties', {
@@ -58,7 +58,8 @@ describe('VCS root property updates: full writes + dev reads', () => {
     });
     expect(update).toMatchObject({ success: true, action: 'update_vcs_root_properties' });
 
-    const devBatch = await callToolsBatch('dev', [
+    // VCS tools are now full-only
+    const devBatch = await callToolsBatch('full', [
       { tool: 'get_vcs_root', args: { id: vcsId } },
       { tool: 'list_vcs_roots', args: { projectId } },
     ]);
@@ -98,7 +99,8 @@ describe('VCS root property updates: full writes + dev reads', () => {
     });
     expect(update2).toMatchObject({ success: true, action: 'update_vcs_root_properties' });
 
-    const get2 = (await callTool('dev', 'get_vcs_root', { id: vcsId })) as unknown as {
+    // VCS tools are now full-only
+    const get2 = (await callTool('full', 'get_vcs_root', { id: vcsId })) as unknown as {
       id: string;
       properties?: { property?: Array<{ name?: string; value?: string }> };
     };

--- a/tests/integration/vcs-scenario.test.ts
+++ b/tests/integration/vcs-scenario.test.ts
@@ -54,10 +54,11 @@ describe('VCS roots: full writes + dev reads', () => {
     }
   });
 
-  it('verifies VCS root with get/list (dev)', async () => {
+  it('verifies VCS root with get/list (full)', async () => {
     if (!hasTeamCityEnv || !created) return expect(true).toBe(true);
 
-    const devBatch = await callToolsBatch('dev', [
+    // VCS tools are now full-only
+    const devBatch = await callToolsBatch('full', [
       { tool: 'get_vcs_root', args: { id: vcsId } },
       { tool: 'list_vcs_roots', args: { projectId } },
     ]);

--- a/tests/unit/tools/changes-problems-admin.test.ts
+++ b/tests/unit/tools/changes-problems-admin.test.ts
@@ -1,5 +1,12 @@
 import { type ToolDefinition, getRequiredTool } from '@/tools';
 
+// Full mode needed for list_users, list_roles, get_versioned_settings_status
+jest.mock('@/config', () => ({
+  getTeamCityUrl: () => 'https://example.test',
+  getTeamCityToken: () => 'token',
+  getMCPMode: () => 'full',
+}));
+
 type PaginatedMock = jest.Mock<Promise<{ data: Record<string, unknown> }>, [string?]>;
 
 const createPaginatedMock = (items: unknown[], key: string): PaginatedMock =>

--- a/tests/unit/tools/compatibility-lookups.test.ts
+++ b/tests/unit/tools/compatibility-lookups.test.ts
@@ -1,8 +1,8 @@
-// Force dev mode (read-only) for lookup tools
+// Force full mode for compatibility lookup tools (moved out of dev mode)
 jest.mock('@/config', () => ({
   getTeamCityUrl: () => 'https://example.test',
   getTeamCityToken: () => 'token',
-  getMCPMode: () => 'dev',
+  getMCPMode: () => 'full',
 }));
 
 describe('tools: compatibility lookups', () => {

--- a/tests/unit/tools/list-pagination-all.test.ts
+++ b/tests/unit/tools/list-pagination-all.test.ts
@@ -1,8 +1,8 @@
-// Dev mode is fine for list tools
+// Full mode needed for list_agents, list_agent_pools, list_vcs_roots
 jest.mock('@/config', () => ({
   getTeamCityUrl: () => 'https://example.test',
   getTeamCityToken: () => 'token',
-  getMCPMode: () => 'dev',
+  getMCPMode: () => 'full',
 }));
 
 function parseCount(locator?: string): { count: number; start: number } {

--- a/tests/unit/tools/simple-getters.test.ts
+++ b/tests/unit/tools/simple-getters.test.ts
@@ -1,10 +1,10 @@
-// Dev mode ok for getters/ping
+// Full mode for tests that include check_teamcity_connection (now full-only)
 // Use required tool helper to avoid undefined checks
 
 jest.mock('@/config', () => ({
   getTeamCityUrl: () => 'https://example.test',
   getTeamCityToken: () => 'token',
-  getMCPMode: () => 'dev',
+  getMCPMode: () => 'full',
 }));
 
 describe('tools: simple getters and utilities', () => {


### PR DESCRIPTION
## Summary

This is a **breaking change** that reduces the Dev mode tool surface from 42 to 27 tools, saving ~4-5k tokens of context and focusing Dev mode on actual developer workflows.

### Tools moved to Full-only (15)

| Category | Tools |
|----------|-------|
| Users & Roles | `list_users`, `list_roles` |
| Agents | `list_agents`, `list_agent_pools`, `get_agent_enabled_info` |
| Compatibility | `get_compatible_agents_for_build_type`, `count_compatible_agents_for_build_type`, `get_compatible_agents_for_queued_build`, `get_compatible_build_types_for_agent`, `get_incompatible_build_types_for_agent` |
| VCS | `list_vcs_roots`, `get_vcs_root`, `get_versioned_settings_status` |
| Server | `check_teamcity_connection`, `check_availability_guard` |

### Rationale

- **Agent/Compatibility tools**: Infrastructure monitoring and capacity planning, not developer workflows
- **VCS tools**: Configuration/admin tasks, not needed for day-to-day development
- **User/Role tools**: Admin tasks
- **Server tools**: `check_teamcity_connection` is redundant with `ping`, `check_availability_guard` is server admin

### What stays in Dev mode

- `get_server_info` - useful for version diagnostics
- `cancel_queued_build` - developer convenience (single-build, lower risk than bulk operations)

### Migration

Users relying on these tools must switch to Full mode:
- Set `MCP_MODE=full` environment variable, or
- Use `--mode full` CLI argument

## Test plan

- [x] All unit tests pass
- [x] All integration tests updated to use correct modes
- [x] Documentation updated (`docs/mcp-tools-mode-matrix.md`)
- [x] `EXPECTED_DEV_TOOLS` test updated to match new tool set

🤖 Generated with [Claude Code](https://claude.com/claude-code)