### PR TITLE
fix: resolve HTTP 400 when updating artifactRules via update_build_config

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3842,7 +3842,7 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
           }
           if (typedArgs.artifactRules !== undefined) {
             await setArtifactRulesWithFallback(
-              adapter.modules.buildTypes,
+              adapter.http,
               typedArgs.buildTypeId,
               typedArgs.artifactRules
             );
@@ -3866,7 +3866,7 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
         }
         if (typedArgs.artifactRules !== undefined) {
           await setArtifactRulesWithFallback(
-            adapter.modules.buildTypes,
+            adapter.http,
             typedArgs.buildTypeId,
             typedArgs.artifactRules
           );

--- a/tests/tools.update-build-config.test.ts
+++ b/tests/tools.update-build-config.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for update_build_config tool
- * Verifies artifactRules uses settings/ path and other fields remain unchanged
+ * Verifies artifactRules uses direct HTTP (not the OpenAPI client) and other fields remain unchanged
  */
 import type { ToolDefinition } from '@/tools';
 
@@ -19,6 +19,9 @@ jest.mock('@/utils/logger', () => ({
   }),
 }));
 
+// Mock axios put for artifact rules (bypasses OpenAPI client)
+const mockPut = jest.fn(async () => ({ data: 'OK' }));
+
 // Mock TeamCityAPI to capture setBuildTypeField calls
 const setBuildTypeField = jest.fn(async () => ({ data: 'OK' }));
 const getBuildType = jest.fn(async () => ({
@@ -34,6 +37,13 @@ const getBuildType = jest.fn(async () => ({
 jest.mock('@/api-client', () => ({
   TeamCityAPI: {
     getInstance: jest.fn(() => ({
+      http: {
+        put: mockPut,
+        defaults: {
+          baseURL: 'https://teamcity.test.local',
+          timeout: 30000,
+        },
+      },
       buildTypes: {
         getBuildType,
         setBuildTypeField,
@@ -45,9 +55,11 @@ jest.mock('@/api-client', () => ({
 describe('Tool: update_build_config', () => {
   beforeEach(() => {
     setBuildTypeField.mockClear();
+    mockPut.mockClear();
+    mockPut.mockResolvedValue({ data: 'OK' });
   });
 
-  it('uses settings/artifactRules for artifact rules update', async () => {
+  it('uses direct HTTP PUT for artifact rules update (bypassing OpenAPI client)', async () => {
     const { getRequiredTool } = await import('../src/tools');
     const tool = getRequiredTool('update_build_config') as ToolDefinition;
 
@@ -61,7 +73,7 @@ describe('Tool: update_build_config', () => {
 
     await tool.handler(args);
 
-    // Assert individual field updates
+    // Assert name/description/paused still use OpenAPI client
     expect(setBuildTypeField).toHaveBeenCalledWith(
       'HoneycombHaven_ApiGatewayBuild',
       'name',
@@ -77,14 +89,28 @@ describe('Tool: update_build_config', () => {
       'paused',
       'true'
     );
-    expect(setBuildTypeField).toHaveBeenCalledWith(
-      'HoneycombHaven_ApiGatewayBuild',
+
+    // Artifact rules should use direct HTTP PUT with unencoded slashes in path
+    expect(mockPut).toHaveBeenCalledWith(
+      '/app/rest/buildTypes/HoneycombHaven_ApiGatewayBuild/settings/artifactRules',
+      'dist/** => api-gateway-%build.number%.zip',
+      { headers: { 'Content-Type': 'text/plain' } }
+    );
+
+    // setBuildTypeField should NOT be called for artifact rules
+    expect(setBuildTypeField).not.toHaveBeenCalledWith(
+      expect.anything(),
       'settings/artifactRules',
-      'dist/** => api-gateway-%build.number%.zip'
+      expect.anything()
+    );
+    expect(setBuildTypeField).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'artifactRules',
+      expect.anything()
     );
   });
 
-  it('retries artifact rules update using legacy field when needed', async () => {
+  it('retries artifact rules update using legacy path when settings/ path fails', async () => {
     const { getRequiredTool } = await import('../src/tools');
     const tool = getRequiredTool('update_build_config') as ToolDefinition;
 
@@ -93,23 +119,50 @@ describe('Tool: update_build_config', () => {
       artifactRules: 'dist/** => legacy.zip',
     };
 
-    setBuildTypeField.mockRejectedValueOnce(
+    // First call to settings/artifactRules fails with 400
+    mockPut.mockRejectedValueOnce(
       Object.assign(new Error('bad request'), { response: { status: 400 } })
     );
 
     await tool.handler(args);
 
-    expect(setBuildTypeField).toHaveBeenNthCalledWith(
+    // First attempt: settings/artifactRules
+    expect(mockPut).toHaveBeenNthCalledWith(
       1,
-      'HoneycombHaven_ApiGatewayBuild',
-      'settings/artifactRules',
-      'dist/** => legacy.zip'
+      '/app/rest/buildTypes/HoneycombHaven_ApiGatewayBuild/settings/artifactRules',
+      'dist/** => legacy.zip',
+      { headers: { 'Content-Type': 'text/plain' } }
     );
-    expect(setBuildTypeField).toHaveBeenNthCalledWith(
+
+    // Fallback: artifactRules (legacy path)
+    expect(mockPut).toHaveBeenNthCalledWith(
       2,
-      'HoneycombHaven_ApiGatewayBuild',
-      'artifactRules',
-      'dist/** => legacy.zip'
+      '/app/rest/buildTypes/HoneycombHaven_ApiGatewayBuild/artifactRules',
+      'dist/** => legacy.zip',
+      { headers: { 'Content-Type': 'text/plain' } }
+    );
+  });
+
+  it('properly encodes buildTypeId in URL path', async () => {
+    const { getRequiredTool } = await import('../src/tools');
+    const tool = getRequiredTool('update_build_config') as ToolDefinition;
+
+    // buildTypeId with special characters that need encoding
+    const args = {
+      buildTypeId: 'Project_Build With Spaces',
+      artifactRules: 'output/** => build.zip',
+    };
+
+    // Make getBuildType throw to trigger fallback path which uses typedArgs.buildTypeId directly
+    getBuildType.mockRejectedValueOnce(new Error('not found'));
+
+    await tool.handler(args);
+
+    // buildTypeId should be URL-encoded, but the settings/artifactRules path should NOT
+    expect(mockPut).toHaveBeenCalledWith(
+      '/app/rest/buildTypes/Project_Build%20With%20Spaces/settings/artifactRules',
+      'output/** => build.zip',
+      { headers: { 'Content-Type': 'text/plain' } }
     );
   });
 });

--- a/tests/unit/teamcity/build-configuration-update-manager.test.ts
+++ b/tests/unit/teamcity/build-configuration-update-manager.test.ts
@@ -43,6 +43,8 @@ describe('BuildConfigurationUpdateManager', () => {
     mockClient.resetAllMocks();
     mockClient.buildTypes.setBuildTypeField.mockResolvedValue(undefined);
     mockClient.buildTypes.deleteBuildParameterOfBuildType_2.mockResolvedValue(undefined);
+    // Mock http.put for artifact rules (uses direct HTTP instead of OpenAPI client)
+    (mockClient.http.put as jest.Mock).mockResolvedValue({ data: 'OK' });
 
     manager = createManager();
   });
@@ -207,11 +209,12 @@ describe('BuildConfigurationUpdateManager', () => {
       retrieveSpy.mockRestore();
     });
 
-    it('falls back to legacy artifactRules field when settings path is rejected', async () => {
+    it('falls back to legacy artifactRules path when settings path is rejected', async () => {
       const error = Object.assign(new Error('bad request'), {
         response: { status: 400 },
       });
-      mockClient.buildTypes.setBuildTypeField.mockRejectedValueOnce(error);
+      // First http.put call for settings/artifactRules fails
+      (mockClient.http.put as jest.Mock).mockRejectedValueOnce(error);
       const retrieveSpy = jest
         .spyOn(manager, 'retrieveConfiguration')
         .mockResolvedValue({ ...updatedConfig, artifactRules: 'dist/** => archive.zip' });
@@ -222,17 +225,18 @@ describe('BuildConfigurationUpdateManager', () => {
         })
       ).resolves.toEqual({ ...updatedConfig, artifactRules: 'dist/** => archive.zip' });
 
-      expect(mockClient.buildTypes.setBuildTypeField).toHaveBeenNthCalledWith(
+      // Uses direct HTTP PUT (not OpenAPI client) with unencoded slashes in path
+      expect(mockClient.http.put).toHaveBeenNthCalledWith(
         1,
-        'cfg1',
-        'settings/artifactRules',
-        'dist/** => archive.zip'
+        '/app/rest/buildTypes/cfg1/settings/artifactRules',
+        'dist/** => archive.zip',
+        { headers: { 'Content-Type': 'text/plain' } }
       );
-      expect(mockClient.buildTypes.setBuildTypeField).toHaveBeenNthCalledWith(
+      expect(mockClient.http.put).toHaveBeenNthCalledWith(
         2,
-        'cfg1',
-        'artifactRules',
-        'dist/** => archive.zip'
+        '/app/rest/buildTypes/cfg1/artifactRules',
+        'dist/** => archive.zip',
+        { headers: { 'Content-Type': 'text/plain' } }
       );
 
       retrieveSpy.mockRestore();

--- a/tests/unit/tools/project-build-crud.test.ts
+++ b/tests/unit/tools/project-build-crud.test.ts
@@ -239,8 +239,17 @@ describe('tools: project/build CRUD & updates', () => {
       jest.isolateModules(() => {
         (async () => {
           const setBuildTypeField = jest.fn(async () => ({}));
+          const mockPut = jest.fn(async () => ({ data: 'OK' }));
           jest.doMock('@/api-client', () => ({
-            TeamCityAPI: { getInstance: () => ({ buildTypes: { setBuildTypeField } }) },
+            TeamCityAPI: {
+              getInstance: () => ({
+                http: {
+                  put: mockPut,
+                  defaults: { baseURL: 'https://test.local', timeout: 30000 },
+                },
+                buildTypes: { setBuildTypeField },
+              }),
+            },
           }));
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           const { getRequiredTool } = require('@/tools');


### PR DESCRIPTION
## Summary

- Fix HTTP 400 error when setting `artifactRules` via `update_build_config` tool
- Bypass OpenAPI client's URL encoding issue (`/` → `%2F`) by using direct HTTP PUT
- Maintain fallback to legacy `artifactRules` path for older TeamCity servers

## Root Cause

The auto-generated OpenAPI client (`@openapitools/openapi-generator-cli` with `typescript-axios`) uses `encodeURIComponent()` on path parameters, which encodes `/` to `%2F`. TeamCity's API expects unencoded slashes in paths like `/app/rest/buildTypes/{id}/settings/artifactRules`.

## Test plan

- [x] Unit tests pass for `tools.update-build-config.test.ts` (3/3)
- [x] Unit tests pass for `build-configuration-update-manager.test.ts` (13/13)
- [x] Integration test passes against real TeamCity server
- [x] TypeScript build compiles successfully
- [x] Lint passes on modified files

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)