### PR TITLE
fix: resolve HTTP 406 when updating build configuration fields

### DIFF
--- a/src/teamcity/build-configuration-update-manager.ts
+++ b/src/teamcity/build-configuration-update-manager.ts
@@ -34,7 +34,7 @@ export const setArtifactRulesWithFallback = async (
   try {
     // Primary path: settings/artifactRules (modern TeamCity)
     await http.put(`/app/rest/buildTypes/${encodedId}/settings/artifactRules`, artifactRules, {
-      headers: { 'Content-Type': 'text/plain' },
+      headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' },
     });
   } catch (err) {
     if (!isArtifactRulesRetryableError(err)) {
@@ -50,7 +50,7 @@ export const setArtifactRulesWithFallback = async (
     try {
       // Fallback path: artifactRules (older TeamCity servers)
       await http.put(`/app/rest/buildTypes/${encodedId}/artifactRules`, artifactRules, {
-        headers: { 'Content-Type': 'text/plain' },
+        headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' },
       });
     } catch (fallbackError) {
       debug('Legacy artifact rules update failed', {
@@ -402,14 +402,16 @@ export class BuildConfigurationUpdateManager {
           await this.client.modules.buildTypes.setBuildTypeField(
             currentConfig.id,
             'name',
-            updates.name
+            updates.name,
+            { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
           );
         }
         if (updates.description !== undefined) {
           await this.client.modules.buildTypes.setBuildTypeField(
             currentConfig.id,
             'description',
-            updates.description ?? ''
+            updates.description ?? '',
+            { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
           );
         }
       }
@@ -427,7 +429,8 @@ export class BuildConfigurationUpdateManager {
           await this.client.modules.buildTypes.setBuildTypeField(
             currentConfig.id,
             `settings/${setting.name}`,
-            setting.value
+            setting.value,
+            { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
           );
         }
         /* eslint-enable no-await-in-loop */
@@ -457,7 +460,8 @@ export class BuildConfigurationUpdateManager {
           await this.client.modules.buildTypes.setBuildTypeField(
             currentConfig.id,
             `parameters/${name}`,
-            value
+            value,
+            { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
           );
         }
         /* eslint-enable no-await-in-loop */

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3830,14 +3830,16 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
             await adapter.modules.buildTypes.setBuildTypeField(
               typedArgs.buildTypeId,
               'name',
-              typedArgs.name
+              typedArgs.name,
+              { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
             );
           }
           if (typedArgs.description !== undefined) {
             await adapter.modules.buildTypes.setBuildTypeField(
               typedArgs.buildTypeId,
               'description',
-              typedArgs.description
+              typedArgs.description,
+              { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
             );
           }
           if (typedArgs.artifactRules !== undefined) {
@@ -3854,14 +3856,16 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
           await adapter.modules.buildTypes.setBuildTypeField(
             typedArgs.buildTypeId,
             'name',
-            typedArgs.name
+            typedArgs.name,
+            { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
           );
         }
         if (typedArgs.description !== undefined) {
           await adapter.modules.buildTypes.setBuildTypeField(
             typedArgs.buildTypeId,
             'description',
-            typedArgs.description
+            typedArgs.description,
+            { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
           );
         }
         if (typedArgs.artifactRules !== undefined) {
@@ -3878,7 +3882,8 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
         await adapter.modules.buildTypes.setBuildTypeField(
           typedArgs.buildTypeId,
           'paused',
-          String(typedArgs.paused)
+          String(typedArgs.paused),
+          { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
         );
       }
 
@@ -4285,7 +4290,7 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
             {
               headers: {
                 'Content-Type': 'text/plain',
-                Accept: 'application/json',
+                Accept: 'text/plain',
               },
             }
           );

--- a/tests/tools.update-build-config.test.ts
+++ b/tests/tools.update-build-config.test.ts
@@ -77,24 +77,27 @@ describe('Tool: update_build_config', () => {
     expect(setBuildTypeField).toHaveBeenCalledWith(
       'HoneycombHaven_ApiGatewayBuild',
       'name',
-      'New Name'
+      'New Name',
+      { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
     );
     expect(setBuildTypeField).toHaveBeenCalledWith(
       'HoneycombHaven_ApiGatewayBuild',
       'description',
-      'New description'
+      'New description',
+      { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
     );
     expect(setBuildTypeField).toHaveBeenCalledWith(
       'HoneycombHaven_ApiGatewayBuild',
       'paused',
-      'true'
+      'true',
+      { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
     );
 
     // Artifact rules should use direct HTTP PUT with unencoded slashes in path
     expect(mockPut).toHaveBeenCalledWith(
       '/app/rest/buildTypes/HoneycombHaven_ApiGatewayBuild/settings/artifactRules',
       'dist/** => api-gateway-%build.number%.zip',
-      { headers: { 'Content-Type': 'text/plain' } }
+      { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
     );
 
     // setBuildTypeField should NOT be called for artifact rules
@@ -131,7 +134,7 @@ describe('Tool: update_build_config', () => {
       1,
       '/app/rest/buildTypes/HoneycombHaven_ApiGatewayBuild/settings/artifactRules',
       'dist/** => legacy.zip',
-      { headers: { 'Content-Type': 'text/plain' } }
+      { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
     );
 
     // Fallback: artifactRules (legacy path)
@@ -139,7 +142,7 @@ describe('Tool: update_build_config', () => {
       2,
       '/app/rest/buildTypes/HoneycombHaven_ApiGatewayBuild/artifactRules',
       'dist/** => legacy.zip',
-      { headers: { 'Content-Type': 'text/plain' } }
+      { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
     );
   });
 
@@ -162,7 +165,7 @@ describe('Tool: update_build_config', () => {
     expect(mockPut).toHaveBeenCalledWith(
       '/app/rest/buildTypes/Project_Build%20With%20Spaces/settings/artifactRules',
       'output/** => build.zip',
-      { headers: { 'Content-Type': 'text/plain' } }
+      { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
     );
   });
 });

--- a/tests/unit/teamcity/build-configuration-update-manager.test.ts
+++ b/tests/unit/teamcity/build-configuration-update-manager.test.ts
@@ -194,12 +194,14 @@ describe('BuildConfigurationUpdateManager', () => {
       expect(mockClient.buildTypes.setBuildTypeField).toHaveBeenCalledWith(
         'cfg1',
         'name',
-        'Renamed Config'
+        'Renamed Config',
+        { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
       );
       expect(mockClient.buildTypes.setBuildTypeField).toHaveBeenCalledWith(
         'cfg1',
         'settings/buildNumberPattern',
-        '%build.number%'
+        '%build.number%',
+        { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
       );
       expect(mockClient.buildTypes.deleteBuildParameterOfBuildType_2).toHaveBeenCalledWith(
         'token',
@@ -230,13 +232,13 @@ describe('BuildConfigurationUpdateManager', () => {
         1,
         '/app/rest/buildTypes/cfg1/settings/artifactRules',
         'dist/** => archive.zip',
-        { headers: { 'Content-Type': 'text/plain' } }
+        { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
       );
       expect(mockClient.http.put).toHaveBeenNthCalledWith(
         2,
         '/app/rest/buildTypes/cfg1/artifactRules',
         'dist/** => archive.zip',
-        { headers: { 'Content-Type': 'text/plain' } }
+        { headers: { 'Content-Type': 'text/plain', Accept: 'text/plain' } }
       );
 
       retrieveSpy.mockRestore();

--- a/tests/unit/tools/manage-build-config-extensions.test.ts
+++ b/tests/unit/tools/manage-build-config-extensions.test.ts
@@ -688,7 +688,7 @@ describe('build configuration extended management tools', () => {
             expect.objectContaining({
               headers: expect.objectContaining({
                 'Content-Type': 'text/plain',
-                Accept: 'application/json',
+                Accept: 'text/plain',
               }),
             })
           );
@@ -711,7 +711,7 @@ describe('build configuration extended management tools', () => {
             expect.objectContaining({
               headers: expect.objectContaining({
                 'Content-Type': 'text/plain',
-                Accept: 'application/json',
+                Accept: 'text/plain',
               }),
             })
           );


### PR DESCRIPTION
## Summary

- Fixes HTTP 406 errors when using `set_build_config_state` and `update_build_config` tools
- Root cause: `setBuildTypeField` calls used `Content-Type: text/plain` but didn't override the global `Accept: application/json` header
- TeamCity's text/plain endpoints return text/plain responses, causing content negotiation mismatch

## Changes

Added `Accept: text/plain` header to all `setBuildTypeField` calls in:
- `src/tools.ts` - 6 calls (5 in `update_build_config`, 1 in `set_build_config_state`)
- `src/teamcity/build-configuration-update-manager.ts` - 4 calls in `applyUpdates`
- `setArtifactRulesWithFallback` - 2 calls for consistency

## Test plan

- [x] All 1286 unit tests pass
- [x] Build succeeds
- [x] Integration test against live TeamCity server confirms fix

**Integration test results:**
```
--- Test 1: Accept: application/json (OLD behavior) ---
Failed as expected: 406 Request failed with status code 406

--- Test 2: Accept: text/plain (NEW behavior - the fix) ---
SUCCESS: Accept: text/plain works!

✅ Integration test PASSED - HTTP 406 fix verified!
```

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)