### PR TITLE
fix: add type parameter to manage_agent_requirements

### DIFF
--- a/src/teamcity/agent-requirements-manager.ts
+++ b/src/teamcity/agent-requirements-manager.ts
@@ -9,6 +9,7 @@ type StringMap = Record<string, string>;
 interface ManageRequirementInput {
   buildTypeId: string;
   requirementId?: string;
+  type?: string;
   properties?: Record<string, unknown>;
   disabled?: boolean;
 }
@@ -243,6 +244,7 @@ export class AgentRequirementsManager {
     const mergedProps = mergeRecords(baseProps, toStringRecord(input.properties));
     const payload: AgentRequirement = {
       ...(existing ?? {}),
+      type: input.type ?? existing?.type,
       disabled: input.disabled ?? existing?.disabled,
     };
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4172,9 +4172,33 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
           type: 'string',
           description: 'Requirement ID (required for update/delete)',
         },
+        type: {
+          type: 'string',
+          enum: [
+            'exists',
+            'not-exists',
+            'equals',
+            'does-not-equal',
+            'more-than',
+            'less-than',
+            'no-more-than',
+            'no-less-than',
+            'ver-more-than',
+            'ver-less-than',
+            'ver-no-more-than',
+            'ver-no-less-than',
+            'contains',
+            'does-not-contain',
+            'starts-with',
+            'ends-with',
+            'matches',
+            'does-not-match',
+          ],
+          description: 'Requirement type (e.g., exists, equals, contains, starts-with, matches)',
+        },
         properties: {
           type: 'object',
-          description: 'Requirement properties (e.g. property-name, condition, value)',
+          description: 'Requirement properties (e.g. property-name, property-value)',
         },
         disabled: { type: 'boolean', description: 'Disable or enable the requirement' },
       },
@@ -4182,11 +4206,32 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
     },
     handler: async (args: unknown) => {
       const propertyValue = z.union([z.string(), z.number(), z.boolean()]);
+      const requirementTypes = [
+        'exists',
+        'not-exists',
+        'equals',
+        'does-not-equal',
+        'more-than',
+        'less-than',
+        'no-more-than',
+        'no-less-than',
+        'ver-more-than',
+        'ver-less-than',
+        'ver-no-more-than',
+        'ver-no-less-than',
+        'contains',
+        'does-not-contain',
+        'starts-with',
+        'ends-with',
+        'matches',
+        'does-not-match',
+      ] as const;
       const schema = z
         .object({
           buildTypeId: z.string().min(1),
           action: z.enum(['add', 'update', 'delete']),
           requirementId: z.string().min(1).optional(),
+          type: z.enum(requirementTypes).optional(),
           properties: z.record(z.string(), propertyValue).optional(),
           disabled: z.boolean().optional(),
         })
@@ -4212,6 +4257,7 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
             case 'add': {
               const result = await manager.addRequirement({
                 buildTypeId: typed.buildTypeId,
+                type: typed.type,
                 properties: typed.properties,
                 disabled: typed.disabled,
               });
@@ -4226,6 +4272,7 @@ const FULL_MODE_TOOLS: ToolDefinition[] = [
             case 'update': {
               const result = await manager.updateRequirement(typed.requirementId as string, {
                 buildTypeId: typed.buildTypeId,
+                type: typed.type,
                 properties: typed.properties,
                 disabled: typed.disabled,
               });

--- a/tests/integration/build-config-extensions-scenario.test.ts
+++ b/tests/integration/build-config-extensions-scenario.test.ts
@@ -195,9 +195,9 @@ describe('Build configuration dependency/feature management (full)', () => {
       const requirementAdd = await callTool<ActionResult>('full', 'manage_agent_requirements', {
         buildTypeId: TARGET_BT_ID,
         action: 'add',
+        type: 'exists',
         properties: {
           'property-name': 'env.ANSIBLE',
-          condition: 'exists',
         },
       });
       expect(requirementAdd).toMatchObject({


### PR DESCRIPTION
## Summary

Fixes #338 - `manage_agent_requirements` was failing with HTTP 400 when adding agent requirements because the tool had no way to specify the requirement `type` (e.g., `exists`, `equals`, `contains`).

TeamCity requires the type as an XML attribute on the `<agent-requirement>` element, but the tool only accepted `properties`.

## Changes

- Add `type` parameter with enum validation for 18 requirement types:
  `exists`, `not-exists`, `equals`, `does-not-equal`, `more-than`, `less-than`, `no-more-than`, `no-less-than`, `ver-more-than`, `ver-less-than`, `ver-no-more-than`, `ver-no-less-than`, `contains`, `does-not-contain`, `starts-with`, `ends-with`, `matches`, `does-not-match`
- Update `ManageRequirementInput` interface and `buildPayload()` method
- Fix integration test to use `type` param instead of `condition` property
- Add unit tests for type handling

## Test plan

- [x] Unit tests pass (8/8 in agent-requirements-manager)
- [x] Tool tests pass (7/7 in manage-build-config-extensions)
- [x] Integration test passes against real TeamCity server
- [x] Build succeeds

## Usage

```json
{
  "buildTypeId": "Infrastructure_DeployUgreen",
  "action": "add",
  "type": "exists",
  "properties": {"property-name": "env.ANSIBLE"}
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)