### PR TITLE
fix: update MCP registry schema to 2025-12-11

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Daghis/teamcity",
   "description": "MCP server exposing JetBrains TeamCity CI/CD workflows to AI coding assistants",
   "repository": {


### PR DESCRIPTION
## Summary
- Update MCP registry schema from `2025-10-17` to `2025-12-11`
- Fixes CI publish failure: the MCP registry now rejects the older schema version

## Test plan
- [ ] CI publish step succeeds with the new schema version

🤖 Generated with [Claude Code](https://claude.com/claude-code)