### PR TITLE
fix: use draft MCP registry schema instead of dated versions

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/draft/server.schema.json",
   "name": "io.github.Daghis/teamcity",
   "description": "MCP server exposing JetBrains TeamCity CI/CD workflows to AI coding assistants",
   "repository": {


### PR DESCRIPTION
## Summary
- Update MCP registry schema from dated `2025-12-11` to `draft` format
- The registry has deprecated all dated schema versions and now requires the draft schema URL

## Context
The previous PR (#346) updated from `2025-10-17` to `2025-12-11`, but this version is also deprecated. The MCP registry now requires `draft` as the schema version.

Error from CI:
```
Error: deprecated schema detected: https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json.
Migrate to the current schema format for new servers.
```

## Test plan
- [ ] CI publish step succeeds with the draft schema version

🤖 Generated with [Claude Code](https://claude.com/claude-code)