### PR TITLE
fix: update mcp-publisher to v1.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install MCP Publisher
         if: steps.exists.outputs.exists == 'false' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_registry == 'true')
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.3.10/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.4.0/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
             | tar xz mcp-publisher
 
       - name: Login to MCP Registry


### PR DESCRIPTION
## Summary
- Update mcp-publisher from v1.3.10 to v1.4.0 in the publish workflow
- The old publisher version incorrectly rejects both dated and draft schema versions

## Context
Previous PRs (#346, #348) updated the schema URL, but the publish still fails because the mcp-publisher v1.3.10 is outdated and rejects all schema formats.

## Test plan
- [ ] CI publish step succeeds after this update

🤖 Generated with [Claude Code](https://claude.com/claude-code)