### PR TITLE
fix: revert to 2025-12-11 schema (compatible with mcp-publisher v1.4.0)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/draft/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Daghis/teamcity",
   "description": "MCP server exposing JetBrains TeamCity CI/CD workflows to AI coding assistants",
   "repository": {


### PR DESCRIPTION
## Summary
- Revert schema from `draft` to `2025-12-11`
- The draft schema URL is rejected by mcp-publisher v1.4.0
- The official quickstart guide shows using `2025-12-11`

## Test plan
- [ ] Trigger manual workflow_dispatch to verify MCP registry publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)