### PR TITLE
docs: update README and mode matrix for v2.1.x features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,29 @@ A Model Control Protocol (MCP) server that bridges AI coding assistants with Jet
 
 The TeamCity MCP Server allows developers using AI-powered coding assistants (Claude Code, Cursor, Windsurf) to interact with TeamCity directly from their development environment via MCP tools.
 
+> **Upgrading from 1.x?** Version 2.0.0 moved 15 tools from Dev to Full mode, including queue management, agent compatibility checks, and server health monitoring. If you relied on these tools in Dev mode, switch to `MCP_MODE=full` or use runtime mode switching (v2.1.0+). See [CHANGELOG.md](CHANGELOG.md) for details.
+
 ## Features
 
 ### 🚀 Two Operational Modes
 
-- **Dev Mode** (default): Safe CI/CD operations
-  - Trigger builds
-  - Monitor build status and progress
-  - Fetch build logs
-  - Investigate test failures
-  - List projects and configurations
+- **Dev Mode** (default): Safe CI/CD operations (31 tools, ~14k context tokens)
+  - Trigger builds and monitor status
+  - Fetch build logs and inspect test failures
+  - List projects, configurations, and queue
+  - Read parameters and investigate problems
 
-- **Full Mode**: Complete infrastructure management
+- **Full Mode**: Complete infrastructure management (87 tools, ~26k context tokens)
   - All Dev mode features, plus:
   - Create and clone build configurations
-  - Manage build steps and triggers
+  - Manage build steps, triggers, and dependencies
   - Configure VCS roots and agents
-  - Set up new projects
-  - Modify infrastructure settings
+  - Full CRUD for parameters (build config, project, and output parameters)
+  - Queue management and server administration
 
-See the [Tools Mode Matrix](docs/mcp-tools-mode-matrix.md) for the complete list of 77 tools and their availability by mode.
+**Runtime Mode Switching (v2.1.0+):** Switch between modes at runtime using the `get_mcp_mode` and `set_mcp_mode` tools—no restart required. MCP clients that support notifications will see the tool list update automatically.
+
+See the [Tools Mode Matrix](docs/mcp-tools-mode-matrix.md) for the complete list of 87 tools and their availability by mode.
 
 ### 🎯 Key Capabilities
 
@@ -44,7 +47,7 @@ See the [Tools Mode Matrix](docs/mcp-tools-mode-matrix.md) for the complete list
 
 ### Prerequisites
 
-- Node.js >= 20.10.0
+- Node.js >= 20.10.0 and < 21
 - TeamCity Server 2020.1+ with REST API access
 - TeamCity authentication token
 
@@ -248,14 +251,18 @@ The CI workflow runs `npm run build:bundle` and uploads the generated `coverage/
 
 ```
 teamcity-mcp/
-├── src/               # Source code
-│   ├── tools/        # MCP tool implementations
-│   ├── utils/        # Utility functions
-│   ├── types/        # TypeScript type definitions
-│   └── config/       # Configuration management
-├── tests/            # Test files
-├── docs/             # Documentation
-└── .agent-os/        # Agent OS specifications
+├── src/                    # Source code
+│   ├── tools.ts           # All 87 MCP tool definitions
+│   ├── server.ts          # MCP server setup
+│   ├── api-client.ts      # TeamCity API singleton
+│   ├── config/            # Configuration with Zod validation
+│   ├── teamcity/          # Domain logic (build, agent, config managers)
+│   ├── teamcity-client/   # Auto-generated OpenAPI client
+│   ├── types/             # TypeScript type definitions
+│   └── utils/             # Logger, MCP helpers, pagination
+├── tests/                  # Unit and integration tests
+├── docs/                   # Documentation
+└── scripts/                # Build and maintenance scripts
 ```
 
 ## API Documentation

--- a/docs/mcp-tools-mode-matrix.md
+++ b/docs/mcp-tools-mode-matrix.md
@@ -5,6 +5,8 @@ Legend: Dev = developer-focused (PRs/builds/logs/trigger, read-only config). Ful
 | Category | Tool | Dev | Full |
 |---|---|---|---|
 | Basic | `ping` | Yes | Yes |
+| Basic | `get_mcp_mode` | Yes | Yes |
+| Basic | `set_mcp_mode` | Yes | Yes |
 | Projects | `list_projects` | Yes | Yes |
 | Projects | `get_project` | Yes | Yes |
 | Projects | `list_project_hierarchy` | Yes | Yes |
@@ -36,6 +38,14 @@ Legend: Dev = developer-focused (PRs/builds/logs/trigger, read-only config). Ful
 | Parameters | `add_parameter` | No | Yes |
 | Parameters | `update_parameter` | No | Yes |
 | Parameters | `delete_parameter` | No | Yes |
+| Parameters (Project) | `list_project_parameters` | Yes | Yes |
+| Parameters (Project) | `add_project_parameter` | No | Yes |
+| Parameters (Project) | `update_project_parameter` | No | Yes |
+| Parameters (Project) | `delete_project_parameter` | No | Yes |
+| Parameters (Output) | `list_output_parameters` | Yes | Yes |
+| Parameters (Output) | `add_output_parameter` | No | Yes |
+| Parameters (Output) | `update_output_parameter` | No | Yes |
+| Parameters (Output) | `delete_output_parameter` | No | Yes |
 | VCS | `list_vcs_roots` | No | Yes |
 | VCS | `get_vcs_root` | No | Yes |
 | VCS | `get_versioned_settings_status` | No | Yes |
@@ -82,8 +92,10 @@ Legend: Dev = developer-focused (PRs/builds/logs/trigger, read-only config). Ful
 | Users & Roles | `list_users` | No | Yes |
 | Users & Roles | `list_roles` | No | Yes |
 
-**Summary:** 77 tools total — 27 available in Dev mode, 50 Full-only.
+**Summary:** 87 tools total — 31 available in Dev mode, 56 Full-only.
 
 Notes:
-- Dev mode focuses on developer workflows (builds, tests, logs) and excludes infrastructure/admin tools to reduce context size (~4-5k tokens saved).
+- Dev mode focuses on developer workflows (builds, tests, logs) and excludes infrastructure/admin tools to reduce context size (~12k tokens saved).
 - Admin tools (agents, VCS roots, users, compatibility checks) require Full mode.
+- **New in v2.1.0:** Runtime mode switching via `get_mcp_mode` and `set_mcp_mode` tools.
+- **New in v2.1.1:** Full CRUD for project and output parameters.


### PR DESCRIPTION
## Summary

- Update tool count from 77 to 87 (31 dev, 56 full-only)
- Add v2.0.0 upgrade notice highlighting breaking changes (15 tools moved to full mode)
- Document runtime mode switching feature (v2.1.0)
- Document project and output parameter tools (v2.1.1)
- Fix Node.js version constraint to include `< 21` upper bound
- Update project structure to reflect actual codebase layout

## Test plan

- [x] Verified tool counts match actual codebase (87 total, 31 dev, 56 full-only)
- [x] Verified mode matrix rows add up correctly
- [x] Checked markdown formatting renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)