### PR TITLE
chore: add placeholder values to server.json environment variables

### DIFF
--- a/server.json
+++ b/server.json
@@ -28,11 +28,13 @@
         {
           "name": "TEAMCITY_URL",
           "description": "Base URL of your TeamCity server",
+          "placeholder": "https://teamcity.example.com/",
           "isRequired": true
         },
         {
           "name": "TEAMCITY_TOKEN",
           "description": "TeamCity personal access token with required permissions",
+          "placeholder": "YOUR_TOKEN_HERE",
           "isRequired": true,
           "isSecret": true
         },


### PR DESCRIPTION
## Summary
- Add `placeholder` field to `TEAMCITY_URL` with value `https://teamcity.example.com/`
- Add `placeholder` field to `TEAMCITY_TOKEN` with value `YOUR_TOKEN_HERE`

This improves the Glama.ai deployment experience by showing clear example values in the generated test commands, instead of auto-generated JWT-like strings that confused users.

## Test plan
- [ ] Verify JSON is valid
- [ ] Check Glama admin page shows the placeholder values in generated commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)