### PR TITLE
docs: fix claude mcp add syntax and expand Node.js support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,17 +50,18 @@ jobs:
       - run: npm run typecheck
 
   tests:
-    name: Tests with coverage (unit) – shard ${{ matrix.shard }}/4
+    name: Tests (Node ${{ matrix.node }}) – shard ${{ matrix.shard }}/4
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        node: [20, 22, 24]
         shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
       - name: Run tests with coverage (unit-only + JUnit)
@@ -95,7 +96,7 @@ jobs:
           fail_ci_if_error: true
 
   aggregate:
-    name: Lint, Typecheck, Test (Node 20)
+    name: Lint, Typecheck, Test (Node 20, 22, 24)
     runs-on: ubuntu-latest
     needs: [lint, format, typecheck, tests]
     if: always()

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See the [Tools Mode Matrix](docs/mcp-tools-mode-matrix.md) for the complete list
 
 ### Prerequisites
 
-- Node.js >= 20.10.0 and < 21
+- Node.js >= 20.10.0 (LTS versions 20, 22, 24 tested in CI)
 - TeamCity Server 2020.1+ with REST API access
 - TeamCity authentication token
 
@@ -90,12 +90,13 @@ npx -y @daghis/teamcity-mcp
 
 ## Claude Code
 
-- Add the MCP:
-  - `claude mcp add [-s user] teamcity -- npx -y @daghis/teamcity-mcp`
+- Add the MCP (relying on `.env` for configuration):
+  - `claude mcp add teamcity -- npx -y @daghis/teamcity-mcp`
 - With env vars (if not using .env):
-  - `claude mcp add [-s user] teamcity -- env TEAMCITY_URL="https://teamcity.example.com" TEAMCITY_TOKEN="tc_<your_token>" MCP_MODE=dev npx -y @daghis/teamcity-mcp`
+  - `claude mcp add teamcity -e TEAMCITY_URL="https://teamcity.example.com" -e TEAMCITY_TOKEN="tc_<your_token>" -- npx -y @daghis/teamcity-mcp`
 - With CLI arguments (recommended for Windows):
-  - `claude mcp add [-s user] teamcity -- npx -y @daghis/teamcity-mcp --url "https://teamcity.example.com" --token "tc_<your_token>" --mode dev`
+  - `claude mcp add teamcity -- npx -y @daghis/teamcity-mcp --url "https://teamcity.example.com" --token "tc_<your_token>" --mode dev`
+- Add `-s user` to install user-wide instead of project-scoped (default)
 - Context usage (Opus 4.1, estimates):
   - Dev (default): ~14k tokens for MCP tools
   - Full (`MCP_MODE=full`): ~26k tokens for MCP tools

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "teamcity-mcp": "dist/index.js"
   },
   "engines": {
-    "node": ">=20.10.0 <21"
+    "node": ">=20.10.0"
   },
   "scripts": {
     "dev": "node ./node_modules/tsx/dist/cli.mjs watch src/index.ts",


### PR DESCRIPTION
## Summary
- Fix incorrect `claude mcp add` syntax in README.md — the `-e` environment variable options must come before the `--` separator, not after it
- Clarify the `-s user` scope option as a separate bullet point
- Remove Node.js upper bound constraint (`< 21`) from package.json engines
- Expand CI test matrix to include Node 20, 22, and 24
- Update README prerequisites to reflect expanded Node.js compatibility

## Test plan
- [x] Manually tested the corrected `claude mcp add` command syntax
- [x] `npm run check` passes (typecheck, lint, format)
- [x] `npm test` passes (2071 tests)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)