### PR TITLE
fix(ci): remove duplicate workflow_run trigger from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ name: Publish to npm
 on:
   release:
     types: [published]
-  workflow_run:
-    workflows: ["Release Please"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       publish_to_registry:
@@ -20,10 +17,7 @@ permissions:
 
 jobs:
   publish:
-    if: >-
-      ${{ github.event_name == 'release' ||
-          (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-          github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     name: Publish package
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Remove redundant `workflow_run` trigger from publish workflow
- The `release: [published]` trigger is sufficient and correct
- Eliminates race condition where both triggers fire simultaneously, causing one to fail with E403

## Problem
When Release Please creates a release, both triggers fire:
1. `release: [published]` - because a release was created
2. `workflow_run: ["Release Please"]` - because the workflow completed

Both runs check npm at nearly the same time (before either has published), see `exists=false`, and try to publish. One succeeds, the other fails.

## Test plan
- [x] Verify workflow YAML is valid
- [ ] Next release will have only one publish run

🤖 Generated with [Claude Code](https://claude.com/claude-code)