### PR TITLE
fix(ci): migrate from deprecated codecov/test-results-action to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,11 @@ jobs:
         run: npm run test:coverage:ci -- --reporters=default --reporters=jest-junit --shard=${{ matrix.shard }}/4 --passWithNoTests
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && github.actor != 'dependabot[bot]' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/junit-${{ matrix.shard }}.xml
+          report_type: test_results
       - name: Upload coverage to Codecov
         if: ${{ success() && github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

- Migrates from deprecated `codecov/test-results-action@v1` to `codecov/codecov-action@v5` with `report_type: test_results`

The `codecov/test-results-action` is being deprecated in favor of the unified `codecov/codecov-action@v5` approach.

## Test plan

- [ ] Verify CI workflow runs successfully
- [ ] Check Codecov dashboard shows test results are still being uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)