### PR TITLE
fix(deps): update qs to 6.14.2 to fix DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5956,6 +5956,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
       "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8426,9 +8427,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Summary
- Updates `qs` from 6.14.1 to 6.14.2 (transitive dep via express/body-parser)
- Resolves Dependabot alert #22: arrayLimit bypass in comma parsing allows denial of service

## Test plan
- [x] `npm run check` passes (typecheck, lint, format)
- [x] All 2069 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)