### PR TITLE
fix: add dotenv quiet option to prevent stdout pollution

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import type { ApplicationConfig } from '@/types/config';
 
 // Load environment variables
-dotenv.config();
+dotenv.config({ quiet: true });
 
 // Environment variable schema
 const envSchema = z.object({


### PR DESCRIPTION
## Description

While the `dotenv.config()` call in src/index.ts was quieted in #253 by adding `{quiet: true}` to the options, there is a stray dotenv.config() in the src/config.ts module lacking this option.  This is a PR to add the same `quiet: true` option in there, fixing stdout pollution of the MCP protocol stream.

## Related Issue

Fixes #400.

## TODO list (for me, the contributor)

- [ ] Consider new/improved tests - there must be a testing gap for this to have gone missed
- [ ] Look at failing test cases

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Checklist

- [x] My code follows the project's coding style
- [x] I have run `npm run lint` and `npm run typecheck` with no errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`npm test`)
- [ ] I have updated the documentation accordingly (if applicable)
    - n/a, unless I need to update CHANGELOG.md in the PR
- [x] My changes generate no new warnings

## Testing

1. Run code as-is without the `quiet: true` added in config.ts.  Observe the following console output:

```
$ npm run dev

> @daghis/teamcity-mcp@2.2.1 dev
> node ./node_modules/tsx/dist/cli.mjs watch src/index.ts

[dotenv@17.3.1] injecting env (0) from .env -- tip: 🔐 prevent committing .env to code: https://dotenvx.com/precommit
TeamCity URL not configured. Please set TEAMCITY_URL environment variable.
Please configure TEAMCITY_URL and TEAMCITY_TOKEN via:
  - CLI arguments: --url <url> --token <token>
  - Config file: --config <path>
  - Environment variables
  - .env file
Run with --help for more information.
```

2. After adding `quiet: true`, run it again and observe the following output ("injecting env" message is gone):
 
```
$ npm run dev

> @daghis/teamcity-mcp@2.2.1 dev
> node ./node_modules/tsx/dist/cli.mjs watch src/index.ts

TeamCity URL not configured. Please set TEAMCITY_URL environment variable.
Please configure TEAMCITY_URL and TEAMCITY_TOKEN via:
  - CLI arguments: --url <url> --token <token>
  - Config file: --config <path>
  - Environment variables
  - .env file
Run with --help for more information.
```

## Additional Notes

<!-- Any additional information that reviewers should know -->
