### PR TITLE
fix: silence dotenv stdout pollution in config module

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,13 +1,9 @@
 /**
  * Configuration management for TeamCity MCP Server
  */
-import dotenv from 'dotenv';
 import { z } from 'zod';
 
 import type { ApplicationConfig } from '@/types/config';
-
-// Load environment variables
-dotenv.config();
 
 // Environment variable schema
 const envSchema = z.object({


### PR DESCRIPTION
## Summary

- Removes the `dotenv.config()` call (and its import) from `src/config/index.ts` entirely
- This was a top-level side effect that ran at import time, *before* the intended setup sequence in `index.ts` (CLI args → `--config` file → `.env`), causing stdout pollution of the MCP protocol stream
- All env reading in the config module happens inside functions via `process.env` at call time, so it doesn't need to trigger dotenv loading itself — that's the entry point's responsibility

Closes #400
Supersedes #401

## Test plan

- [x] `npm run check` passes (typecheck, lint, format)
- [x] `npm test` passes (2074 tests, 0 failures)
- [x] Verified the only remaining runtime `dotenv.config()` is in `src/index.ts` with `{ quiet: true }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)