### PR TITLE
fix: write snapshot dep options as properties, not XML options

### DIFF
--- a/src/teamcity/build-dependency-manager.ts
+++ b/src/teamcity/build-dependency-manager.ts
@@ -60,14 +60,6 @@ const defaultTypeFor = (dependencyType: DependencyType): string | undefined => {
   }
 };
 
-const SNAPSHOT_DEPENDENCY_OPTION_KEYS = new Set([
-  'run-build-on-the-same-agent',
-  'sync-revisions',
-  'take-successful-builds-only',
-  'take-started-build-with-same-revisions',
-  'do-not-run-new-build-if-there-is-a-suitable-one',
-]);
-
 const toStringRecord = (input?: Record<string, unknown>): StringMap => {
   if (!input) {
     return {};
@@ -134,16 +126,6 @@ const optionsToRecord = (options?: SnapshotDependencyOptions): StringMap => {
   return map;
 };
 
-const recordToOptions = (record: StringMap): SnapshotDependencyOptions | undefined => {
-  const entries = Object.entries(record);
-  if (entries.length === 0) {
-    return undefined;
-  }
-  return {
-    option: entries.map(([name, value]) => ({ name, value })),
-  };
-};
-
 const mergeRecords = (base: StringMap, override: StringMap): StringMap => {
   const merged: StringMap = { ...base };
   for (const [key, value] of Object.entries(override)) {
@@ -191,32 +173,6 @@ const propertiesToXml = (properties?: Properties | undefined): string | undefine
   }
 
   return `<properties>${nodes.join('')}</properties>`;
-};
-
-const optionsToXml = (options?: SnapshotDependencyOptions | undefined): string | undefined => {
-  if (!options) {
-    return undefined;
-  }
-  const entries = options.option;
-  const list = Array.isArray(entries) ? entries : entries != null ? [entries] : [];
-
-  if (list.length === 0) {
-    return undefined;
-  }
-
-  const nodes = list
-    .filter((item) => item?.name)
-    .map((item) => {
-      const name = item?.name ?? '';
-      const value = item?.value != null ? String(item.value) : '';
-      return `<option name="${escapeXml(name)}" value="${escapeXml(value)}"/>`;
-    });
-
-  if (nodes.length === 0) {
-    return undefined;
-  }
-
-  return `<options>${nodes.join('')}</options>`;
 };
 
 const sourceBuildTypeToXml = (
@@ -280,11 +236,6 @@ const dependencyToXml = (
   const propertiesXml = propertiesToXml(payload.properties);
   if (propertiesXml) {
     fragments.push(propertiesXml);
-  }
-
-  const optionsXml = optionsToXml((payload as SnapshotDependencyWithOptions).options);
-  if (optionsXml) {
-    fragments.push(optionsXml);
   }
 
   return `<${root}${attributesToString(attributes)}>${fragments.join('')}</${root}>`;
@@ -463,53 +414,27 @@ export class BuildDependencyManager {
     existing: DependencyResource | undefined,
     input: ManageDependencyInput
   ): ArtifactDependency | SnapshotDependency {
-    const existingSnapshot = existing as SnapshotDependencyWithOptions | undefined;
+    // TeamCity's REST API expects all snapshot dependency settings in <properties>,
+    // even though GET responses return some of them in an undocumented <options> block.
+    // We merge existing options into properties so they survive the round-trip.
     const baseProperties = propertiesToRecord(existing?.properties as Properties | undefined);
-    const inputPropertyRecord = toStringRecord(input.properties);
-    const inputExplicitOptions = toStringRecord(input.options);
-
-    let optionOverrides: StringMap = {};
-    let propertyOverrides: StringMap = inputPropertyRecord;
-
-    let baseOptions: StringMap = {};
     if (dependencyType === 'snapshot') {
-      baseOptions = optionsToRecord(existingSnapshot?.options);
-      const knownOptionKeys = new Set<string>([
-        ...Object.keys(baseOptions),
-        ...Object.keys(inputExplicitOptions),
-      ]);
-      for (const key of SNAPSHOT_DEPENDENCY_OPTION_KEYS) {
-        knownOptionKeys.add(key);
-      }
-
-      const derivedOptionOverrides: StringMap = { ...inputExplicitOptions };
-      const derivedPropertyOverrides: StringMap = {};
-
-      for (const [key, value] of Object.entries(inputPropertyRecord)) {
-        if (knownOptionKeys.has(key)) {
-          derivedOptionOverrides[key] = value;
-        } else {
-          derivedPropertyOverrides[key] = value;
-        }
-      }
-
-      optionOverrides = derivedOptionOverrides;
-      propertyOverrides = derivedPropertyOverrides;
-    } else if (Object.keys(inputExplicitOptions).length > 0) {
-      optionOverrides = inputExplicitOptions;
+      const existingOptions = optionsToRecord(
+        (existing as SnapshotDependencyWithOptions | undefined)?.options
+      );
+      Object.assign(baseProperties, existingOptions);
     }
 
-    const mergedProps = mergeRecords(baseProperties, propertyOverrides);
+    const inputOverrides = mergeRecords(
+      toStringRecord(input.properties),
+      toStringRecord(input.options)
+    );
+    const mergedProps = mergeRecords(baseProperties, inputOverrides);
     const properties = recordToProperties(mergedProps);
-
-    let mergedOptions: StringMap = {};
-    if (dependencyType === 'snapshot') {
-      mergedOptions = mergeRecords(baseOptions, optionOverrides);
-    }
 
     const resolvedType = input.type ?? existing?.type ?? defaultTypeFor(dependencyType);
 
-    const payload: ArtifactDependency | SnapshotDependencyWithOptions = {
+    const payload: ArtifactDependency | SnapshotDependency = {
       ...(existing ?? {}),
       disabled: input.disabled ?? existing?.disabled,
     };
@@ -521,15 +446,6 @@ export class BuildDependencyManager {
       payload.properties = properties;
     } else {
       delete payload.properties;
-    }
-
-    if (dependencyType === 'snapshot') {
-      const options = recordToOptions(mergedOptions);
-      if (options) {
-        (payload as SnapshotDependencyWithOptions).options = options;
-      } else {
-        delete (payload as SnapshotDependencyWithOptions).options;
-      }
     }
 
     const dependsOn = input.dependsOn ?? existing?.['source-buildType']?.id;

--- a/tests/integration/build-config-extensions-scenario.test.ts
+++ b/tests/integration/build-config-extensions-scenario.test.ts
@@ -108,6 +108,7 @@ describe('Build configuration dependency/feature management (full)', () => {
         dependsOn: SOURCE_BT_ID,
         properties: {
           'run-build-if-dependency-failed': 'false',
+          'take-successful-builds-only': 'true',
         },
       });
       expect(snapshotAdd).toMatchObject({
@@ -127,6 +128,7 @@ describe('Build configuration dependency/feature management (full)', () => {
           dependencyId: snapshotId,
           properties: {
             'run-build-if-dependency-failed': 'true',
+            'take-successful-builds-only': 'false',
           },
         });
         expect(snapshotUpdate).toMatchObject({

--- a/tests/unit/teamcity/build-dependency-manager.test.ts
+++ b/tests/unit/teamcity/build-dependency-manager.test.ts
@@ -167,7 +167,7 @@ describe('BuildDependencyManager', () => {
         );
       });
 
-      it('should separate options from properties for snapshot dependencies', async () => {
+      it('should write all snapshot settings as properties (not options)', async () => {
         buildTypesApi.addSnapshotDependencyToBuildType.mockResolvedValue(
           createMockAxiosResponse({ id: 'snapshot-dep-2' })
         );
@@ -183,13 +183,13 @@ describe('BuildDependencyManager', () => {
         });
 
         const xmlBody = buildTypesApi.addSnapshotDependencyToBuildType.mock.calls[0]?.[2] as string;
-        expect(xmlBody).toContain('<options>');
-        expect(xmlBody).toContain('name="run-build-on-the-same-agent" value="true"');
+        expect(xmlBody).not.toContain('<options>');
         expect(xmlBody).toContain('<properties>');
+        expect(xmlBody).toContain('name="run-build-on-the-same-agent" value="true"');
         expect(xmlBody).toContain('name="custom-property" value="value"');
       });
 
-      it('should handle all known snapshot dependency option keys', async () => {
+      it('should write all snapshot option keys as properties', async () => {
         buildTypesApi.addSnapshotDependencyToBuildType.mockResolvedValue(
           createMockAxiosResponse({ id: 'snapshot-dep-3' })
         );
@@ -208,12 +208,35 @@ describe('BuildDependencyManager', () => {
         });
 
         const xmlBody = buildTypesApi.addSnapshotDependencyToBuildType.mock.calls[0]?.[2] as string;
-        expect(xmlBody).toContain('<options>');
+        expect(xmlBody).not.toContain('<options>');
+        expect(xmlBody).toContain('<properties>');
         expect(xmlBody).toContain('run-build-on-the-same-agent');
         expect(xmlBody).toContain('sync-revisions');
         expect(xmlBody).toContain('take-successful-builds-only');
         expect(xmlBody).toContain('take-started-build-with-same-revisions');
         expect(xmlBody).toContain('do-not-run-new-build-if-there-is-a-suitable-one');
+      });
+
+      it('should write options input as properties', async () => {
+        buildTypesApi.addSnapshotDependencyToBuildType.mockResolvedValue(
+          createMockAxiosResponse({ id: 'snapshot-dep-4' })
+        );
+
+        await manager.addDependency({
+          buildTypeId: 'Config_B',
+          dependencyType: 'snapshot',
+          dependsOn: 'Base_Config',
+          options: {
+            'take-successful-builds-only': 'true',
+            'sync-revisions': 'true',
+          },
+        });
+
+        const xmlBody = buildTypesApi.addSnapshotDependencyToBuildType.mock.calls[0]?.[2] as string;
+        expect(xmlBody).not.toContain('<options>');
+        expect(xmlBody).toContain('<properties>');
+        expect(xmlBody).toContain('name="take-successful-builds-only" value="true"');
+        expect(xmlBody).toContain('name="sync-revisions" value="true"');
       });
     });
 
@@ -348,7 +371,7 @@ describe('BuildDependencyManager', () => {
     });
 
     describe('snapshot dependencies', () => {
-      it('should update an existing snapshot dependency', async () => {
+      it('should update an existing snapshot dependency with options merged into properties', async () => {
         buildTypesApi.getSnapshotDependency.mockResolvedValue(
           createMockAxiosResponse({
             id: 'snapshot-dep-1',
@@ -376,16 +399,17 @@ describe('BuildDependencyManager', () => {
         });
 
         expect(result.id).toBe('snapshot-dep-1');
-        expect(buildTypesApi.replaceSnapshotDependency).toHaveBeenCalledWith(
-          'Config_B',
-          'snapshot-dep-1',
-          undefined,
-          expect.stringContaining('<snapshot-dependency'),
-          expect.any(Object)
-        );
+        const xmlBody = buildTypesApi.replaceSnapshotDependency.mock.calls[0]?.[3] as string;
+        expect(xmlBody).toContain('<snapshot-dependency');
+        expect(xmlBody).not.toContain('<options>');
+        expect(xmlBody).toContain('<properties>');
+        // Existing property preserved
+        expect(xmlBody).toContain('name="run-build-if-dependency-failed" value="false"');
+        // Existing option from GET merged into properties and overridden
+        expect(xmlBody).toContain('name="run-build-on-the-same-agent" value="true"');
       });
 
-      it('should merge options with existing values', async () => {
+      it('should merge existing GET options into properties on update', async () => {
         buildTypesApi.getSnapshotDependency.mockResolvedValue(
           createMockAxiosResponse({
             id: 'snapshot-dep-1',
@@ -413,8 +437,10 @@ describe('BuildDependencyManager', () => {
         });
 
         const xmlBody = buildTypesApi.replaceSnapshotDependency.mock.calls[0]?.[3] as string;
-        expect(xmlBody).toContain('run-build-on-the-same-agent');
-        expect(xmlBody).toContain('sync-revisions');
+        expect(xmlBody).not.toContain('<options>');
+        expect(xmlBody).toContain('<properties>');
+        expect(xmlBody).toContain('name="run-build-on-the-same-agent" value="true"');
+        expect(xmlBody).toContain('name="sync-revisions" value="true"');
       });
     });
 
@@ -696,7 +722,7 @@ describe('BuildDependencyManager', () => {
     });
   });
 
-  describe('edge cases for option parsing', () => {
+  describe('edge cases for option parsing (GET options merged into properties)', () => {
     it('should handle single option object instead of array', async () => {
       buildTypesApi.getSnapshotDependency.mockResolvedValue(
         createMockAxiosResponse({
@@ -719,6 +745,8 @@ describe('BuildDependencyManager', () => {
       });
 
       const xmlBody = buildTypesApi.replaceSnapshotDependency.mock.calls[0]?.[3] as string;
+      expect(xmlBody).toContain('<properties>');
+      expect(xmlBody).not.toContain('<options>');
       expect(xmlBody).toContain('name="singleOption" value="singleValue"');
     });
 
@@ -743,7 +771,9 @@ describe('BuildDependencyManager', () => {
       });
 
       const xmlBody = buildTypesApi.replaceSnapshotDependency.mock.calls[0]?.[3] as string;
-      expect(xmlBody).toContain('run-build-on-the-same-agent');
+      expect(xmlBody).toContain('<properties>');
+      expect(xmlBody).not.toContain('<options>');
+      expect(xmlBody).toContain('name="run-build-on-the-same-agent" value="true"');
     });
 
     it('should handle options with missing name', async () => {
@@ -768,6 +798,7 @@ describe('BuildDependencyManager', () => {
       });
 
       const xmlBody = buildTypesApi.replaceSnapshotDependency.mock.calls[0]?.[3] as string;
+      expect(xmlBody).toContain('<properties>');
       expect(xmlBody).toContain('validOption');
       expect(xmlBody).not.toContain('orphanValue');
     });
@@ -794,6 +825,7 @@ describe('BuildDependencyManager', () => {
       });
 
       const xmlBody = buildTypesApi.replaceSnapshotDependency.mock.calls[0]?.[3] as string;
+      expect(xmlBody).toContain('<properties>');
       expect(xmlBody).toContain('name="optionWithNoValue" value=""');
     });
   });
@@ -1075,7 +1107,7 @@ describe('BuildDependencyManager', () => {
   });
 
   describe('artifact dependency options handling', () => {
-    it('should include explicit options for artifact dependencies when provided', async () => {
+    it('should write explicit options as properties for artifact dependencies', async () => {
       buildTypesApi.addArtifactDependencyToBuildType.mockResolvedValue(
         createMockAxiosResponse({ id: 'dep-1' })
       );
@@ -1089,12 +1121,10 @@ describe('BuildDependencyManager', () => {
         },
       });
 
-      // For artifact dependencies, options should NOT be included in XML
-      // They should be treated as properties instead
       const xmlBody = buildTypesApi.addArtifactDependencyToBuildType.mock.calls[0]?.[2] as string;
-      // Artifact dependencies don't support options in the same way as snapshot dependencies
-      // The options get converted to properties for artifact dependencies
       expect(xmlBody).not.toContain('<options>');
+      expect(xmlBody).toContain('<properties>');
+      expect(xmlBody).toContain('name="custom-option" value="value"');
     });
   });
 

--- a/tests/unit/tools/manage-build-config-extensions.test.ts
+++ b/tests/unit/tools/manage-build-config-extensions.test.ts
@@ -241,12 +241,11 @@ describe('build configuration extended management tools', () => {
             '<source-buildType id="New_Base_Config"/>'
           );
           const updateSnapshotXml = replaceSnapshotDependency.mock.calls[0]?.[3] as string;
-          expect(updateSnapshotXml).toContain(
-            '<properties><property name="run-build-if-dependency-failed" value="true"/></properties>'
-          );
-          expect(updateSnapshotXml).toContain(
-            '<options><option name="run-build-on-the-same-agent" value="true"/></options>'
-          );
+          // Both existing properties and GET options are merged into <properties>
+          expect(updateSnapshotXml).toContain('name="run-build-if-dependency-failed" value="true"');
+          expect(updateSnapshotXml).toContain('name="run-build-on-the-same-agent" value="true"');
+          expect(updateSnapshotXml).toContain('<properties>');
+          expect(updateSnapshotXml).not.toContain('<options>');
 
           res = await getRequiredTool('manage_build_dependencies').handler({
             buildTypeId: 'Config_A',


### PR DESCRIPTION
## Summary

Fixes #406.

- TeamCity's REST API [SnapshotDependency schema](https://www.jetbrains.com/help/teamcity/rest/snapshotdependency.html) has no `options` field — all settings (`take-successful-builds-only`, `sync-revisions`, etc.) belong in `<properties>`
- The code incorrectly separated known option keys into an `<options>` XML block, which POST silently ignored and PUT rejected with HTTP 400
- Now merges existing GET `options` into properties for round-trip fidelity and writes everything as `<properties>`
- Removes dead option-routing code (`SNAPSHOT_DEPENDENCY_OPTION_KEYS`, `recordToOptions`, `optionsToXml`)

## Test plan

- [x] All 2070 unit tests pass (59 in build-dependency-manager alone)
- [x] All 29 integration tests pass against live TeamCity, including `build-config-extensions-scenario` which now tests `take-successful-builds-only` in add/update
- [x] `npm run check` passes (typecheck, lint, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)