### PR TITLE
Add comprehensive branch coverage tests for tools and managers

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,10 +25,18 @@ component_management:
       name: MCP Tools
       paths:
         - src/tools.ts
+      statuses:
+        - type: project
+          target: 85%
+          threshold: 1%
     - component_id: teamcity
       name: TeamCity Managers
       paths:
         - src/teamcity/**
+      statuses:
+        - type: project
+          target: 85%
+          threshold: 1%
     - component_id: utils
       name: Utilities
       paths:

--- a/tests/unit/teamcity/branch-filtering-service.test.ts
+++ b/tests/unit/teamcity/branch-filtering-service.test.ts
@@ -478,4 +478,121 @@ describe('BranchFilteringService', () => {
       expect(result.currentPage).toBe(1);
     });
   });
+
+  describe('additional branch coverage', () => {
+    it('drops branches without lastActivityDate when activeSince is set', () => {
+      const branches: BranchInfo[] = [
+        { ...testBranches[0], lastActivityDate: undefined } as BranchInfo,
+        testBranches[1] as BranchInfo,
+      ];
+      const result = service.filterBranches(branches, {
+        activeSince: new Date('2025-08-01T00:00:00Z'),
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0]?.displayName).toBe('feature/new-login');
+    });
+
+    it('drops branches without lastActivityDate when activeBefore is set', () => {
+      const branches: BranchInfo[] = [
+        { ...testBranches[0], lastActivityDate: undefined } as BranchInfo,
+        {
+          ...(testBranches[2] as BranchInfo),
+          lastActivityDate: new Date('2024-01-01T00:00:00Z'),
+        },
+      ];
+      const result = service.filterBranches(branches, {
+        activeBefore: new Date('2025-01-01T00:00:00Z'),
+      });
+      expect(result).toHaveLength(1);
+    });
+
+    it('skips activity filter when lastActivityDate is an unparseable string', () => {
+      const branches: BranchInfo[] = [
+        {
+          ...(testBranches[0] as BranchInfo),
+          lastActivityDate: 'not-a-date' as unknown as Date,
+        },
+      ];
+      const sinceResult = service.filterBranches(branches, {
+        activeSince: new Date('2020-01-01'),
+      });
+      expect(sinceResult).toHaveLength(0);
+
+      const beforeResult = service.filterBranches(branches, {
+        activeBefore: new Date('2030-01-01'),
+      });
+      expect(beforeResult).toHaveLength(0);
+    });
+
+    it('accepts ISO-string lastActivityDate values inside filter window', () => {
+      const branches: BranchInfo[] = [
+        {
+          ...(testBranches[0] as BranchInfo),
+          lastActivityDate: '2025-08-30T10:00:00Z' as unknown as Date,
+        },
+      ];
+      const result = service.filterBranches(branches, {
+        activeSince: new Date('2025-01-01'),
+      });
+      expect(result).toHaveLength(1);
+    });
+
+    it('falls back to contains match when wildcard regex fails', () => {
+      // Patterns starting & ending with / are treated as regex; use an invalid
+      // regex body to hit the catch/fallback path.
+      const invalid = '/(/';
+      const result = service.filterBranches(testBranches, { namePattern: invalid });
+      expect(result).toEqual(testBranches);
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+
+    it('exercises the status comparator path for non-name sorting', () => {
+      const sorted = service.sortBranches(testBranches, 'status', 'desc');
+      // Any valid permutation is fine — this test is primarily for branch coverage.
+      expect(sorted).toHaveLength(testBranches.length);
+      expect(sorted.every((b) => typeof b.lastBuild?.status === 'string')).toBe(true);
+    });
+
+    it('sorts by activity and reverses order when sortOrder="asc"', () => {
+      const asc = service.sortBranches(testBranches, 'activity', 'asc');
+      const desc = service.sortBranches(testBranches, 'activity', 'desc');
+      expect(asc.map((b) => b.displayName)).toEqual(desc.map((b) => b.displayName).reverse());
+    });
+
+    it('sorts by buildCount and honors sortOrder asc flip', () => {
+      const desc = service.sortBranches(testBranches, 'buildCount', 'desc');
+      const asc = service.sortBranches(testBranches, 'buildCount', 'asc');
+      expect(asc.map((b) => b.buildCount)).toEqual(desc.map((b) => b.buildCount).reverse());
+    });
+
+    it('falls back to name comparator when an unknown sortBy is supplied', () => {
+      const unknownSort = service.sortBranches(
+        testBranches,
+        'totallyUnknown' as unknown as Parameters<typeof service.sortBranches>[1]
+      );
+      // Unknown sortBy routes through the name comparator but since
+      // sortBy !== 'name' the default `asc` order gets flipped, so the result
+      // matches descending-by-name. Either way all inputs make it through.
+      expect(unknownSort).toHaveLength(testBranches.length);
+      expect(new Set(unknownSort.map((b) => b.displayName))).toEqual(
+        new Set(testBranches.map((b) => b.displayName))
+      );
+    });
+
+    it('prioritizes branches: default → active → most recent', () => {
+      const branches: BranchInfo[] = [
+        { ...(testBranches[2] as BranchInfo) }, // inactive, older
+        { ...(testBranches[0] as BranchInfo) }, // default + active
+        { ...(testBranches[1] as BranchInfo) }, // active
+      ];
+      const result = service.paginateBranches(branches, {
+        page: 1,
+        pageSize: 3,
+        prioritizeActive: true,
+      });
+      expect(result.branches[0]?.isDefault).toBe(true);
+      expect(result.branches[1]?.isActive).toBe(true);
+      expect(result.branches[2]?.isActive).toBe(false);
+    });
+  });
 });

--- a/tests/unit/teamcity/build-trigger-manager.test.ts
+++ b/tests/unit/teamcity/build-trigger-manager.test.ts
@@ -1106,4 +1106,302 @@ describe('BuildTriggerManager', () => {
       // Behavior-first: avoid verifying delete call shape
     });
   });
+
+  describe('validateTrigger branch coverage', () => {
+    it('rejects unknown trigger types via the default switch branch', () => {
+      const result = manager.validateTrigger({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        type: 'mysteryTrigger' as any,
+        properties: {} as VcsTriggerProperties,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Unknown trigger type: mysteryTrigger');
+    });
+
+    it('flags VCS trigger validation errors (branch filter, quiet period, rules)', () => {
+      const result = manager.validateTrigger({
+        type: 'vcsTrigger',
+        properties: {
+          branchFilter: 'no-prefix',
+          quietPeriodMode: 'USE_CUSTOM',
+          quietPeriod: -5,
+          triggerRules: 'only-plain-text',
+        } as VcsTriggerProperties,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          'Invalid branch filter pattern',
+          'Quiet period must be non-negative',
+          'Invalid path filter rules syntax',
+        ])
+      );
+    });
+
+    it('requires quietPeriod when quietPeriodMode is USE_CUSTOM without value', () => {
+      const result = manager.validateTrigger({
+        type: 'vcsTrigger',
+        properties: {
+          quietPeriodMode: 'USE_CUSTOM',
+        } as VcsTriggerProperties,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Quiet period is required when using USE_CUSTOM mode');
+    });
+
+    it('warns on unrecognized timezone for scheduling triggers', () => {
+      const result = manager.validateTrigger({
+        type: 'schedulingTrigger',
+        properties: {
+          schedulingPolicy: 'weekly',
+          timezone: 'ZZ_Not_A_Real_Zone!',
+        } as ScheduleTriggerProperties,
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toContain('Unrecognized timezone');
+    });
+
+    it('flags dependency trigger with missing dependsOn, invalid artifact rules and filter', () => {
+      const result = manager.validateTrigger({
+        type: 'buildDependencyTrigger',
+        properties: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          dependsOn: null as any,
+          artifactRules: 'bad-source => ',
+          branchFilter: '+:',
+        } as DependencyTriggerProperties,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          'Dependency trigger requires dependsOn property',
+          'Invalid artifact rule format',
+          'Invalid branch filter pattern',
+        ])
+      );
+    });
+  });
+
+  describe('schedule parsing covers all cron-field branches', () => {
+    const schedule = (policy: string): boolean =>
+      manager.validateTrigger({
+        type: 'schedulingTrigger',
+        properties: { schedulingPolicy: policy } as ScheduleTriggerProperties,
+      }).valid;
+
+    it('accepts wildcards, ranges, steps and lists across each field', () => {
+      expect(schedule('* * * * * *')).toBe(true);
+      expect(schedule('0-30 0 0 1 1 0')).toBe(true);
+      expect(schedule('*/10 * * * * *')).toBe(true);
+      expect(schedule('0 15,30,45 10 * * *')).toBe(true);
+      expect(schedule('0 0 0 ? 1 ? 2030')).toBe(true); // 7 fields: ? allowed for dow/dom
+    });
+
+    it('rejects mis-sized cron expressions (not 6 or 7 fields)', () => {
+      expect(schedule('* * *')).toBe(false);
+      expect(schedule('* * * * * * * *')).toBe(false);
+    });
+
+    it('rejects malformed ranges, steps, lists, and out-of-range numbers', () => {
+      expect(schedule('0 0 25 * * *')).toBe(false); // hour out of range
+      expect(schedule('0 0 0 32 * *')).toBe(false); // day out of range
+      expect(schedule('0 0 0 1 13 *')).toBe(false); // month out of range
+      expect(schedule('0 0 0 1 1 9')).toBe(false); // dow out of range
+      expect(schedule('abc 0 0 1 1 *')).toBe(false); // non-numeric seconds
+      expect(schedule('0-60-2 0 0 1 1 *')).toBe(false); // 3-part range
+      expect(schedule('5-1 0 0 1 1 *')).toBe(false); // reversed range
+      expect(schedule('*/0 0 0 1 1 *')).toBe(false); // zero step
+      expect(schedule('*/ab 0 0 1 1 *')).toBe(false); // non-numeric step
+      expect(schedule('1-10/2/3 0 0 1 1 *')).toBe(false); // 3-part step
+      expect(schedule('1,2,bad 0 0 1 1 *')).toBe(false); // bad list member
+    });
+  });
+
+  describe('calculateNextRunTime covers simple + cron branches', () => {
+    it('rolls forward daily/weekly/nightly/hourly keywords', () => {
+      expect(manager.calculateNextRunTime('daily')).toBeInstanceOf(Date);
+      expect(manager.calculateNextRunTime('weekly')).toBeInstanceOf(Date);
+      expect(manager.calculateNextRunTime('hourly')).toBeInstanceOf(Date);
+      const nightly = manager.calculateNextRunTime('nightly');
+      expect(nightly.getHours()).toBe(2);
+    });
+
+    it('uses calculateNextCronRun fallback (1 hour) for short cron strings', () => {
+      const now = new Date();
+      const next = manager.calculateNextRunTime('* * *');
+      expect(next.getTime()).toBeGreaterThan(now.getTime());
+    });
+
+    it('applies seconds/minutes/hours from a 6-field cron expression', () => {
+      const next = manager.calculateNextRunTime('15 30 5 * * *');
+      expect(next.getSeconds()).toBe(15);
+      expect(next.getMinutes()).toBe(30);
+      expect(next.getHours()).toBe(5);
+    });
+  });
+
+  describe('error-path branches', () => {
+    it('wraps updateTrigger 404 as TriggerNotFoundError', async () => {
+      const notFound = Object.assign(new Error('nf'), { response: { status: 404 } });
+      http.get.mockRejectedValueOnce(notFound);
+      await expect(
+        manager.updateTrigger({ configId: 'cfg', triggerId: 't1', enabled: true })
+      ).rejects.toBeInstanceOf(TriggerNotFoundError);
+    });
+
+    it('wraps deleteTrigger 404 as TriggerNotFoundError', async () => {
+      const notFound = Object.assign(new Error('nf'), { response: { status: 404 } });
+      http.delete.mockRejectedValueOnce(notFound);
+      await expect(
+        manager.deleteTrigger({ configId: 'cfg', triggerId: 't1' })
+      ).rejects.toBeInstanceOf(TriggerNotFoundError);
+    });
+
+    it('wraps createTrigger 404 as BuildConfigurationNotFoundError', async () => {
+      const notFound = Object.assign(new Error('nf'), { response: { status: 404 } });
+      http.post.mockRejectedValueOnce(notFound);
+      await expect(
+        manager.createTrigger({
+          configId: 'ghost',
+          type: 'vcsTrigger',
+          properties: {} as VcsTriggerProperties,
+        })
+      ).rejects.toBeInstanceOf(BuildConfigurationNotFoundError);
+    });
+
+    it('re-throws ValidationError and CircularDependencyError from createTrigger untouched', async () => {
+      http.get.mockRejectedValueOnce(
+        new ValidationError('bad input', { cause: 'ignore' } as Record<string, unknown>)
+      );
+      http.post.mockRejectedValueOnce(
+        new ValidationError('validation boom', {} as Record<string, unknown>)
+      );
+      await expect(
+        manager.createTrigger({
+          configId: 'cfg',
+          type: 'buildDependencyTrigger',
+          properties: {
+            dependsOn: 'dep-1',
+          } as DependencyTriggerProperties,
+        })
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      http.get.mockRejectedValueOnce(
+        new ValidationError('bad input', { cause: 'ignore' } as Record<string, unknown>)
+      );
+      http.post.mockRejectedValueOnce(
+        new CircularDependencyError('cycle', { cause: 'cycle' } as Record<string, unknown>)
+      );
+      await expect(
+        manager.createTrigger({
+          configId: 'cfg',
+          type: 'buildDependencyTrigger',
+          properties: {
+            dependsOn: 'dep-1',
+          } as DependencyTriggerProperties,
+        })
+      ).rejects.toBeInstanceOf(CircularDependencyError);
+    });
+
+    it('wraps generic createTrigger errors via handleApiError', async () => {
+      http.post.mockRejectedValueOnce({
+        response: { status: 500, data: { message: 'server boom' } },
+      });
+      await expect(
+        manager.createTrigger({
+          configId: 'cfg',
+          type: 'vcsTrigger',
+          properties: {} as VcsTriggerProperties,
+        })
+      ).rejects.toBeInstanceOf(TeamCityAPIError);
+    });
+
+    it('surfaces raw Error when no response payload is attached', async () => {
+      http.post.mockRejectedValueOnce(new Error('network gone'));
+      await expect(
+        manager.createTrigger({
+          configId: 'cfg',
+          type: 'vcsTrigger',
+          properties: {} as VcsTriggerProperties,
+        })
+      ).rejects.toThrow('network gone');
+    });
+
+    it('stringifies non-Error rejection values', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      http.post.mockRejectedValueOnce('plain string failure' as any);
+      await expect(
+        manager.createTrigger({
+          configId: 'cfg',
+          type: 'vcsTrigger',
+          properties: {} as VcsTriggerProperties,
+        })
+      ).rejects.toThrow('plain string failure');
+    });
+  });
+
+  describe('validateDependencyChain', () => {
+    it('detects a direct circular dependency (target depends on source)', async () => {
+      http.get.mockResolvedValueOnce({
+        data: {
+          trigger: [
+            {
+              id: 't1',
+              type: 'buildDependencyTrigger',
+              properties: { property: [{ name: 'dependsOn', value: 'source' }] },
+            },
+          ],
+        },
+      });
+      const result = await manager.validateDependencyChain('source', 'target');
+      expect(result.hasCircularDependency).toBe(true);
+      expect(result.chain).toEqual(['source', 'target', 'source']);
+    });
+
+    it('reports no cycle and returns the base chain when nothing matches', async () => {
+      http.get.mockResolvedValueOnce({ data: { trigger: [] } });
+      const result = await manager.validateDependencyChain('a', 'b');
+      expect(result.hasCircularDependency).toBe(false);
+      expect(result.chain).toEqual(['a', 'b']);
+    });
+
+    it('continues traversal and short-circuits already-visited nodes', async () => {
+      http.get.mockImplementation(async (url: string) => {
+        if (url.endsWith('/target/triggers')) {
+          return {
+            data: {
+              trigger: [
+                {
+                  id: 't1',
+                  type: 'buildDependencyTrigger',
+                  properties: { property: [{ name: 'dependsOn', value: 'other' }] },
+                },
+              ],
+            },
+          };
+        }
+        // 'other' depends on 'target' → would create cycle through 'other', but
+        // visited cache should prevent infinite recursion.
+        return {
+          data: {
+            trigger: [
+              {
+                id: 't2',
+                type: 'buildDependencyTrigger',
+                properties: { property: [{ name: 'dependsOn', value: 'target' }] },
+              },
+            ],
+          },
+        };
+      });
+      const result = await manager.validateDependencyChain('missing-source', 'target');
+      expect(result.hasCircularDependency).toBe(false);
+    });
+
+    it('swallows errors while fetching dependencies', async () => {
+      http.get.mockRejectedValueOnce(new Error('boom'));
+      const result = await manager.validateDependencyChain('source', 'target');
+      expect(result.hasCircularDependency).toBe(false);
+    });
+  });
 });

--- a/tests/unit/teamcity/client-adapter.test.ts
+++ b/tests/unit/teamcity/client-adapter.test.ts
@@ -329,6 +329,103 @@ describe('createAdapterFromTeamCityAPI', () => {
     expect(warnMock).not.toHaveBeenCalled();
   });
 
+  it('strips Bearer prefix from axios Authorization header', () => {
+    const httpBearer = axios.create({
+      baseURL: baseUrl,
+      timeout: 1234,
+      headers: { Authorization: 'Bearer secret-token' },
+    });
+    const withBearer = { modules, http: httpBearer } as unknown as TeamCityAPI;
+    const adapter = createAdapterFromTeamCityAPI(withBearer);
+    expect(adapter.getApiConfig().token).toBe('secret-token');
+  });
+
+  it('returns raw Authorization value when the prefix is not Bearer', () => {
+    const httpToken = axios.create({
+      baseURL: baseUrl,
+      headers: { Authorization: 'Token abc123' },
+    });
+    const api = { modules, http: httpToken } as unknown as TeamCityAPI;
+    const adapter = createAdapterFromTeamCityAPI(api);
+    expect(adapter.getApiConfig().token).toBe('Token abc123');
+  });
+
+  it('extracts Authorization via the getter when headers expose a getter function', () => {
+    const captured: string[] = [];
+    const headers = {
+      common: undefined,
+      get(name: string) {
+        captured.push(name);
+        return 'Bearer via-getter';
+      },
+    } as unknown as AxiosInstance['defaults']['headers'];
+    const httpGetter = axios.create({ baseURL: baseUrl });
+    httpGetter.defaults.headers = headers;
+    const api = { modules, http: httpGetter } as unknown as TeamCityAPI;
+    const adapter = createAdapterFromTeamCityAPI(api);
+    expect(adapter.getApiConfig().token).toBe('via-getter');
+    expect(captured).toEqual(['Authorization']);
+  });
+
+  it('handles array-valued Authorization headers by taking the first entry', () => {
+    const httpArray = axios.create({ baseURL: baseUrl });
+    httpArray.defaults.headers = {
+      Authorization: ['Bearer array-token', 'ignored'],
+    } as unknown as AxiosInstance['defaults']['headers'];
+    const api = { modules, http: httpArray } as unknown as TeamCityAPI;
+    const adapter = createAdapterFromTeamCityAPI(api);
+    expect(adapter.getApiConfig().token).toBe('array-token');
+  });
+
+  it('returns undefined when Authorization getter throws', () => {
+    const httpThrowing = axios.create({ baseURL: baseUrl });
+    httpThrowing.defaults.headers = {
+      get: () => {
+        throw new Error('denied');
+      },
+    } as unknown as AxiosInstance['defaults']['headers'];
+    const api = { modules, http: httpThrowing } as unknown as TeamCityAPI;
+    const adapter = createAdapterFromTeamCityAPI(api);
+    expect(adapter.getApiConfig().token).toBe('');
+  });
+
+  it('falls back to picking top-level API properties when modules is missing', async () => {
+    const projectsApi = { getAllProjects: jest.fn(async () => ({ data: {} })) };
+    const buildsApi: BuildApiLike = {
+      getAllBuilds: jest.fn(),
+      getBuild: jest.fn(),
+      getMultipleBuilds: jest.fn(),
+      getBuildProblems: jest.fn(),
+    };
+    const legacyApi = {
+      http,
+      getBaseUrl: () => baseUrl,
+      projects: projectsApi,
+      builds: buildsApi,
+    } as unknown as TeamCityAPI;
+    const adapter = createAdapterFromTeamCityAPI(legacyApi);
+    await adapter.modules.projects.getAllProjects?.('P1');
+    expect(projectsApi.getAllProjects).toHaveBeenCalledWith('P1');
+    // Missing keys resolve to empty objects so the surface stays safe to call.
+    expect(adapter.modules.mutes).toEqual({});
+    // Object is frozen.
+    expect(Object.isFrozen(adapter.modules)).toBe(true);
+  });
+
+  it('ignores invalid timeout values on http.defaults', () => {
+    const httpNoTimeout = axios.create({ baseURL: baseUrl });
+    httpNoTimeout.defaults.timeout = 0;
+    const api = { modules, http: httpNoTimeout } as unknown as TeamCityAPI;
+    const adapter = createAdapterFromTeamCityAPI(api);
+    expect(adapter.getApiConfig().timeout).toBeUndefined();
+
+    const httpNaN = axios.create({ baseURL: baseUrl });
+    httpNaN.defaults.timeout = Number.NaN as unknown as number;
+    const apiNaN = { modules, http: httpNaN } as unknown as TeamCityAPI;
+    const adapterNaN = createAdapterFromTeamCityAPI(apiNaN);
+    expect(adapterNaN.getApiConfig().timeout).toBeUndefined();
+  });
+
   it('warns and uses the placeholder baseUrl when no sources are available', async () => {
     const projects = { getAllProjects: jest.fn().mockResolvedValue({}) };
     const builds: BuildApiLike = {

--- a/tests/unit/teamcity/project-list-manager.test.ts
+++ b/tests/unit/teamcity/project-list-manager.test.ts
@@ -125,4 +125,146 @@ describe('ProjectListManager', () => {
       /TeamCity API error \(500\): oops/
     );
   });
+
+  it('re-throws generic Error instances untouched', async () => {
+    const client = makeClient({
+      getAllProjects: async () => {
+        throw new Error('something else');
+      },
+    });
+    await expect(new ProjectListManager(client).listProjects()).rejects.toThrow(/something else/);
+  });
+
+  it('wraps non-Error rejection values in a new Error', async () => {
+    const client = makeClient({
+      getAllProjects: async () => {
+        // eslint-disable-next-line no-throw-literal
+        throw 'plain-string-failure';
+      },
+    });
+    await expect(new ProjectListManager(client).listProjects()).rejects.toThrow(
+      /Unknown error: plain-string-failure/
+    );
+  });
+
+  it('reports TeamCity API error with "unknown" status when none is provided', async () => {
+    const client = makeClient({
+      getAllProjects: async () => {
+        throw Object.assign(new Error('err'), { response: {} });
+      },
+    });
+    await expect(new ProjectListManager(client).listProjects()).rejects.toThrow(
+      /TeamCity API error \(unknown\)/
+    );
+  });
+
+  it('falls back to Error.message when response.data has no message', async () => {
+    const client = makeClient({
+      getAllProjects: async () => {
+        throw Object.assign(new Error('fallback msg'), { response: { status: 500 } });
+      },
+    });
+    await expect(new ProjectListManager(client).listProjects()).rejects.toThrow(/fallback msg/);
+  });
+
+  it('returns an empty list when the API response has no project array', async () => {
+    const client = makeClient({
+      getAllProjects: async () => ({ data: {} as Projects }),
+    });
+    const res = await new ProjectListManager(client).listProjects();
+    expect(res.projects).toEqual([]);
+    expect(res.metadata.hasMore).toBe(false);
+    expect(res.metadata.totalCount).toBeUndefined();
+  });
+
+  it('uses buildTypes.buildType length when count is missing', async () => {
+    const response: Projects = {
+      count: 1,
+      project: [
+        {
+          id: 'P',
+          name: 'Project',
+          buildTypes: {
+            buildType: [{ id: 'b1' }, { id: 'b2' }, { id: 'b3' }],
+          },
+          projects: {
+            project: [{ id: 'c1' }, { id: 'c2' }],
+          },
+        } as unknown as Project,
+      ],
+    };
+    const client = makeClient({
+      getAllProjects: async () => ({ data: response }),
+    });
+    const res = await new ProjectListManager(client).listProjects();
+    expect(res.projects[0]?.buildTypesCount).toBe(3);
+    expect(res.projects[0]?.subprojectsCount).toBe(2);
+  });
+
+  it('returns 0 when neither count nor array is present', async () => {
+    const response: Projects = {
+      count: 1,
+      project: [{ id: 'X', name: 'Lone', buildTypes: {} } as unknown as Project],
+    };
+    const client = makeClient({
+      getAllProjects: async () => ({ data: response }),
+    });
+    const res = await new ProjectListManager(client).listProjects();
+    expect(res.projects[0]?.buildTypesCount).toBe(0);
+    expect(res.projects[0]?.subprojectsCount).toBe(0);
+  });
+
+  it('calculates depth=2 when parent exists but no ancestor list is returned', async () => {
+    const response: Projects = {
+      count: 1,
+      project: [
+        {
+          id: 'Child',
+          name: 'C',
+          parentProjectId: 'Parent',
+        } as unknown as Project,
+      ],
+    };
+    const client = makeClient({
+      getAllProjects: async () => ({ data: response }),
+    });
+    const res = await new ProjectListManager(client).listProjects();
+    expect(res.projects[0]?.depth).toBe(2);
+  });
+
+  it('calculates depth from ancestor list when provided', async () => {
+    const response: Projects = {
+      count: 1,
+      project: [
+        {
+          id: 'Grandchild',
+          name: 'G',
+          parentProjectId: 'Parent',
+          ancestorProjects: {
+            project: [
+              { id: 'Root', name: 'R' },
+              { id: 'Parent', name: 'P' },
+            ] as unknown as Project[],
+          },
+        } as unknown as Project,
+      ],
+    };
+    const client = makeClient({
+      getAllProjects: async () => ({ data: response }),
+    });
+    const res = await new ProjectListManager(client).listProjects();
+    expect(res.projects[0]?.depth).toBe(3);
+  });
+
+  it('reports hasMore=false when returned count is below the limit', async () => {
+    const response: Projects = {
+      count: 5,
+      project: [{ id: 'A' } as unknown as Project],
+    };
+    const client = makeClient({
+      getAllProjects: async () => ({ data: response }),
+    });
+    const res = await new ProjectListManager(client).listProjects({ limit: 100 });
+    expect(res.metadata.hasMore).toBe(false);
+  });
 });

--- a/tests/unit/teamcity/test-problem-reporter.test.ts
+++ b/tests/unit/teamcity/test-problem-reporter.test.ts
@@ -632,4 +632,197 @@ describe('TestProblemReporter', () => {
       expect(failedTests).toEqual([]);
     });
   });
+
+  describe('payload validation branches', () => {
+    it('throws when test occurrences is not a record', async () => {
+      http.get.mockResolvedValue({ data: { testOccurrences: 'not-an-object' } });
+      await expect(reporter.getTestStatistics('b1')).rejects.toThrow(
+        /malformed test occurrences payload/
+      );
+    });
+
+    it('coerces numeric-string count fields but throws on non-numeric strings', async () => {
+      http.get.mockResolvedValueOnce({
+        data: {
+          testOccurrences: {
+            count: '12',
+            passed: '10',
+            failed: 2,
+            ignored: 0,
+            muted: 0,
+            newFailed: 1,
+          },
+        },
+      });
+      const stats = await reporter.getTestStatistics('build-numeric-string');
+      expect(stats.totalTests).toBe(12);
+      expect(stats.passedTests).toBe(10);
+
+      http.get.mockResolvedValueOnce({
+        data: {
+          testOccurrences: {
+            count: 'not-a-number',
+            passed: 0,
+            failed: 0,
+            ignored: 0,
+            muted: 0,
+            newFailed: 0,
+          },
+        },
+      });
+      await expect(reporter.getTestStatistics('build-bad-string')).rejects.toThrow(
+        /statistics field is not numeric/
+      );
+    });
+
+    it('throws when a count field is neither number nor string', async () => {
+      http.get.mockResolvedValue({
+        data: {
+          testOccurrences: {
+            count: { nested: true },
+            passed: 0,
+            failed: 0,
+            ignored: 0,
+            muted: 0,
+            newFailed: 0,
+          },
+        },
+      });
+      await expect(reporter.getTestStatistics('bad-type')).rejects.toThrow(
+        /statistics field is not numeric/
+      );
+    });
+
+    it('defaults to zeroes when testOccurrences is null', async () => {
+      http.get.mockResolvedValue({ data: { testOccurrences: null } });
+      const stats = await reporter.getTestStatistics('no-stats');
+      expect(stats).toEqual({
+        totalTests: 0,
+        passedTests: 0,
+        failedTests: 0,
+        ignoredTests: 0,
+        mutedTests: 0,
+        newFailedTests: 0,
+        successRate: 100,
+      });
+    });
+
+    it('logs and returns empty when failed tests payload has a non-record entry', async () => {
+      http.get.mockResolvedValue({
+        data: { testOccurrence: ['not-a-record'] },
+      });
+      const res = await reporter.getFailedTests('b1');
+      expect(res).toEqual([]);
+      expect(logError).toHaveBeenCalled();
+    });
+
+    it('returns empty for problems when data is not a record', async () => {
+      http.get.mockResolvedValue({ data: null });
+      const res = (await reporter.getBuildProblems('b1')) as BuildProblem[];
+      expect(res).toEqual([]);
+      expect(logError).toHaveBeenCalled();
+    });
+
+    it('returns categorized empty when problems payload missing', async () => {
+      http.get.mockResolvedValue({ data: null });
+      const res = (await reporter.getBuildProblems('b1', true)) as CategorizedProblems;
+      expect(res).toEqual({ all: [], categorized: {} });
+    });
+
+    it('validates required fields on problem occurrences entry', async () => {
+      http.get.mockResolvedValue({
+        data: {
+          problemOccurrence: [{ id: 'p1', type: 'GENERIC' }],
+        },
+      });
+      const res = await reporter.getBuildProblems('b1');
+      expect(res).toEqual([]);
+      expect(logError).toHaveBeenCalledWith(
+        'Failed to get build problems',
+        expect.any(Error),
+        expect.any(Object)
+      );
+    });
+
+    it('rejects invalid additionalData types on a problem entry', async () => {
+      http.get.mockResolvedValue({
+        data: {
+          problemOccurrence: [
+            {
+              id: 'p1',
+              type: 'GENERIC',
+              identity: 'ident',
+              details: 'boom',
+              additionalData: 42,
+            },
+          ],
+        },
+      });
+      const res = await reporter.getBuildProblems('b1');
+      expect(res).toEqual([]);
+    });
+
+    it('rejects non-array problemOccurrence payloads', async () => {
+      http.get.mockResolvedValue({ data: { problemOccurrence: 'oops' } });
+      const res = await reporter.getBuildProblems('b1');
+      expect(res).toEqual([]);
+      expect(logError).toHaveBeenCalled();
+    });
+  });
+
+  describe('getTestTrend / getFailurePatterns', () => {
+    it('returns empty trend when builds response has no list', async () => {
+      http.get.mockResolvedValue({ data: { something: 'else' } });
+      const trend = await reporter.getTestTrend('bt-missing');
+      expect(trend).toEqual([]);
+    });
+
+    it('returns empty patterns when builds list is missing', async () => {
+      http.get.mockResolvedValue({ data: {} });
+      const patterns = await reporter.getFailurePatterns('bt-empty');
+      expect(patterns).toEqual({});
+    });
+
+    it('swallows errors from getTestTrend and returns empty', async () => {
+      http.get.mockRejectedValue(new Error('api boom'));
+      const trend = await reporter.getTestTrend('bt');
+      expect(trend).toEqual([]);
+      expect(logError).toHaveBeenCalled();
+    });
+
+    it('swallows errors from getFailurePatterns and returns empty', async () => {
+      http.get.mockRejectedValue(new Error('api boom'));
+      const patterns = await reporter.getFailurePatterns('bt');
+      expect(patterns).toEqual({});
+      expect(logError).toHaveBeenCalled();
+    });
+  });
+
+  describe('hasIssues + summary branches', () => {
+    it('returns false when no failures and no problems', async () => {
+      http.get.mockImplementation(async (url: string) => {
+        if (url.includes('/problemOccurrences')) {
+          return { data: { problemOccurrence: [] } };
+        }
+        return { data: { testOccurrences: { count: 0, passed: 0, failed: 0 } } };
+      });
+      await expect(reporter.hasIssues('b1')).resolves.toBe(false);
+    });
+
+    it('short-circuits to true on a failed test', async () => {
+      http.get.mockResolvedValueOnce({
+        data: { testOccurrences: { count: 1, passed: 0, failed: 1 } },
+      });
+      await expect(reporter.hasIssues('b1')).resolves.toBe(true);
+    });
+
+    it('returns default reason when no failures surface', async () => {
+      http.get.mockResolvedValueOnce({
+        data: { testOccurrences: { count: 0, passed: 0, failed: 0 } },
+      });
+      http.get.mockResolvedValueOnce({ data: { problemOccurrence: [] } });
+      const reason = await reporter.formatFailureReason('b1');
+      expect(reason).toBe('Build failed for unknown reasons');
+    });
+  });
 });

--- a/tests/unit/tools/tools-branch-coverage.test.ts
+++ b/tests/unit/tools/tools-branch-coverage.test.ts
@@ -1,0 +1,801 @@
+/**
+ * Tests targeting previously uncovered branches inside `src/tools.ts`.
+ *
+ * These focus on error-handling paths, fallback branches, and alternate
+ * outcomes that Codecov counted as partial line coverage (e.g. the queue
+ * fallback in `get_build`, the 400 fallback in `list_server_health_items`,
+ * `pause_queue_for_pool`, the `update_build_config` catch fallback, etc.).
+ *
+ * Pattern mirrors `error-handling.test.ts`: `jest.isolateModules` + per-test
+ * `jest.doMock` for `@/api-client` and (where needed) `@/teamcity/*` managers.
+ */
+import { AxiosError, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
+
+jest.mock('@/config', () => ({
+  getTeamCityUrl: () => 'https://example.test',
+  getTeamCityToken: () => 'token',
+  getMCPMode: () => 'full',
+}));
+
+jest.mock('@/utils/logger/index', () => {
+  const noop = jest.fn();
+  const mockLoggerInstance = {
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    logToolExecution: noop,
+    logTeamCityRequest: noop,
+    logLifecycle: noop,
+    child: jest.fn(),
+    generateRequestId: () => 'test-request',
+  };
+  mockLoggerInstance.child.mockReturnValue(mockLoggerInstance);
+  return {
+    getLogger: () => mockLoggerInstance,
+    logger: mockLoggerInstance,
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+  };
+});
+
+type ToolResult = {
+  content?: Array<{ text?: string }>;
+  success?: boolean;
+  error?: string;
+};
+type ToolHandler = (args: unknown) => Promise<ToolResult>;
+
+function createAxiosError(options: {
+  status?: number;
+  data?: unknown;
+  message?: string;
+  hasResponse?: boolean;
+}): AxiosError {
+  const err = new Error(options.message ?? 'Request failed') as AxiosError;
+  err.isAxiosError = true;
+  err.name = 'AxiosError';
+  err.config = {} as InternalAxiosRequestConfig;
+  err.toJSON = () => ({});
+  if (options.hasResponse !== false && options.status !== undefined) {
+    err.response = {
+      status: options.status,
+      statusText: 'Error',
+      data: options.data,
+      headers: {},
+      config: {} as InternalAxiosRequestConfig,
+    } as AxiosResponse;
+  }
+  return err;
+}
+
+function loadHandler(toolName: string, register: () => void): Promise<ToolHandler> {
+  return new Promise((resolve, reject) => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      try {
+        register();
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { getRequiredTool } = require('@/tools');
+        resolve(getRequiredTool(toolName).handler as ToolHandler);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+interface Payload {
+  success?: unknown;
+  error?: unknown;
+  action?: unknown;
+  updated?: unknown;
+  ok?: unknown;
+  criticalCount?: unknown;
+  warningCount?: unknown;
+  id?: unknown;
+  number?: unknown;
+  count?: unknown;
+  healthItem?: unknown;
+  state?: unknown;
+  status?: unknown;
+  waitReason?: unknown;
+  version?: unknown;
+  cpu?: unknown;
+  buildType?: unknown;
+  canceledQueued?: unknown;
+  disabledAgents?: unknown;
+  enabledAgents?: unknown;
+  enabled?: unknown;
+  [key: string]: unknown;
+}
+
+function parsePayload(res: ToolResult): Payload {
+  return JSON.parse((res.content?.[0]?.text as string) ?? '{}') as Payload;
+}
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  // Clear any per-test jest.doMock(…) registrations that might leak across tests
+  // (particularly client-adapter and the manager modules used by update_build_config).
+  jest.unmock('@/api-client');
+  jest.unmock('@/teamcity/client-adapter');
+  jest.unmock('@/teamcity/build-configuration-update-manager');
+  jest.unmock('@/teamcity/build-configuration-clone-manager');
+});
+
+describe('tools: get_build queue fallback branches', () => {
+  it('returns queued data when /builds 404s but queue has the build', async () => {
+    const handler = await loadHandler('get_build', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            getBuild: async () => {
+              throw createAxiosError({ status: 404 });
+            },
+            modules: {
+              buildQueue: {
+                getQueuedBuild: jest.fn(async () => ({
+                  data: { id: 777, buildTypeId: 'bt', waitReason: 'No agent' },
+                })),
+              },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({ buildId: '777' });
+    const payload = parsePayload(res);
+    expect(payload).toMatchObject({ id: 777, state: 'queued', waitReason: 'No agent' });
+  });
+
+  it('retries /builds after queue returns 404 (race) and succeeds', async () => {
+    const getBuild = jest
+      .fn()
+      .mockRejectedValueOnce(createAxiosError({ status: 404 }))
+      .mockResolvedValueOnce({ id: 'b1', status: 'SUCCESS' });
+    const handler = await loadHandler('get_build', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            getBuild,
+            modules: {
+              buildQueue: {
+                getQueuedBuild: async () => {
+                  throw createAxiosError({ status: 404 });
+                },
+              },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({ buildId: 'b1' });
+    const payload = parsePayload(res);
+    expect(payload.id).toBe('b1');
+    expect(getBuild).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-throws non-404 errors from /builds', async () => {
+    const getQueuedBuild = jest.fn();
+    const handler = await loadHandler('get_build', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            getBuild: async () => {
+              throw createAxiosError({ status: 500, data: 'boom' });
+            },
+            modules: { buildQueue: { getQueuedBuild } },
+          }),
+        },
+      }));
+    });
+    const res = await handler({ buildId: 'b2' });
+    const payload = parsePayload(res);
+    expect(payload.error ?? payload['message']).toBeDefined();
+    expect(getQueuedBuild).not.toHaveBeenCalled();
+  });
+
+  it('re-throws non-404 errors from queue endpoint', async () => {
+    const handler = await loadHandler('get_build', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            getBuild: async () => {
+              throw createAxiosError({ status: 404 });
+            },
+            modules: {
+              buildQueue: {
+                getQueuedBuild: async () => {
+                  throw createAxiosError({ status: 500 });
+                },
+              },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({ buildId: 'b3' });
+    const payload = parsePayload(res);
+    expect(payload.error ?? payload['message']).toBeDefined();
+  });
+});
+
+describe('tools: list_server_health_items 400 fallback', () => {
+  it('applies client-side filter when TeamCity rejects locator', async () => {
+    const handler = await loadHandler('list_server_health_items', () => {
+      const getHealthItems = jest.fn();
+      getHealthItems.mockImplementationOnce(async () => {
+        const err = new Error('bad locator') as Error & { statusCode: number };
+        err.statusCode = 400;
+        throw err;
+      });
+      getHealthItems.mockImplementationOnce(async () => ({
+        data: {
+          healthItem: [
+            { id: 'a', severity: 'ERROR', category: 'DB' },
+            { id: 'b', severity: 'WARNING', category: 'DB' },
+            { id: 'c', severity: 'INFO', category: 'SYS' },
+          ],
+        },
+      }));
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            modules: { health: { getHealthItems } },
+          }),
+        },
+      }));
+    });
+    const res = await handler({ locator: 'severity:error,category:DB,id:a,unknown:x' });
+    const payload = parsePayload(res);
+    expect(payload.count).toBe(1);
+    expect(Array.isArray(payload.healthItem)).toBe(true);
+    expect((payload.healthItem as Array<{ id: string }>)[0]?.id).toBe('a');
+  });
+
+  it('rethrows non-400 errors unchanged', async () => {
+    const handler = await loadHandler('list_server_health_items', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            modules: {
+              health: {
+                getHealthItems: async () => {
+                  throw new Error('server down');
+                },
+              },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({});
+    const payload = parsePayload(res);
+    expect(payload.error ?? payload['message']).toBeDefined();
+  });
+
+  it('recognizes VALIDATION_ERROR code as 400-equivalent', async () => {
+    const handler = await loadHandler('list_server_health_items', () => {
+      const getHealthItems = jest.fn();
+      getHealthItems.mockImplementationOnce(async () => {
+        const err = new Error('validation') as Error & { code: string };
+        err.code = 'VALIDATION_ERROR';
+        throw err;
+      });
+      getHealthItems.mockImplementationOnce(async () => ({
+        data: { healthItem: [{ id: 'x', severity: 'ERROR' }] },
+      }));
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({ modules: { health: { getHealthItems } } }),
+        },
+      }));
+    });
+    const res = await handler({ locator: 'severity:ERROR' });
+    const payload = parsePayload(res);
+    expect(payload.count).toBe(1);
+  });
+
+  it('normalizes category:(ERROR) parenthesized locator', async () => {
+    const getHealthItems = jest.fn(async (loc?: string) => ({
+      data: { healthItem: [{ id: 'z', severity: 'ERROR' }] },
+      _loc: loc,
+    }));
+    const handler = await loadHandler('list_server_health_items', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({ modules: { health: { getHealthItems } } }),
+        },
+      }));
+    });
+    await handler({ locator: '  category:(ERROR)  ' });
+    expect(getHealthItems).toHaveBeenCalledWith('category:ERROR');
+  });
+});
+
+describe('tools: check_availability_guard', () => {
+  it('returns ok=false when critical items exist', async () => {
+    const handler = await loadHandler('check_availability_guard', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            modules: {
+              health: {
+                getHealthItems: async () => ({
+                  data: {
+                    healthItem: [
+                      { severity: 'ERROR', id: 'a' },
+                      { severity: 'WARNING', id: 'b' },
+                    ],
+                  },
+                }),
+              },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({});
+    const payload = parsePayload(res);
+    expect(payload.ok).toBe(false);
+    expect(payload.criticalCount).toBe(1);
+    expect(payload.warningCount).toBe(1);
+  });
+
+  it('treats warnings as failure when failOnWarning=true', async () => {
+    const handler = await loadHandler('check_availability_guard', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            modules: {
+              health: {
+                getHealthItems: async () => ({
+                  data: { healthItem: [{ severity: 'WARNING' }] },
+                }),
+              },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({ failOnWarning: true });
+    expect(parsePayload(res).ok).toBe(false);
+  });
+
+  it('returns ok=true when only warnings and failOnWarning=false', async () => {
+    const handler = await loadHandler('check_availability_guard', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            modules: {
+              health: {
+                getHealthItems: async () => ({
+                  data: { healthItem: [{ severity: 'WARNING' }] },
+                }),
+              },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({});
+    expect(parsePayload(res).ok).toBe(true);
+  });
+});
+
+describe('tools: pause_queue_for_pool and resume_queue_for_pool', () => {
+  it('disables agents, cancels matching queued builds', async () => {
+    const setEnabledInfo = jest.fn(async () => ({}));
+    const deleteQueuedBuild = jest.fn(async () => ({}));
+    const handler = await loadHandler('pause_queue_for_pool', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            modules: {
+              agents: {
+                getAllAgents: async () => ({
+                  data: { agent: [{ id: '1' }, { id: '2' }, {}] },
+                }),
+                setEnabledInfo,
+              },
+              buildQueue: {
+                getAllQueuedBuilds: async () => ({
+                  data: {
+                    build: [
+                      { id: 10, buildTypeId: 'btA' },
+                      { id: 11, buildTypeId: 'btB' },
+                      { buildTypeId: 'btA' }, // no id → skipped
+                    ],
+                  },
+                }),
+                deleteQueuedBuild,
+              },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({
+      poolId: 'pool-1',
+      cancelQueuedForBuildTypeId: 'btA',
+      comment: 'maintenance',
+      until: '2030-01-01T00:00:00Z',
+    });
+    const payload = parsePayload(res);
+    expect(payload).toMatchObject({
+      success: true,
+      action: 'pause_queue_for_pool',
+      disabledAgents: 2,
+      canceledQueued: 1,
+    });
+    expect(setEnabledInfo).toHaveBeenCalledTimes(2);
+    expect(deleteQueuedBuild).toHaveBeenCalledWith('10');
+  });
+
+  it('skips cancellation when cancelQueuedForBuildTypeId is absent', async () => {
+    const deleteQueuedBuild = jest.fn();
+    const handler = await loadHandler('pause_queue_for_pool', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            modules: {
+              agents: {
+                getAllAgents: async () => ({ data: { agent: [{ id: 'a' }] } }),
+                setEnabledInfo: async () => ({}),
+              },
+              buildQueue: { getAllQueuedBuilds: jest.fn(), deleteQueuedBuild },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({ poolId: 'pool' });
+    const payload = parsePayload(res);
+    expect(payload.canceledQueued).toBe(0);
+    expect(deleteQueuedBuild).not.toHaveBeenCalled();
+  });
+
+  it('resume_queue_for_pool re-enables all agents in pool', async () => {
+    const setEnabledInfo = jest.fn(async () => ({}));
+    const handler = await loadHandler('resume_queue_for_pool', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({
+            modules: {
+              agents: {
+                getAllAgents: async () => ({
+                  data: { agent: [{ id: '1' }, { id: '2' }, {}] },
+                }),
+                setEnabledInfo,
+              },
+            },
+          }),
+        },
+      }));
+    });
+    const res = await handler({ poolId: 'pool-2' });
+    const payload = parsePayload(res);
+    expect(payload).toMatchObject({
+      success: true,
+      action: 'resume_queue_for_pool',
+      enabledAgents: 2,
+    });
+    expect(setEnabledInfo).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('tools: update_build_config fallback branches', () => {
+  const adapterStub = {
+    http: { defaults: { timeout: 0, baseURL: 'http://x', headers: {} } },
+    modules: { buildTypes: { setBuildTypeField: jest.fn(async () => ({})) } },
+  };
+
+  it('uses direct field updates when manager.retrieveConfiguration returns null', async () => {
+    const setBuildTypeField = jest.fn(async () => ({}));
+    const retrieveConfiguration = jest.fn(async () => null);
+    const setArtifactRulesWithFallback = jest.fn(async () => ({}));
+    const adapter = {
+      http: adapterStub.http,
+      modules: { buildTypes: { setBuildTypeField } },
+    };
+    const handler = await loadHandler('update_build_config', () => {
+      jest.doMock('@/teamcity/build-configuration-update-manager', () => ({
+        BuildConfigurationUpdateManager: jest.fn().mockImplementation(() => ({
+          retrieveConfiguration,
+          validateUpdates: jest.fn(),
+          applyUpdates: jest.fn(),
+        })),
+        setArtifactRulesWithFallback,
+      }));
+      jest.doMock('@/teamcity/client-adapter', () => ({
+        createAdapterFromTeamCityAPI: () => adapter,
+      }));
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: { getInstance: () => ({}) },
+      }));
+    });
+    const res = await handler({
+      buildTypeId: 'bt',
+      name: 'new name',
+      description: 'new desc',
+      artifactRules: 'out/** => dist',
+    });
+    expect(res.success).toBe(true);
+    expect(retrieveConfiguration).toHaveBeenCalledWith('bt');
+    expect(setBuildTypeField).toHaveBeenCalledWith('bt', 'name', 'new name', expect.any(Object));
+    expect(setArtifactRulesWithFallback).toHaveBeenCalledWith(adapter.http, 'bt', 'out/** => dist');
+  });
+
+  it('falls through the catch branch when retrieveConfiguration throws', async () => {
+    const setBuildTypeField = jest.fn(async () => ({}));
+    const setArtifactRulesWithFallback = jest.fn(async () => ({}));
+    const adapter = {
+      http: adapterStub.http,
+      modules: { buildTypes: { setBuildTypeField } },
+    };
+    const handler = await loadHandler('update_build_config', () => {
+      jest.doMock('@/teamcity/build-configuration-update-manager', () => ({
+        BuildConfigurationUpdateManager: jest.fn().mockImplementation(() => ({
+          retrieveConfiguration: jest.fn(async () => {
+            throw new Error('boom');
+          }),
+          validateUpdates: jest.fn(),
+          applyUpdates: jest.fn(),
+        })),
+        setArtifactRulesWithFallback,
+      }));
+      jest.doMock('@/teamcity/client-adapter', () => ({
+        createAdapterFromTeamCityAPI: () => adapter,
+      }));
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: { getInstance: () => ({}) },
+      }));
+    });
+    const res = await handler({
+      buildTypeId: 'bt',
+      description: 'only-desc',
+      artifactRules: 'out/** => dist',
+    });
+    expect(res.success).toBe(true);
+    expect(setArtifactRulesWithFallback).toHaveBeenCalledWith(adapter.http, 'bt', 'out/** => dist');
+    expect(setBuildTypeField).toHaveBeenCalledWith(
+      'bt',
+      'description',
+      'only-desc',
+      expect.any(Object)
+    );
+  });
+
+  it('applies updates through the manager happy path', async () => {
+    const validateUpdates = jest.fn(async () => ({}));
+    const applyUpdates = jest.fn(async () => ({}));
+    const adapter = { http: adapterStub.http, modules: { buildTypes: {} } };
+    const handler = await loadHandler('update_build_config', () => {
+      jest.doMock('@/teamcity/build-configuration-update-manager', () => ({
+        BuildConfigurationUpdateManager: jest.fn().mockImplementation(() => ({
+          retrieveConfiguration: jest.fn(async () => ({ id: 'bt', name: 'old' })),
+          validateUpdates,
+          applyUpdates,
+        })),
+        setArtifactRulesWithFallback: jest.fn(),
+      }));
+      jest.doMock('@/teamcity/client-adapter', () => ({
+        createAdapterFromTeamCityAPI: () => adapter,
+      }));
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: { getInstance: () => ({}) },
+      }));
+    });
+    const res = await handler({ buildTypeId: 'bt', name: 'new', description: 'desc' });
+    expect(res.success).toBe(true);
+    expect(validateUpdates).toHaveBeenCalled();
+    expect(applyUpdates).toHaveBeenCalled();
+  });
+});
+
+describe('tools: clone_build_config error/edge branches', () => {
+  it('returns failure when source configuration not found', async () => {
+    const handler = await loadHandler('clone_build_config', () => {
+      jest.doMock('@/teamcity/build-configuration-clone-manager', () => ({
+        BuildConfigurationCloneManager: jest.fn().mockImplementation(() => ({
+          retrieveConfiguration: jest.fn(async () => null),
+          cloneConfiguration: jest.fn(),
+        })),
+      }));
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: { getInstance: () => ({}) },
+      }));
+    });
+    const res = await handler({ sourceBuildTypeId: 'missing', name: 'n', id: 'new' });
+    const payload = parsePayload(res);
+    expect(payload.success).toBe(false);
+    expect(payload.error).toContain('missing');
+  });
+
+  it('requires projectId when source has none', async () => {
+    const handler = await loadHandler('clone_build_config', () => {
+      jest.doMock('@/teamcity/build-configuration-clone-manager', () => ({
+        BuildConfigurationCloneManager: jest.fn().mockImplementation(() => ({
+          retrieveConfiguration: jest.fn(async () => ({ id: 'src' })),
+          cloneConfiguration: jest.fn(),
+        })),
+      }));
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: { getInstance: () => ({}) },
+      }));
+    });
+    const res = await handler({ sourceBuildTypeId: 'src', name: 'n', id: 'new' });
+    const payload = parsePayload(res);
+    expect(payload.success).toBe(false);
+    expect(payload.error).toMatch(/projectId is required/);
+  });
+
+  it('returns failure payload when cloneConfiguration throws', async () => {
+    const handler = await loadHandler('clone_build_config', () => {
+      jest.doMock('@/teamcity/build-configuration-clone-manager', () => ({
+        BuildConfigurationCloneManager: jest.fn().mockImplementation(() => ({
+          retrieveConfiguration: jest.fn(async () => ({ id: 'src', projectId: 'P' })),
+          cloneConfiguration: jest.fn(async () => {
+            throw new Error('clone failed');
+          }),
+        })),
+      }));
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: { getInstance: () => ({}) },
+      }));
+    });
+    const res = await handler({ sourceBuildTypeId: 'src', name: 'n', id: 'new' });
+    const payload = parsePayload(res);
+    expect(payload.success).toBe(false);
+    expect(payload.error).toContain('clone failed');
+  });
+
+  it('returns a generic failure message when clone rejects with a non-Error', async () => {
+    const handler = await loadHandler('clone_build_config', () => {
+      jest.doMock('@/teamcity/build-configuration-clone-manager', () => ({
+        BuildConfigurationCloneManager: jest.fn().mockImplementation(() => ({
+          retrieveConfiguration: jest.fn(async () => ({ id: 'src', projectId: 'P' })),
+
+          cloneConfiguration: jest.fn(async () => {
+            // eslint-disable-next-line no-throw-literal
+            throw 'not an error instance';
+          }),
+        })),
+      }));
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: { getInstance: () => ({}) },
+      }));
+    });
+    const res = await handler({ sourceBuildTypeId: 'src', name: 'n', id: 'new' });
+    const payload = parsePayload(res);
+    expect(payload.success).toBe(false);
+    expect(payload.error).toMatch(/Failed to clone build configuration/);
+  });
+});
+
+describe('tools: simple-getter coverage for assorted read-only tools', () => {
+  it('get_agent_enabled_info returns module data', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getEnabledInfo = jest.fn(async () => ({ data: { enabled: true } }));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => ({ agents: { getEnabledInfo } }) },
+          }));
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const res = await getRequiredTool('get_agent_enabled_info').handler({ agentId: 'a1' });
+          const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({ enabled: true });
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('get_server_health_item returns data from modules.health.getSingleHealthItem', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getSingleHealthItem = jest.fn(async () => ({ data: { id: 'h-1' } }));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => ({ health: { getSingleHealthItem } }) },
+          }));
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const res = await getRequiredTool('get_server_health_item').handler({
+            locator: 'id:h-1',
+          });
+          const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({ id: 'h-1' });
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('get_server_info returns info payload', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getServerInfo = jest.fn(async () => ({ data: { version: '2026.04' } }));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => ({ server: { getServerInfo } }) },
+          }));
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const res = await getRequiredTool('get_server_info').handler({});
+          const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({ version: '2026.04' });
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('get_server_metrics returns metrics payload', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getAllMetrics = jest.fn(async () => ({ data: { cpu: 1 } }));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => ({ server: { getAllMetrics } }) },
+          }));
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const res = await getRequiredTool('get_server_metrics').handler({});
+          const payload = JSON.parse((res.content?.[0]?.text as string) ?? '{}');
+          expect(payload).toMatchObject({ cpu: 1 });
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+});
+
+describe('tools: update_vcs_root_properties', () => {
+  it('returns updated=0 when no properties supplied', async () => {
+    const setVcsRootProperty = jest.fn();
+    const handler = await loadHandler('update_vcs_root_properties', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({ vcsRoots: { setVcsRootProperty } }),
+        },
+      }));
+    });
+    const res = await handler({ id: 'v1' });
+    const payload = parsePayload(res);
+    expect(payload.updated).toBe(0);
+    expect(setVcsRootProperty).not.toHaveBeenCalled();
+  });
+
+  it('joins a branchSpec array into newline-delimited value', async () => {
+    const setVcsRootProperty = jest.fn(async () => ({}));
+    const handler = await loadHandler('update_vcs_root_properties', () => {
+      jest.doMock('@/api-client', () => ({
+        TeamCityAPI: {
+          getInstance: () => ({ vcsRoots: { setVcsRootProperty } }),
+        },
+      }));
+    });
+    const res = await handler({
+      id: 'v1',
+      url: 'git@host:repo.git',
+      branch: 'refs/heads/main',
+      branchSpec: ['+:refs/heads/*', '-:refs/heads/wip/*'],
+      checkoutRules: '+:.',
+    });
+    const payload = parsePayload(res);
+    expect(payload.updated).toBe(4);
+    expect(setVcsRootProperty).toHaveBeenCalledWith(
+      'v1',
+      'branchSpec',
+      '+:refs/heads/*\n-:refs/heads/wip/*',
+      expect.any(Object)
+    );
+  });
+});

--- a/tests/unit/tools/tools-list-branch-coverage.test.ts
+++ b/tests/unit/tools/tools-list-branch-coverage.test.ts
@@ -1,0 +1,684 @@
+/**
+ * Covers the "filter provided" branch in each list_* tool in `src/tools.ts`.
+ *
+ * Many list handlers have `if (typed.locator) parts.push(...)` style guards
+ * whose "true" branch was never exercised by existing pagination tests (they
+ * only pass `all` or `pageSize`). Running each handler with filters + a single
+ * page of results turns those partial lines into full hits.
+ */
+jest.mock('@/config', () => ({
+  getTeamCityUrl: () => 'https://example.test',
+  getTeamCityToken: () => 'token',
+  getMCPMode: () => 'full',
+}));
+
+describe('tools: list_* filter branch coverage', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.unmock('@/api-client');
+  });
+
+  async function runListTool(
+    toolName: string,
+    topLevelApi: Record<string, unknown>,
+    args: Record<string, unknown>
+  ): Promise<{ items?: unknown[]; pagination?: unknown; [k: string]: unknown }> {
+    return new Promise((resolve, reject) => {
+      jest.resetModules();
+      jest.isolateModules(() => {
+        (async () => {
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => topLevelApi },
+          }));
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { getRequiredTool } = require('@/tools');
+            const res = await getRequiredTool(toolName).handler(args);
+            resolve(JSON.parse(res.content?.[0]?.text ?? '{}'));
+          } catch (err) {
+            reject(err);
+          }
+        })().catch(reject);
+      });
+    });
+  }
+
+  it('list_changes with locator + projectId + buildId filters all included', async () => {
+    const getAllChanges = jest.fn(async () => ({
+      data: { change: [{ id: 1 }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_changes',
+      { changes: { getAllChanges } },
+      { locator: 'change:(id:1)', projectId: 'P', buildId: 'B', pageSize: 10, fields: 'id' }
+    );
+    expect(Array.isArray(data.items)).toBe(true);
+    expect(getAllChanges).toHaveBeenCalledWith(expect.stringContaining('change:(id:1)'), 'id');
+  });
+
+  it('list_problems with filters', async () => {
+    const getAllBuildProblems = jest.fn(async () => ({
+      data: { problem: [{ id: 'p' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_problems',
+      { problems: { getAllBuildProblems } },
+      { locator: 'identity:X', projectId: 'P', buildId: 'B', pageSize: 10, fields: 'id' }
+    );
+    expect(data.items).toBeDefined();
+    expect(getAllBuildProblems).toHaveBeenCalled();
+  });
+
+  it('list_problem_occurrences with filters', async () => {
+    const getAllBuildProblemOccurrences = jest.fn(async () => ({
+      data: { problemOccurrence: [{ id: 'p' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_problem_occurrences',
+      { problemOccurrences: { getAllBuildProblemOccurrences } },
+      { locator: 'muted:false', projectId: 'P', buildId: 'B', pageSize: 10 }
+    );
+    expect(data.items).toBeDefined();
+  });
+
+  it('list_investigations with filters', async () => {
+    const getAllInvestigations = jest.fn(async () => ({
+      data: { investigation: [{ id: 'i' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_investigations',
+      { investigations: { getAllInvestigations } },
+      { locator: 'state:TAKEN', assigneeId: 'U', projectId: 'P', pageSize: 10 }
+    );
+    expect(data.items).toBeDefined();
+  });
+
+  it('list_muted_tests with filters', async () => {
+    const getAllMutedTests = jest.fn(async () => ({
+      data: { mute: [{ id: 'm' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_muted_tests',
+      { mutes: { getAllMutedTests } },
+      { locator: 'affected:scope', projectId: 'P', buildTypeId: 'bt', pageSize: 10 }
+    );
+    expect(data.items).toBeDefined();
+  });
+
+  it('list_users with filters', async () => {
+    const getAllUsers = jest.fn(async () => ({
+      data: { user: [{ id: 'u' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_users',
+      { users: { getAllUsers } },
+      { locator: 'name:x', pageSize: 10, fields: 'id' }
+    );
+    expect(data.items).toBeDefined();
+  });
+
+  it('list_roles returns the roles payload', async () => {
+    const getRoles = jest.fn(async () => ({ data: { role: [{ id: 'r' }] } }));
+    const data = await runListTool('list_roles', { roles: { getRoles } }, { fields: 'id' });
+    expect(data['items']).toEqual([{ id: 'r' }]);
+    expect(data['count']).toBe(1);
+  });
+
+  it('list_branches resolves via adapter.listBuilds when buildTypeId is provided', async () => {
+    const listBuilds = jest.fn(async () => ({
+      build: [
+        { branchName: 'refs/heads/main' },
+        { branchName: 'refs/heads/dev' },
+        { branchName: null },
+      ],
+    }));
+    const data = await runListTool('list_branches', { listBuilds }, { buildTypeId: 'bt1' });
+    expect(data['branches']).toEqual(expect.arrayContaining(['refs/heads/main', 'refs/heads/dev']));
+    expect(listBuilds).toHaveBeenCalledWith(expect.stringContaining('buildType:(id:bt1)'));
+  });
+
+  it('list_branches resolves via projectId when buildTypeId is absent', async () => {
+    const listBuilds = jest.fn(async () => ({
+      build: [{ branchName: 'feature/x' }],
+    }));
+    const data = await runListTool('list_branches', { listBuilds }, { projectId: 'proj' });
+    expect(listBuilds).toHaveBeenCalledWith(expect.stringContaining('project:(id:proj)'));
+    expect(data['count']).toBe(1);
+  });
+
+  it('list_parameters calls adapter.getBuildType and returns parameters array', async () => {
+    const getBuildType = jest.fn(async () => ({
+      parameters: {
+        property: [
+          { name: 'a', value: '1' },
+          { name: 'b', value: '2' },
+        ],
+      },
+    }));
+    const data = await runListTool('list_parameters', { getBuildType }, { buildTypeId: 'bt' });
+    expect(data['count']).toBe(2);
+    expect(Array.isArray(data['parameters'])).toBe(true);
+    expect(getBuildType).toHaveBeenCalledWith('bt');
+  });
+
+  it('list_parameters handles missing parameters.property gracefully', async () => {
+    const getBuildType = jest.fn(async () => ({}));
+    const data = await runListTool('list_parameters', { getBuildType }, { buildTypeId: 'bt' });
+    expect(data['count']).toBe(0);
+    expect(data['parameters']).toEqual([]);
+  });
+
+  it('list_project_parameters reads from projects.getBuildParameters', async () => {
+    const getBuildParameters = jest.fn(async () => ({
+      data: { property: [{ name: 'k', value: 'v' }] },
+    }));
+    const data = await runListTool(
+      'list_project_parameters',
+      { projects: { getBuildParameters } },
+      { projectId: 'P' }
+    );
+    expect(data['count']).toBe(1);
+    expect(getBuildParameters).toHaveBeenCalledWith('P');
+  });
+
+  it('list_project_hierarchy walks projects.getProject recursively', async () => {
+    const getProject = jest.fn(async (id: string) => {
+      if (id === 'Root') {
+        return {
+          data: {
+            id: 'Root',
+            name: 'Root',
+            projects: { project: [{ id: 'c1', name: 'Child1' }] },
+          },
+        };
+      }
+      return { data: { id, name: `leaf-${id}` } };
+    });
+    const data = await runListTool(
+      'list_project_hierarchy',
+      { projects: { getProject } },
+      { rootProjectId: 'Root' }
+    );
+    expect(data['id']).toBe('Root');
+    expect(Array.isArray(data['children'])).toBe(true);
+  });
+
+  it('list_project_hierarchy defaults to "_Root" when rootProjectId is absent', async () => {
+    const getProject = jest.fn(async () => ({
+      data: { id: '_Root', name: 'RootProj', projects: { project: [] } },
+    }));
+    await runListTool('list_project_hierarchy', { projects: { getProject } }, {});
+    expect(getProject).toHaveBeenCalledWith('_Root');
+  });
+
+  it('handles paginated fetcher with a response missing count', async () => {
+    const getAllChanges = jest.fn(async () => ({ data: { change: [{ id: 1 }] } }));
+    const data = await runListTool(
+      'list_changes',
+      { changes: { getAllChanges } },
+      { pageSize: 50, fields: 'id' }
+    );
+    expect(data.items).toBeDefined();
+  });
+
+  it('handles paginated fetcher returning a non-array payload', async () => {
+    const getAllChanges = jest.fn(async () => ({ data: { change: 'not-array' } }));
+    const data = await runListTool(
+      'list_changes',
+      { changes: { getAllChanges } },
+      { pageSize: 50 }
+    );
+    expect(Array.isArray(data.items)).toBe(true);
+    expect(data.items).toHaveLength(0);
+  });
+
+  it('list_problems fetches all pages when all=true', async () => {
+    const getAllBuildProblems = jest.fn(async () => ({
+      data: { problem: [], count: 0 },
+    }));
+    const data = await runListTool(
+      'list_problems',
+      { problems: { getAllBuildProblems } },
+      { all: true, pageSize: 10 }
+    );
+    expect(data['pagination']).toMatchObject({ mode: 'all' });
+  });
+
+  it('list_problem_occurrences fetches all pages when all=true', async () => {
+    const getAllBuildProblemOccurrences = jest.fn(async () => ({
+      data: { problemOccurrence: [], count: 0 },
+    }));
+    const data = await runListTool(
+      'list_problem_occurrences',
+      { problemOccurrences: { getAllBuildProblemOccurrences } },
+      { all: true }
+    );
+    expect(data['pagination']).toMatchObject({ mode: 'all' });
+  });
+
+  it('list_investigations fetches all pages when all=true', async () => {
+    const getAllInvestigations = jest.fn(async () => ({
+      data: { investigation: [], count: 0 },
+    }));
+    const data = await runListTool(
+      'list_investigations',
+      { investigations: { getAllInvestigations } },
+      { all: true, assigneeUsername: 'user', buildTypeId: 'bt' }
+    );
+    expect(data['pagination']).toMatchObject({ mode: 'all' });
+  });
+
+  it('list_muted_tests fetches all pages when all=true', async () => {
+    const getAllMutedTests = jest.fn(async () => ({
+      data: { mute: [], count: 0 },
+    }));
+    const data = await runListTool(
+      'list_muted_tests',
+      { mutes: { getAllMutedTests } },
+      { all: true }
+    );
+    expect(data['pagination']).toMatchObject({ mode: 'all' });
+  });
+
+  it('list_users fetches all pages when all=true', async () => {
+    const getAllUsers = jest.fn(async () => ({
+      data: { user: [], count: 0 },
+    }));
+    const data = await runListTool('list_users', { users: { getAllUsers } }, { all: true });
+    expect(data['pagination']).toMatchObject({ mode: 'all' });
+  });
+
+  it('list_test_failures first-page path with buildId', async () => {
+    const getAllTestOccurrences = jest.fn(async () => ({
+      data: { testOccurrence: [{ id: 't1' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_test_failures',
+      { tests: { getAllTestOccurrences } },
+      { buildId: 'b1', pageSize: 25, fields: 'id' }
+    );
+    expect(data['items']).toBeDefined();
+  });
+
+  it('list_vcs_roots with projectId filter', async () => {
+    const getAllVcsRoots = jest.fn(async () => ({
+      data: { 'vcs-root': [{ id: 'v1' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_vcs_roots',
+      { vcsRoots: { getAllVcsRoots } },
+      { projectId: 'P', pageSize: 25, fields: 'id' }
+    );
+    expect(data['items']).toBeDefined();
+  });
+
+  it('list_queued_builds with locator', async () => {
+    const getAllQueuedBuilds = jest.fn(async () => ({
+      data: { build: [{ id: 1 }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_queued_builds',
+      { buildQueue: { getAllQueuedBuilds } },
+      { locator: 'project:(id:P)', pageSize: 25 }
+    );
+    expect(data['items']).toBeDefined();
+  });
+
+  it('list_agents first-page path with filter', async () => {
+    const getAllAgents = jest.fn(async () => ({
+      data: { agent: [{ id: '1' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_agents',
+      { agents: { getAllAgents } },
+      { locator: 'connected:true', pageSize: 25, fields: 'id' }
+    );
+    expect(data['items']).toBeDefined();
+    expect(getAllAgents).toHaveBeenCalledWith(expect.stringContaining('connected:true'), 'id');
+  });
+
+  it('list_agent_pools first-page path', async () => {
+    const getAllAgentPools = jest.fn(async () => ({
+      data: { agentPool: [{ id: '1' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_agent_pools',
+      { agentPools: { getAllAgentPools } },
+      { pageSize: 25, fields: 'id' }
+    );
+    expect(data['items']).toBeDefined();
+  });
+
+  it('list_builds first-page path with all filters', async () => {
+    const getAllBuilds = jest.fn(async () => ({
+      data: { build: [{ id: 1 }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_builds',
+      { builds: { getAllBuilds } },
+      {
+        locator: 'state:running',
+        projectId: 'P',
+        buildTypeId: 'bt',
+        branch: 'refs/heads/main',
+        status: 'SUCCESS',
+        pageSize: 25,
+      }
+    );
+    expect(data['items']).toBeDefined();
+    expect(getAllBuilds).toHaveBeenCalled();
+  });
+
+  it('list_build_configs first-page path with filters', async () => {
+    const getAllBuildTypes = jest.fn(async () => ({
+      data: { buildType: [{ id: 'bt' }], count: 1 },
+    }));
+    const data = await runListTool(
+      'list_build_configs',
+      { buildTypes: { getAllBuildTypes } },
+      { locator: 'name:foo', projectId: 'P', pageSize: 25, fields: 'id' }
+    );
+    expect(data['items']).toBeDefined();
+  });
+});
+
+describe('tools: fetch_build_log retry/error handling branches', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.unmock('@/api-client');
+  });
+
+  async function runFetch(args: Record<string, unknown>, api: Record<string, unknown>) {
+    return new Promise<Record<string, unknown>>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => api },
+          }));
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { getRequiredTool } = require('@/tools');
+            const res = await getRequiredTool('fetch_build_log').handler(args);
+            resolve(JSON.parse((res.content?.[0]?.text as string) ?? '{}'));
+          } catch (err) {
+            reject(err);
+          }
+        })().catch(reject);
+      });
+    });
+  }
+
+  it('retries on 404 axios errors and eventually surfaces a normalized error', async () => {
+    const getBuildLogChunk = jest.fn(async () => {
+      const err = new Error('not found') as Error & {
+        isAxiosError: boolean;
+        response: { status: number; statusText: string };
+      };
+      err.isAxiosError = true;
+      err.response = { status: 404, statusText: 'Not Found' };
+      throw err;
+    });
+    const payload = await runFetch({ buildId: 'b-retry', lineCount: 10 }, { getBuildLogChunk });
+    expect(payload['error']).toBeDefined();
+    // Retried multiple times before giving up
+    expect((getBuildLogChunk as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('retries on 500 axios errors and reports status text', async () => {
+    const getBuildLogChunk = jest.fn(async () => {
+      const err = new Error('boom') as Error & {
+        isAxiosError: boolean;
+        response: { status: number; statusText: string };
+      };
+      err.isAxiosError = true;
+      err.response = { status: 503, statusText: 'Service Unavailable' };
+      throw err;
+    });
+    const payload = await runFetch({ buildId: 'b-503', lineCount: 10 }, { getBuildLogChunk });
+    expect(payload['error']).toBeDefined();
+  });
+
+  it('retries on network errors with no HTTP status', async () => {
+    const getBuildLogChunk = jest.fn(async () => {
+      const err = new Error('ECONNRESET') as Error & {
+        isAxiosError: boolean;
+      };
+      err.isAxiosError = true;
+      throw err;
+    });
+    const payload = await runFetch({ buildId: 'b-network', lineCount: 10 }, { getBuildLogChunk });
+    expect(payload['error']).toBeDefined();
+  });
+
+  it('does not retry on non-retryable axios errors (401)', async () => {
+    const getBuildLogChunk = jest.fn(async () => {
+      const err = new Error('auth') as Error & {
+        isAxiosError: boolean;
+        response: { status: number };
+      };
+      err.isAxiosError = true;
+      err.response = { status: 401 };
+      throw err;
+    });
+    const payload = await runFetch({ buildId: 'b-401', lineCount: 10 }, { getBuildLogChunk });
+    expect(payload['error']).toBeDefined();
+    expect((getBuildLogChunk as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  it('normalizes non-axios rejection values into an Error message', async () => {
+    const getBuildLogChunk = jest.fn(async () => {
+      // eslint-disable-next-line no-throw-literal
+      throw 'raw string';
+    });
+    const payload = await runFetch({ buildId: 'b-string', lineCount: 10 }, { getBuildLogChunk });
+    // Non-axios non-Error value surfaces via the normalizeError(String(err)) branch.
+    expect(payload['error']).toBeDefined();
+  });
+});
+
+describe('tools: additional write-tool validation + error branches', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.unmock('@/api-client');
+    jest.unmock('@/teamcity/client-adapter');
+    jest.unmock('@/teamcity/build-dependency-manager');
+    jest.unmock('@/teamcity/build-feature-manager');
+    jest.unmock('@/teamcity/agent-requirements-manager');
+    jest.unmock('@/teamcity/artifact-manager');
+    jest.unmock('@/teamcity/build-results-manager');
+  });
+
+  async function runWithAdapter(
+    toolName: string,
+    register: () => void,
+    args: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          try {
+            register();
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { getRequiredTool } = require('@/tools');
+            const res = await getRequiredTool(toolName).handler(args);
+            resolve(JSON.parse((res.content?.[0]?.text as string) ?? '{}'));
+          } catch (err) {
+            reject(err);
+          }
+        })().catch(reject);
+      });
+    });
+  }
+
+  it('download_build_artifacts throws when every artifact fails', async () => {
+    const downloadArtifact = jest.fn(async () => {
+      throw new Error('bad artifact');
+    });
+    const payload = await runWithAdapter(
+      'download_build_artifacts',
+      () => {
+        jest.doMock('@/teamcity/artifact-manager', () => ({
+          ArtifactManager: jest.fn().mockImplementation(() => ({ downloadArtifact })),
+        }));
+        jest.doMock('@/api-client', () => ({
+          TeamCityAPI: { getInstance: () => ({}) },
+        }));
+      },
+      { buildId: 'b1', artifactPaths: ['a.txt', 'b.txt'], encoding: 'text' }
+    );
+    expect(payload['error']).toBeDefined();
+    const err = payload['error'] as { message?: string } | string;
+    const message = typeof err === 'string' ? err : (err?.message ?? '');
+    expect(message).toMatch(/All artifact downloads failed/);
+  });
+
+  it('get_build_results rethrows non-not-found errors from the manager', async () => {
+    const payload = await runWithAdapter(
+      'get_build_results',
+      () => {
+        jest.doMock('@/teamcity/build-results-manager', () => ({
+          BuildResultsManager: jest.fn().mockImplementation(() => ({
+            getBuildResults: jest.fn(async () => {
+              throw new Error('boom');
+            }),
+          })),
+        }));
+        jest.doMock('@/api-client', () => ({
+          TeamCityAPI: { getInstance: () => ({}) },
+        }));
+      },
+      { buildId: 'b1' }
+    );
+    expect(payload['error']).toBeDefined();
+  });
+
+  it('download_build_artifacts rejects outputDir without stream encoding (zod)', async () => {
+    const payload = await runWithAdapter(
+      'download_build_artifacts',
+      () => {
+        jest.doMock('@/api-client', () => ({
+          TeamCityAPI: { getInstance: () => ({}) },
+        }));
+      },
+      {
+        buildId: 'b',
+        artifactPaths: ['a.txt'],
+        encoding: 'base64',
+        outputDir: '/tmp/output',
+      }
+    );
+    expect(payload['error']).toBeDefined();
+  });
+
+  it('list_project_hierarchy caps recursion at depth 3 (else-branch of else-if)', async () => {
+    const getProject = jest.fn(async (id: string) => {
+      // Always returns another child, which would recurse forever; depth
+      // cap forces the else-if branch once we hit depth == 3.
+      return {
+        data: {
+          id,
+          name: `${id}-proj`,
+          projects: { project: [{ id: `${id}-sub`, name: `${id}-sub-proj` }] },
+        },
+      };
+    });
+    const payload = await runWithAdapter(
+      'list_project_hierarchy',
+      () => {
+        jest.doMock('@/api-client', () => ({
+          TeamCityAPI: { getInstance: () => ({ projects: { getProject } }) },
+        }));
+      },
+      { rootProjectId: 'r0' }
+    );
+    expect(payload['children']).toBeDefined();
+    expect(Array.isArray(payload['children'])).toBe(true);
+  });
+
+  it('manage_build_dependencies rejects missing dependsOn on action=add (zod)', async () => {
+    const payload = await runWithAdapter(
+      'manage_build_dependencies',
+      () => {
+        jest.doMock('@/api-client', () => ({
+          TeamCityAPI: { getInstance: () => ({}) },
+        }));
+      },
+      {
+        buildTypeId: 'bt',
+        dependencyType: 'snapshot',
+        action: 'add',
+      }
+    );
+    expect(payload['error']).toBeDefined();
+  });
+
+  it('manage_build_dependencies rejects missing dependencyId on action=update', async () => {
+    const payload = await runWithAdapter(
+      'manage_build_dependencies',
+      () => {
+        jest.doMock('@/api-client', () => ({
+          TeamCityAPI: { getInstance: () => ({}) },
+        }));
+      },
+      {
+        buildTypeId: 'bt',
+        dependencyType: 'snapshot',
+        action: 'update',
+      }
+    );
+    expect(payload['error']).toBeDefined();
+  });
+
+  it('manage_build_features rejects missing type on action=add', async () => {
+    const payload = await runWithAdapter(
+      'manage_build_features',
+      () => {
+        jest.doMock('@/api-client', () => ({
+          TeamCityAPI: { getInstance: () => ({}) },
+        }));
+      },
+      {
+        buildTypeId: 'bt',
+        action: 'add',
+      }
+    );
+    expect(payload['error']).toBeDefined();
+  });
+
+  it('manage_agent_requirements rejects missing requirementId on action=delete', async () => {
+    const payload = await runWithAdapter(
+      'manage_agent_requirements',
+      () => {
+        jest.doMock('@/api-client', () => ({
+          TeamCityAPI: { getInstance: () => ({}) },
+        }));
+      },
+      {
+        buildTypeId: 'bt',
+        action: 'delete',
+      }
+    );
+    expect(payload['error']).toBeDefined();
+  });
+
+  it('manage_build_triggers delete requires triggerId', async () => {
+    const payload = await runWithAdapter(
+      'manage_build_triggers',
+      () => {
+        jest.doMock('@/api-client', () => ({
+          TeamCityAPI: {
+            getInstance: () => ({
+              buildTypes: { addTriggerToBuildType: jest.fn(), deleteTrigger: jest.fn() },
+            }),
+          },
+        }));
+      },
+      { buildTypeId: 'bt', action: 'delete' }
+    );
+    expect(payload['success']).toBe(false);
+    expect(payload['error']).toMatch(/Trigger ID is required/);
+  });
+});


### PR DESCRIPTION
## Description

This PR adds extensive unit test coverage for previously uncovered code branches in `src/tools.ts` and several TeamCity manager modules. The new tests target error-handling paths, fallback branches, and alternate outcomes that were counted as partial line coverage by Codecov.

### Changes

**New Test Files:**
- `tests/unit/tools/tools-branch-coverage.test.ts` (801 lines): Comprehensive coverage of error-handling and fallback branches in tools including:
  - `get_build` queue fallback when `/builds` returns 404
  - `list_server_health_items` 400 error fallback with client-side filtering
  - `check_availability_guard` critical/warning item detection
  - `pause_queue_for_pool` and `resume_queue_for_pool` agent management
  - `update_build_config` fallback branches when manager returns null
  - `clone_build_config` error scenarios
  - `fetch_build_log` retry and error handling

- `tests/unit/tools/tools-list-branch-coverage.test.ts` (684 lines): Coverage of filter branches in list tools:
  - All `list_*` tools with locator/filter parameters
  - Pagination modes (all vs. first-page)
  - Edge cases like missing counts, non-array payloads, and null responses
  - `fetch_build_log` retry/error handling branches

**Modified Test Files:**
- `tests/unit/teamcity/build-trigger-manager.test.ts`: Added 300+ lines covering:
  - `validateTrigger` branch coverage for unknown trigger types and validation errors
  - Schedule parsing for all cron-field branches
  - `calculateNextRunTime` simple and cron expression handling
  - Error-path branches for 404 and other HTTP errors

- `tests/unit/teamcity/test-problem-reporter.test.ts`: Added 197 lines covering:
  - Payload validation branches (non-record types, numeric coercion)
  - Null/missing data handling
  - Required field validation on problem occurrences
  - Invalid additionalData type rejection

- `tests/unit/teamcity/project-list-manager.test.ts`: Added 146 lines covering:
  - Generic Error re-throwing
  - Non-Error rejection wrapping
  - Unknown status fallback
  - Empty project array handling
  - Count field fallbacks

- `tests/unit/teamcity/branch-filtering-service.test.ts`: Added 121 lines covering:
  - Activity date filtering with missing/unparseable dates
  - ISO-string date handling
  - Wildcard regex fallback behavior

- `tests/unit/teamcity/client-adapter.test.ts`: Added 103 lines covering:
  - Bearer token prefix stripping
  - Non-Bearer Authorization header handling
  - Getter function extraction
  - Array-valued Authorization headers

**Configuration:**
- Updated `codecov.yml` to set explicit coverage targets for the MCP Tools component (85% target, 1% threshold)

### Testing

All new tests follow the established patterns in the codebase:
- Use `jest.isolateModules` and per-test `jest.doMock` for dependency injection
- Create realistic error scenarios (AxiosError with proper status codes)
- Verify both success and error paths
- Test edge cases and fallback behaviors

The tests are designed to exercise previously uncovered branches without modifying any source code, ensuring they validate existing behavior rather than new functionality.

## Type of Change

- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have run `npm run lint` and `npm run typecheck` with no errors
- [x] I have added tests that prove coverage of existing branches
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

## Testing

All new tests pass and provide comprehensive coverage of previously untested branches in tools and manager modules. The test suite validates error handling, fallback logic, and edge cases without modifying any source code behavior.