### PR TITLE
ci(claude-review): grant write perms so reviews can post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary
- The Claude Code Review workflow was running to completion but producing no visible output on PRs. On PR #461, the run spent ~7 minutes and ~\$4.45 generating a review, reported `permission_denials_count: 9`, and then posted nothing.
- Root cause: the workflow's \`permissions:\` block granted only \`pull-requests: read\` and \`issues: read\`, so the action's attempts to create a review/comment were denied by the GitHub token.
- Fix: bump \`pull-requests\` and \`issues\` to \`write\`. \`contents\` stays \`read\` and \`id-token: write\` is unchanged.

## Test plan
- [ ] After merge, the next human-authored PR receives a posted Claude review (not just a green check)
- [ ] Run log on that PR no longer reports permission denials for comment/review tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)