### PR TITLE
ci(claude-review): enable show_full_output for debugging

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
Temporary debug flag. PR #461's review run still posts nothing after the permissions fix (#462) — \`permission_denials_count: 16\`, \`No buffered inline comments\`. The action masks tool output by default; this flag surfaces it so we can identify which tools the \`code-review\` plugin needs and either pass them through \`claude_args\` or remove whatever is blocking them.

Will revert once the allowlist is figured out.

## Test plan
- [ ] Merge, then re-run review on PR #461
- [ ] Read full tool output from the run log
- [ ] Follow up with a real fix and revert this flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)