### PR TITLE
ci(claude-review): fix prompt format and post reviews as PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,8 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          show_full_output: true
+          prompt: '/code-review:code-review --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- The \`/code-review:code-review\` slash command takes no PR argument — it reads the PR from event context. Our prompt passed \`owner/repo/pull/N\`, which the command treated as a branch name, so every run failed at \`gh pr view <that-string>\` with \"no pull requests found for branch\" and no review was ever assembled.
- Added \`--comment\` so the review actually posts on the PR instead of only going to the action log.
- Reverted the temporary \`show_full_output: true\` debug flag added in #463 — we now know what was happening.

Diagnosed from the full run log on PR #461 after #463 unmasked tool output. References:
- https://github.com/anthropics/claude-code/tree/main/plugins/code-review
- https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

## Test plan
- [ ] Merge, then trigger a re-review on PR #461
- [ ] Confirm a review comment from \`claude[bot]\` appears on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)