### PR TITLE
fix(tools): enforce same-origin on download_build_artifacts downloadUrl

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -354,17 +354,52 @@ const getErrorMessage = (error: unknown): string => {
   return String(error ?? 'Unknown error');
 };
 
+const urlOrigin = (value: string): string | undefined => {
+  try {
+    const parsed = new URL(value);
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return undefined;
+  }
+};
+
+const assertSameOriginAsTeamCity = (
+  downloadUrl: string,
+  teamCityBaseUrl: string | undefined
+): void => {
+  const target = urlOrigin(downloadUrl);
+  if (!target) {
+    throw new Error(`Invalid downloadUrl: ${downloadUrl}`);
+  }
+  const expected = teamCityBaseUrl ? urlOrigin(teamCityBaseUrl) : undefined;
+  if (!expected) {
+    throw new Error(
+      'TeamCity base URL is not configured; refusing to fetch downloadUrl with credentials'
+    );
+  }
+  if (target !== expected) {
+    throw new Error(
+      `downloadUrl origin "${target}" does not match configured TeamCity origin "${expected}"`
+    );
+  }
+};
+
 const downloadArtifactByUrl = async (
   adapter: TeamCityClientAdapter,
   request: NormalizedArtifactRequest & { downloadUrl: string },
   encoding: 'base64' | 'text' | 'stream',
   options: StreamOptions & { maxSize?: number }
 ): Promise<ArtifactToolPayload> => {
+  // The shared axios instance carries the TeamCity PAT in its default headers.
+  // Reject cross-origin downloadUrls and cross-origin redirects so the token
+  // cannot leak to an attacker-controlled host via a prompt-injected argument.
+  assertSameOriginAsTeamCity(request.downloadUrl, adapter.getApiConfig().baseUrl);
+
   const axios = adapter.getAxios();
   const responseType =
     encoding === 'stream' ? 'stream' : encoding === 'text' ? 'text' : 'arraybuffer';
 
-  const response = await axios.get(request.downloadUrl, { responseType });
+  const response = await axios.get(request.downloadUrl, { responseType, maxRedirects: 0 });
   const mimeType =
     typeof response.headers?.['content-type'] === 'string'
       ? response.headers['content-type']

--- a/tests/unit/tools/download-artifact.test.ts
+++ b/tests/unit/tools/download-artifact.test.ts
@@ -171,7 +171,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
           'content-length': '16',
         },
       });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -204,6 +207,7 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
       expect(payload.artifacts[0].content).toBe('hello world text');
       expect(mockGet).toHaveBeenCalledWith('https://tc.example/artifact.txt', {
         responseType: 'text',
+        maxRedirects: 0,
       });
     });
 
@@ -218,7 +222,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
           data: Buffer.from('not a string'),
           headers: { 'content-type': 'application/octet-stream' },
         });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -259,7 +266,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
         data: Buffer.from('buffer data'),
         headers: { 'content-type': 'application/octet-stream', 'content-length': '11' },
       });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -301,7 +311,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
         data: arrayBuffer,
         headers: { 'content-type': 'application/octet-stream' },
       });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -343,7 +356,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
         data: uint8,
         headers: { 'content-type': 'application/octet-stream' },
       });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -386,7 +402,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
           data: { not: 'a buffer' },
           headers: { 'content-type': 'application/octet-stream' },
         });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -433,7 +452,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
           data: 'this will be rejected',
           headers: { 'content-type': 'text/plain', 'content-length': '1000' },
         });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -481,7 +503,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
           data: largeText,
           headers: { 'content-type': 'text/plain' },
         });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -528,7 +553,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
           data: largeBuffer,
           headers: { 'content-type': 'application/octet-stream' },
         });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -576,7 +604,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
           data: 'not a stream',
           headers: { 'content-type': 'text/plain' },
         });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -632,7 +663,10 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
         data: streamData,
         headers: { 'content-type': 'application/octet-stream', 'content-length': '15' },
       });
-      const mockAdapter = { getAxios: () => ({ get: mockGet }) };
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
 
       const ArtifactManager = jest.fn().mockImplementation(() => ({}));
       const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
@@ -678,6 +712,50 @@ describe('tools: downloadArtifactByUrl branch coverage via download_build_artifa
       } finally {
         await fs.rm(targetDir, { recursive: true, force: true });
       }
+    });
+  });
+
+  describe('downloadUrl origin enforcement', () => {
+    it('rejects downloadUrl whose origin differs from configured TeamCity baseUrl', async () => {
+      const mockGet = jest.fn();
+      const mockAdapter = {
+        getAxios: () => ({ get: mockGet }),
+        getApiConfig: () => ({ baseUrl: 'https://tc.example' }),
+      };
+
+      const ArtifactManager = jest.fn().mockImplementation(() => ({}));
+      const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue(mockAdapter);
+      const getInstance = jest.fn().mockReturnValue({});
+
+      jest.doMock('@/teamcity/artifact-manager', () => ({ ArtifactManager }));
+      jest.doMock('@/teamcity/client-adapter', () => ({ createAdapterFromTeamCityAPI }));
+      jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance } }));
+
+      let handler: ToolHandler | undefined;
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { getRequiredTool } = require('@/tools');
+        handler = getRequiredTool('download_build_artifacts').handler;
+      });
+
+      if (!handler) throw new Error('handler not found');
+
+      const response = await handler({
+        buildId: '123',
+        artifactPaths: [
+          {
+            path: 'leak.bin',
+            buildId: '123',
+            downloadUrl: 'https://attacker.example/steal',
+          },
+        ],
+        encoding: 'base64',
+      });
+
+      const payload = JSON.parse(response.content?.[0]?.text ?? '{}');
+      expect(payload.success).toBe(false);
+      expect(payload.error?.message).toContain('does not match configured TeamCity origin');
+      expect(mockGet).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
The `download_build_artifacts` tool accepted a caller-supplied `downloadUrl` and fetched it with the shared axios instance, which carries the TeamCity PAT as a default `Authorization` header. A cross-origin URL (e.g. reached via a prompt-injected MCP tool argument) would therefore leak the PAT to an attacker-controlled host and also enabled SSRF to internal services.

Validate that `downloadUrl` has the same origin as the configured TeamCity baseUrl before issuing the request, and pass `maxRedirects: 0` so a 3xx response cannot forward the credential to another origin.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses, e.g., "Fixes #123" or "Closes #456" -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have run `npm run lint` and `npm run typecheck` with no errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`npm test`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] My changes generate no new warnings

## Testing

<!-- Describe how you tested your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
