### PR TITLE
ci(claude): grant write perms so the action can push branches and open PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write # Required to push branches with implementation commits
+      pull-requests: write # Required to open PRs from issue comments
+      issues: write # Required to comment progress and results on issues
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary

The `claude.yml` workflow had read-only `contents` / `pull-requests` / `issues` scopes. When the action is invoked via `@claude` on an issue (e.g. issue #467), it can post progress comments but fails with `403 Permission denied to github-actions[bot]` when pushing the implementation branch — and so cannot open the PR it tried to create.

This bumps those three scopes to `write`. Other scopes (`id-token: write`, `actions: read`) are unchanged.

## Test plan
- [ ] Re-trigger `@claude` on issue #467 and confirm the implementation branch lands and the PR opens.
- [ ] Subsequent `@claude` invocations on issues land branches as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)