### PR TITLE
ci(codecov): make codecov upload steps non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         run: npm run test:coverage:ci -- --reporters=default --reporters=jest-junit --shard=${{ matrix.shard }}/4 --passWithNoTests
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && github.actor != 'dependabot[bot]' }}
+        continue-on-error: true
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -78,13 +79,14 @@ jobs:
           report_type: test_results
       - name: Upload coverage to Codecov
         if: ${{ success() && github.actor != 'dependabot[bot]' }}
+        continue-on-error: true
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage/lcov.info
           flags: unittests
           name: codecov-coverage
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
       - name: Codecov bundle analysis
         if: ${{ success() && github.actor != 'dependabot[bot]' && matrix.node == 20 && matrix.shard == 1 }}
         env:


### PR DESCRIPTION
## Summary

Codecov's CLI installer has been failing intermittently across the ecosystem since 2026-04-21 (a sha256/GPG race condition during install — see [codecov/codecov-action#1940](https://github.com/codecov/codecov-action/issues/1940) / [PR #1941](https://github.com/codecov/codecov-action/pull/1941)). These failures have blocked CI on our PRs and on \`main\`, which in turn breaks Release Please's auto-merge flow.

This change makes Codecov uploads non-blocking:

- \`continue-on-error: true\` on both \`codecov/codecov-action\` steps so a failed install/upload doesn't fail the job.
- Flipped the lcov upload from \`fail_ci_if_error: true\` to \`fail_ci_if_error: false\` so the two flags don't contradict.

When Codecov works, behavior is unchanged. When Codecov is in an outage window, the step shows up as a warning rather than failing the job; coverage just won't appear for that run.

## Test plan
- [ ] CI passes on this PR even if Codecov GPG flake recurs.
- [ ] Codecov upload still happens on green runs (visible in the action log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)