### PR TITLE
feat(tools): declare outputSchema for first batch of read tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
         "@types/node": "^25.0.2",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "esbuild": "^0.28.0",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "@types/node": "^25.0.2",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "esbuild": "^0.28.0",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,28 @@ import { getConfig } from './config';
 import { getAvailableTools, getMCPMode, getTool } from './tools';
 
 /**
+ * Extract a JSON-object payload from a tool's text content to surface as
+ * `structuredContent`. Returns undefined when the content is absent, empty,
+ * not JSON, or not a JSON object (the MCP spec requires structuredContent to
+ * be a JSON object, not a primitive or array).
+ */
+function parseStructuredContent(
+  content: Array<{ type: string; text: string }>
+): Record<string, unknown> | undefined {
+  const first = content[0];
+  if (first?.type !== 'text' || typeof first.text !== 'string') return undefined;
+  try {
+    const parsed: unknown = JSON.parse(first.text);
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // not JSON — leave structuredContent unset
+  }
+  return undefined;
+}
+
+/**
  * Create a simple MCP server
  */
 export function createMCPServer(): Server {
@@ -58,6 +80,7 @@ export function createSimpleServer(): Server {
         description: tool.description,
         inputSchema: tool.inputSchema,
         annotations: tool.annotations,
+        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
       })),
     };
     logDebug('MCP response: tools/list', { count: response.tools.length, success: true });
@@ -90,11 +113,23 @@ export function createSimpleServer(): Server {
       const result = await tool.handler(args ?? {});
       // Tool executed successfully
       // MCP SDK expects a specific format for tool responses
-      const response = {
-        content: result.content ?? [
-          { type: 'text', text: result.error ?? 'Tool executed successfully' },
-        ],
-      };
+      const content = result.content ?? [
+        { type: 'text', text: result.error ?? 'Tool executed successfully' },
+      ];
+      const response: {
+        content: Array<{ type: string; text: string }>;
+        structuredContent?: Record<string, unknown>;
+      } = { content };
+      // Per the MCP spec, tools that declare `outputSchema` must return their
+      // payload in `structuredContent`. Our handlers emit a single JSON text
+      // block via the `json()` helper; parse it back into an object so the
+      // wire response matches what the declared schema describes.
+      if (tool.outputSchema && result.success !== false) {
+        const structured = parseStructuredContent(content);
+        if (structured !== undefined) {
+          response.structuredContent = structured;
+        }
+      }
       const duration = Date.now() - started;
       const success = result?.success !== false;
       logDebug('MCP response: tools/call', {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -469,9 +469,190 @@ export interface ToolDefinition {
   description: string;
   annotations: ToolAnnotations;
   inputSchema: unknown;
+  /**
+   * Optional JSON Schema describing the structured response. When present it is
+   * surfaced via `tools/list` and the server will parse the text content of the
+   * handler's result back into `structuredContent` on `tools/call`, per the
+   * MCP spec (2025-06-18: tools declaring `outputSchema` must return structured
+   * content).
+   */
+  outputSchema?: Record<string, unknown>;
   handler: (args: unknown) => Promise<ToolResponse>;
   mode?: 'dev' | 'full'; // If not specified, available in both modes
 }
+
+/**
+ * Reusable JSON Schema fragments for the first batch of tools that declare
+ * `outputSchema`. Schemas stay permissive (`additionalProperties: true`) since
+ * the underlying TeamCity responses include many fields and fields-selector
+ * projections can further narrow them — the goal is to document the stable
+ * top-level shape, not to constrain every nested field.
+ */
+const paginationMetaSchema: Record<string, unknown> = {
+  type: 'object',
+  description: 'Pagination metadata describing which slice was returned.',
+  additionalProperties: true,
+  properties: {
+    page: { type: 'number' },
+    pageSize: { type: 'number' },
+    mode: { type: 'string', enum: ['all'] },
+    fetched: { type: 'number' },
+  },
+};
+
+const buildObjectSchema: Record<string, unknown> = {
+  type: 'object',
+  description: 'TeamCity build representation.',
+  additionalProperties: true,
+  properties: {
+    id: { type: ['number', 'string'] },
+    buildTypeId: { type: 'string' },
+    number: { type: 'string' },
+    state: { type: 'string' },
+    status: { type: 'string' },
+    statusText: { type: 'string' },
+    branchName: { type: 'string' },
+    href: { type: 'string' },
+    webUrl: { type: 'string' },
+  },
+};
+
+const projectObjectSchema: Record<string, unknown> = {
+  type: 'object',
+  description: 'TeamCity project representation.',
+  additionalProperties: true,
+  properties: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    parentProjectId: { type: 'string' },
+    href: { type: 'string' },
+    webUrl: { type: 'string' },
+    archived: { type: 'boolean' },
+    description: { type: 'string' },
+  },
+};
+
+const buildTypeObjectSchema: Record<string, unknown> = {
+  type: 'object',
+  description: 'TeamCity build configuration (buildType) representation.',
+  additionalProperties: true,
+  properties: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    projectId: { type: 'string' },
+    projectName: { type: 'string' },
+    href: { type: 'string' },
+    webUrl: { type: 'string' },
+    paused: { type: 'boolean' },
+    description: { type: 'string' },
+  },
+};
+
+const listOutputSchema = (itemSchema: Record<string, unknown>): Record<string, unknown> => ({
+  type: 'object',
+  additionalProperties: false,
+  required: ['items', 'pagination'],
+  properties: {
+    items: { type: 'array', items: itemSchema },
+    pagination: paginationMetaSchema,
+  },
+});
+
+const buildStatusOutputSchema: Record<string, unknown> = {
+  type: 'object',
+  description: 'Aggregated status for a queued, running, or finished build.',
+  additionalProperties: true,
+  required: ['buildId', 'state', 'percentageComplete'],
+  properties: {
+    buildId: { type: 'string' },
+    buildNumber: { type: 'string' },
+    buildTypeId: { type: 'string' },
+    state: { type: 'string', enum: ['queued', 'running', 'finished', 'failed', 'canceled'] },
+    status: { type: 'string', enum: ['SUCCESS', 'FAILURE', 'ERROR', 'UNKNOWN'] },
+    statusText: { type: 'string' },
+    percentageComplete: { type: 'number' },
+    currentStageText: { type: 'string' },
+    branchName: { type: 'string' },
+    webUrl: { type: 'string' },
+    queuedDate: { type: 'string' },
+    startDate: { type: 'string' },
+    finishDate: { type: 'string' },
+    elapsedSeconds: { type: 'number' },
+    estimatedTotalSeconds: { type: 'number' },
+    estimatedStartTime: { type: 'string' },
+    queuePosition: { type: 'number' },
+    waitReason: { type: 'string' },
+    failureReason: { type: 'string' },
+    canceledBy: { type: 'string' },
+    canceledDate: { type: 'string' },
+    totalQueued: { type: 'number' },
+    canMoveToTop: { type: 'boolean' },
+    testSummary: {
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        total: { type: 'number' },
+        passed: { type: 'number' },
+        failed: { type: 'number' },
+        ignored: { type: 'number' },
+        muted: { type: 'number' },
+        newFailed: { type: 'number' },
+      },
+    },
+    problems: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          type: { type: 'string' },
+          identity: { type: 'string' },
+          description: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+const buildResultsOutputSchema: Record<string, unknown> = {
+  type: 'object',
+  description:
+    'Rich build result bundle assembled by BuildResultsManager. The core build summary is always under `build`; optional sections (artifacts, statistics, changes, dependencies) are present when requested via the corresponding include* flags.',
+  additionalProperties: true,
+  required: ['build'],
+  properties: {
+    build: {
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        id: { type: ['string', 'number'] },
+        number: { type: 'string' },
+        status: { type: 'string' },
+        state: { type: 'string' },
+        buildTypeId: { type: 'string' },
+        projectId: { type: 'string' },
+        branchName: { type: 'string' },
+        statusText: { type: 'string' },
+        webUrl: { type: 'string' },
+      },
+    },
+    artifacts: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    statistics: { type: 'object', additionalProperties: true },
+    changes: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    dependencies: { type: 'array', items: { type: 'object', additionalProperties: true } },
+  },
+};
+
+export const FIRST_BATCH_OUTPUT_SCHEMAS = {
+  list_builds: listOutputSchema(buildObjectSchema),
+  get_build: buildObjectSchema,
+  get_build_status: buildStatusOutputSchema,
+  get_build_results: buildResultsOutputSchema,
+  list_projects: listOutputSchema(projectObjectSchema),
+  get_project: projectObjectSchema,
+  list_build_configs: listOutputSchema(buildTypeObjectSchema),
+  get_build_config: buildTypeObjectSchema,
+} as const;
 
 // Specific argument types are intentionally scoped to the handlers that use them.
 // Zod validates at runtime; these interfaces keep compile-time safety and clean linting.
@@ -726,6 +907,7 @@ const DEV_TOOLS: ToolDefinition[] = [
       openWorldHint: true,
     },
     description: 'List TeamCity projects (supports pagination)',
+    outputSchema: FIRST_BATCH_OUTPUT_SCHEMAS.list_projects,
     inputSchema: {
       type: 'object',
       properties: {
@@ -805,6 +987,7 @@ const DEV_TOOLS: ToolDefinition[] = [
       openWorldHint: true,
     },
     description: 'Get details of a specific project',
+    outputSchema: FIRST_BATCH_OUTPUT_SCHEMAS.get_project,
     inputSchema: {
       type: 'object',
       properties: {
@@ -837,6 +1020,7 @@ const DEV_TOOLS: ToolDefinition[] = [
       openWorldHint: true,
     },
     description: 'List TeamCity builds (supports pagination)',
+    outputSchema: FIRST_BATCH_OUTPUT_SCHEMAS.list_builds,
     inputSchema: {
       type: 'object',
       properties: {
@@ -944,6 +1128,7 @@ const DEV_TOOLS: ToolDefinition[] = [
     },
     description:
       'Get details of a specific build (works for both queued and running/finished builds)',
+    outputSchema: FIRST_BATCH_OUTPUT_SCHEMAS.get_build,
     inputSchema: {
       type: 'object',
       properties: {
@@ -1266,6 +1451,7 @@ const DEV_TOOLS: ToolDefinition[] = [
       openWorldHint: true,
     },
     description: 'Get build status with optional test/problem and queue context details',
+    outputSchema: FIRST_BATCH_OUTPUT_SCHEMAS.get_build_status,
     inputSchema: {
       type: 'object',
       properties: {
@@ -1802,6 +1988,7 @@ const DEV_TOOLS: ToolDefinition[] = [
       openWorldHint: true,
     },
     description: 'List build configurations (supports pagination)',
+    outputSchema: FIRST_BATCH_OUTPUT_SCHEMAS.list_build_configs,
     inputSchema: {
       type: 'object',
       properties: {
@@ -1881,6 +2068,7 @@ const DEV_TOOLS: ToolDefinition[] = [
       openWorldHint: true,
     },
     description: 'Get details of a build configuration',
+    outputSchema: FIRST_BATCH_OUTPUT_SCHEMAS.get_build_config,
     inputSchema: {
       type: 'object',
       properties: {
@@ -2941,6 +3129,7 @@ const DEV_TOOLS: ToolDefinition[] = [
     },
     description:
       'Get detailed results of a build including tests, artifacts, changes, and statistics',
+    outputSchema: FIRST_BATCH_OUTPUT_SCHEMAS.get_build_results,
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -71,16 +71,26 @@ export async function runTool<T>(
       duration,
       { requestId: reqId }
     );
-    // Preserve validation error details for proper shaping
+    // Preserve validation error details for proper shaping. The inner JSON
+    // payload is an error envelope, not the tool's declared output shape, so
+    // mark the outer response with success=false to prevent downstream
+    // consumers (e.g. server.ts surfacing structuredContent for tools with an
+    // outputSchema) from treating it as a conforming payload.
     if (err instanceof z.ZodError) {
       const formatted = formatError(err, { ...context, requestId: reqId });
-      return json(formatted);
+      const response = json(formatted);
+      response.success = false;
+      response.error = msg;
+      return response;
     }
     // Pass through original error so handler can extract rich details
     const formatted = globalErrorHandler.handleToolError(err, toolName, {
       ...context,
       requestId: reqId,
     });
-    return json(formatted);
+    const response = json(formatted);
+    response.success = false;
+    response.error = msg;
+    return response;
   }
 }

--- a/tests/mcp-server.output-schema.test.ts
+++ b/tests/mcp-server.output-schema.test.ts
@@ -202,4 +202,59 @@ describe('MCP server: outputSchema surfacing', () => {
     })) as Record<string, unknown>;
     expect('structuredContent' in result).toBe(false);
   });
+
+  it('tools/call omits structuredContent when the handler returns success=false', async () => {
+    // Regression: a tool with outputSchema whose handler returns a validation
+    // error envelope (success=false, JSON-stringified error) must NOT surface
+    // that envelope as structuredContent — it does not conform to the declared
+    // schema. See review on PR #477.
+    const handler = jest.fn().mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            error: { code: 'VALIDATION_ERROR', message: 'bad input' },
+          }),
+        },
+      ],
+      success: false,
+      error: 'bad input',
+    });
+    const tool: ToolDefinition = {
+      name: 'strict_list',
+      description: 'declares strict list outputSchema',
+      inputSchema: { type: 'object' },
+      outputSchema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['items', 'pagination'],
+        properties: {
+          items: { type: 'array' },
+          pagination: { type: 'object' },
+        },
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler,
+    };
+    (getAvailableTools as jest.Mock).mockReturnValue([tool]);
+    (getTool as jest.Mock).mockImplementation((n: string) =>
+      n === 'strict_list' ? tool : undefined
+    );
+
+    const setRequestHandler = jest.fn();
+    (Server as jest.Mock).mockImplementation(() => ({ setRequestHandler }));
+    createMCPServer();
+    const callHandler = setRequestHandler.mock.calls[1][1];
+
+    const result = (await callHandler({
+      params: { name: 'strict_list', arguments: {} },
+    })) as Record<string, unknown>;
+    expect('structuredContent' in result).toBe(false);
+  });
 });

--- a/tests/mcp-server.output-schema.test.ts
+++ b/tests/mcp-server.output-schema.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Covers the server wiring for `outputSchema`:
+ *   - `tools/list` surfaces `outputSchema` when a tool declares one, and omits
+ *     the field when it does not.
+ *   - `tools/call` includes `structuredContent` (parsed from the text content)
+ *     when the executed tool declares an `outputSchema`, and omits it
+ *     otherwise.
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+import { getConfig } from '@/config';
+import { createMCPServer } from '@/server';
+
+import { type ToolDefinition, getAvailableTools, getTool } from '../src/tools';
+
+jest.mock('@modelcontextprotocol/sdk/server/index.js');
+jest.mock('@modelcontextprotocol/sdk/server/stdio.js');
+jest.mock('@modelcontextprotocol/sdk/types.js', () => ({
+  ErrorCode: {
+    MethodNotFound: -32601,
+    InternalError: -32603,
+  },
+  McpError: class McpError extends Error {
+    constructor(
+      public code: number,
+      message: string
+    ) {
+      super(message);
+      this.name = 'McpError';
+    }
+  },
+  ListToolsRequestSchema: { method: 'tools/list' },
+  CallToolRequestSchema: { method: 'tools/call' },
+}));
+jest.mock('@/config');
+jest.mock('../src/tools', () => ({
+  getAvailableTools: jest.fn(),
+  getTool: jest.fn(),
+  getMCPMode: jest.fn(() => 'full'),
+}));
+jest.mock('@/utils/logger');
+
+const buildConfigResponse = {
+  mcp: { name: 'teamcity-mcp', version: '0.1.0' },
+  server: { mode: 'full' },
+  teamcity: { url: 'https://tc.example', token: 't' },
+};
+
+describe('MCP server: outputSchema surfacing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getConfig as jest.Mock).mockReturnValue(buildConfigResponse);
+  });
+
+  it('tools/list exposes outputSchema when declared and omits it otherwise', async () => {
+    const withSchema: ToolDefinition = {
+      name: 'with_schema',
+      description: 'declares an outputSchema',
+      inputSchema: { type: 'object' },
+      outputSchema: {
+        type: 'object',
+        properties: { ok: { type: 'boolean' } },
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: jest.fn(),
+    };
+    const withoutSchema: ToolDefinition = {
+      name: 'bare',
+      description: 'no outputSchema',
+      inputSchema: { type: 'object' },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: jest.fn(),
+    };
+    (getAvailableTools as jest.Mock).mockReturnValue([withSchema, withoutSchema]);
+    (getTool as jest.Mock).mockImplementation((n: string) =>
+      [withSchema, withoutSchema].find((t) => t.name === n)
+    );
+
+    const setRequestHandler = jest.fn();
+    (Server as jest.Mock).mockImplementation(() => ({ setRequestHandler }));
+
+    createMCPServer();
+    const listHandler = setRequestHandler.mock.calls[0][1];
+    const result = (await listHandler()) as {
+      tools: Array<Record<string, unknown>>;
+    };
+
+    const entries = Object.fromEntries(result.tools.map((t) => [t['name'], t]));
+    expect(entries['with_schema']?.['outputSchema']).toEqual(withSchema.outputSchema);
+    expect(Object.keys(entries['bare'] ?? {})).not.toContain('outputSchema');
+  });
+
+  it('tools/call attaches structuredContent when the tool has an outputSchema', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: JSON.stringify({ items: [{ id: 'P1' }] }) }],
+      success: true,
+    });
+    const tool: ToolDefinition = {
+      name: 'list_projects',
+      description: 'list projects',
+      inputSchema: { type: 'object' },
+      outputSchema: {
+        type: 'object',
+        properties: { items: { type: 'array' } },
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler,
+    };
+    (getAvailableTools as jest.Mock).mockReturnValue([tool]);
+    (getTool as jest.Mock).mockImplementation((n: string) =>
+      n === 'list_projects' ? tool : undefined
+    );
+
+    const setRequestHandler = jest.fn();
+    (Server as jest.Mock).mockImplementation(() => ({ setRequestHandler }));
+    createMCPServer();
+    const callHandler = setRequestHandler.mock.calls[1][1];
+
+    const result = (await callHandler({
+      params: { name: 'list_projects', arguments: {} },
+    })) as { content: unknown; structuredContent?: unknown };
+
+    expect(result.structuredContent).toEqual({ items: [{ id: 'P1' }] });
+  });
+
+  it('tools/call omits structuredContent when the tool has no outputSchema', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: JSON.stringify({ anything: true }) }],
+      success: true,
+    });
+    const tool: ToolDefinition = {
+      name: 'bare',
+      description: 'bare',
+      inputSchema: { type: 'object' },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler,
+    };
+    (getAvailableTools as jest.Mock).mockReturnValue([tool]);
+    (getTool as jest.Mock).mockImplementation((n: string) => (n === 'bare' ? tool : undefined));
+
+    const setRequestHandler = jest.fn();
+    (Server as jest.Mock).mockImplementation(() => ({ setRequestHandler }));
+    createMCPServer();
+    const callHandler = setRequestHandler.mock.calls[1][1];
+
+    const result = (await callHandler({
+      params: { name: 'bare', arguments: {} },
+    })) as Record<string, unknown>;
+    expect('structuredContent' in result).toBe(false);
+  });
+
+  it('tools/call skips structuredContent when the text is not a JSON object', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'not-json' }],
+      success: true,
+    });
+    const tool: ToolDefinition = {
+      name: 'with_schema',
+      description: 'with schema',
+      inputSchema: { type: 'object' },
+      outputSchema: { type: 'object' },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler,
+    };
+    (getAvailableTools as jest.Mock).mockReturnValue([tool]);
+    (getTool as jest.Mock).mockImplementation((n: string) =>
+      n === 'with_schema' ? tool : undefined
+    );
+
+    const setRequestHandler = jest.fn();
+    (Server as jest.Mock).mockImplementation(() => ({ setRequestHandler }));
+    createMCPServer();
+    const callHandler = setRequestHandler.mock.calls[1][1];
+
+    const result = (await callHandler({
+      params: { name: 'with_schema', arguments: {} },
+    })) as Record<string, unknown>;
+    expect('structuredContent' in result).toBe(false);
+  });
+});

--- a/tests/unit/tools/output-schema.test.ts
+++ b/tests/unit/tools/output-schema.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Output schema coverage for the first batch of tools that declare an
+ * `outputSchema`. Each case mocks the underlying TeamCity client, invokes the
+ * tool through its registered handler, and validates the JSON payload against
+ * the declared schema with Ajv — so the acceptance criterion "runtime response
+ * conforms to declared schema" is enforced in CI.
+ */
+import Ajv, { type ValidateFunction } from 'ajv';
+
+jest.mock('@/config', () => ({
+  getTeamCityUrl: () => 'https://example.test',
+  getTeamCityToken: () => 'token',
+  getMCPMode: () => 'full',
+}));
+
+type PayloadShape = Record<string, unknown>;
+
+const compile = (schema: unknown): ValidateFunction => {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  return ajv.compile(schema as object);
+};
+
+const parsePayload = (res: { content?: Array<{ text: string }> }): PayloadShape => {
+  const text = res.content?.[0]?.text ?? '{}';
+  return JSON.parse(text) as PayloadShape;
+};
+
+const assertConforms = (toolName: string, payload: PayloadShape, schema: unknown): void => {
+  const validate = compile(schema);
+  const ok = validate(payload);
+  if (!ok) {
+    throw new Error(
+      `${toolName} response did not conform to declared outputSchema: ${JSON.stringify(
+        validate.errors,
+        null,
+        2
+      )}\nPayload: ${JSON.stringify(payload, null, 2)}`
+    );
+  }
+};
+
+describe('Tool outputSchema: first batch', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('every first-batch tool declares an outputSchema and it is exposed', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool, FIRST_BATCH_OUTPUT_SCHEMAS } = require('@/tools');
+          const firstBatch = [
+            'list_builds',
+            'get_build',
+            'get_build_status',
+            'get_build_results',
+            'list_projects',
+            'get_project',
+            'list_build_configs',
+            'get_build_config',
+          ] as const;
+          for (const name of firstBatch) {
+            const tool = getRequiredTool(name);
+            expect(tool.outputSchema).toBeDefined();
+            expect(tool.outputSchema).toBe(
+              (FIRST_BATCH_OUTPUT_SCHEMAS as Record<string, unknown>)[name]
+            );
+            // Must be a valid JSON Schema — compile must succeed
+            expect(() => compile(tool.outputSchema)).not.toThrow();
+          }
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('list_projects response conforms to declared schema', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getAllProjects = jest.fn(async () =>
+            Promise.resolve({
+              data: {
+                project: [
+                  { id: 'P1', name: 'Project 1', href: '/app/rest/projects/id:P1' },
+                  { id: 'P2', name: 'Project 2' },
+                ],
+                count: 2,
+              },
+            })
+          );
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({
+                projects: { getAllProjects },
+              }),
+            },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const tool = getRequiredTool('list_projects');
+          const res = await tool.handler({ pageSize: 50 });
+          const payload = parsePayload(res);
+          assertConforms('list_projects', payload, tool.outputSchema);
+          expect(payload['items']).toHaveLength(2);
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('get_project response conforms to declared schema', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getProject = jest.fn(async () => ({
+            id: 'P1',
+            name: 'Project One',
+            parentProjectId: '_Root',
+            archived: false,
+          }));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => ({ getProject }) },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const tool = getRequiredTool('get_project');
+          const res = await tool.handler({ projectId: 'P1' });
+          const payload = parsePayload(res);
+          assertConforms('get_project', payload, tool.outputSchema);
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('list_builds response conforms to declared schema', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getAllBuilds = jest.fn(async () =>
+            Promise.resolve({
+              data: {
+                build: [
+                  {
+                    id: 1,
+                    number: '1',
+                    state: 'finished',
+                    status: 'SUCCESS',
+                    buildTypeId: 'BT1',
+                  },
+                ],
+                count: 1,
+              },
+            })
+          );
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({ builds: { getAllBuilds } }),
+            },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const tool = getRequiredTool('list_builds');
+          const res = await tool.handler({ pageSize: 10 });
+          const payload = parsePayload(res);
+          assertConforms('list_builds', payload, tool.outputSchema);
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('get_build response conforms to declared schema', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getBuild = jest.fn(async () => ({
+            id: 42,
+            number: '42',
+            state: 'finished',
+            status: 'SUCCESS',
+            buildTypeId: 'BT1',
+            statusText: 'Tests passed',
+            webUrl: 'https://example.test/viewLog.html?buildId=42',
+          }));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => ({ getBuild }) },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const tool = getRequiredTool('get_build');
+          const res = await tool.handler({ buildId: '42' });
+          const payload = parsePayload(res);
+          assertConforms('get_build', payload, tool.outputSchema);
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('get_build_status response conforms to declared schema', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getBuildStatus = jest.fn().mockResolvedValue({
+            buildId: '42',
+            buildNumber: '42',
+            buildTypeId: 'BT1',
+            state: 'running',
+            status: 'SUCCESS',
+            percentageComplete: 55,
+            statusText: 'building',
+          });
+          jest.doMock('@/teamcity/build-status-manager', () => ({
+            BuildStatusManager: jest.fn().mockImplementation(() => ({ getBuildStatus })),
+          }));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({
+                builds: {},
+                buildQueue: {},
+                getBaseUrl: () => 'https://example.test',
+              }),
+            },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const tool = getRequiredTool('get_build_status');
+          const res = await tool.handler({ buildId: '42' });
+          const payload = parsePayload(res);
+          assertConforms('get_build_status', payload, tool.outputSchema);
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('get_build_results response conforms to declared schema', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getBuildResults = jest.fn().mockResolvedValue({
+            build: {
+              id: 99,
+              number: '99',
+              status: 'SUCCESS',
+              state: 'finished',
+              buildTypeId: 'BT1',
+              statusText: 'ok',
+              webUrl: 'https://example.test/viewLog.html?buildId=99',
+            },
+            artifacts: [{ name: 'a.txt', path: 'a.txt', size: 10 }],
+            statistics: { testCount: 5, passedTests: 5 },
+          });
+          jest.doMock('@/teamcity/build-results-manager', () => ({
+            BuildResultsManager: jest.fn().mockImplementation(() => ({ getBuildResults })),
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const tool = getRequiredTool('get_build_results');
+          const res = await tool.handler({
+            buildId: '99',
+            includeArtifacts: true,
+            includeStatistics: true,
+          });
+          const payload = parsePayload(res);
+          assertConforms('get_build_results', payload, tool.outputSchema);
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('list_build_configs response conforms to declared schema', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getAllBuildTypes = jest.fn(async () =>
+            Promise.resolve({
+              data: {
+                buildType: [{ id: 'BT1', name: 'Build One', projectId: 'P1' }],
+                count: 1,
+              },
+            })
+          );
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: {
+              getInstance: () => ({
+                buildTypes: { getAllBuildTypes },
+              }),
+            },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const tool = getRequiredTool('list_build_configs');
+          const res = await tool.handler({ pageSize: 20 });
+          const payload = parsePayload(res);
+          assertConforms('list_build_configs', payload, tool.outputSchema);
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
+  it('get_build_config response conforms to declared schema', async () => {
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          const getBuildType = jest.fn(async () => ({
+            id: 'BT1',
+            name: 'Build One',
+            projectId: 'P1',
+            projectName: 'Project One',
+            paused: false,
+          }));
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => ({ getBuildType }) },
+          }));
+
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const tool = getRequiredTool('get_build_config');
+          const res = await tool.handler({ buildTypeId: 'BT1' });
+          const payload = parsePayload(res);
+          assertConforms('get_build_config', payload, tool.outputSchema);
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+});

--- a/tests/unit/tools/output-schema.test.ts
+++ b/tests/unit/tools/output-schema.test.ts
@@ -312,6 +312,32 @@ describe('Tool outputSchema: first batch', () => {
     });
   });
 
+  it('runTool error envelope is flagged success=false on the outer ToolResponse', async () => {
+    // Regression for PR #477 review: when a tool with outputSchema rejects bad
+    // input via Zod, runTool's error envelope must NOT be surfaced as
+    // structuredContent. The outer ToolResponse's `success` flag is what
+    // server.ts uses to gate that surfacing, so it must be false.
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(() => {
+        (async () => {
+          jest.doMock('@/api-client', () => ({
+            TeamCityAPI: { getInstance: () => ({ getProject: jest.fn() }) },
+          }));
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { getRequiredTool } = require('@/tools');
+          const res = await getRequiredTool('get_project').handler({});
+          expect(res.success).toBe(false);
+          expect(typeof res.error).toBe('string');
+          // Inner payload is a validation error envelope — not the declared
+          // project shape — confirming why the outer flag must be false.
+          const payload = parsePayload(res);
+          expect(payload['success']).toBe(false);
+          resolve();
+        })().catch(reject);
+      });
+    });
+  });
+
   it('get_build_config response conforms to declared schema', async () => {
     await new Promise<void>((resolve, reject) => {
       jest.isolateModules(() => {

--- a/tests/unit/utils/mcp.test.ts
+++ b/tests/unit/utils/mcp.test.ts
@@ -89,7 +89,10 @@ describe('utils/mcp runTool', () => {
     const handler = jest.fn();
 
     const out = await runTool('sum', schema, handler, { n: 'bad' });
-    expect(out.success).toBe(true); // json() wrapper marks success true
+    // Error envelopes must be flagged as failures so consumers (e.g. the
+    // server's structuredContent gate) do not treat them as valid output.
+    expect(out.success).toBe(false);
+    expect(typeof out.error).toBe('string');
     expect(out.content?.[0]?.text).toContain('zod');
     expect(handler).not.toHaveBeenCalled();
   });
@@ -101,7 +104,8 @@ describe('utils/mcp runTool', () => {
     });
 
     const out = await runTool('f', schema, handler, { x: '1' });
-    expect(out.success).toBe(true);
+    expect(out.success).toBe(false);
+    expect(out.error).toBe('boom');
     expect(out.content?.[0]?.text).toContain('handled');
 
     expect(globalErrorHandler.handleToolError).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Adds MCP `outputSchema` infrastructure on tool registration: `tools/list` surfaces the declared schema, and `tools/call` parses the JSON text payload back into `structuredContent` per the MCP 2025-06-18 spec (which requires tools declaring `outputSchema` to return structured content).
- Ships permissive-but-descriptive JSON Schemas for the first batch: `list_builds`, `get_build`, `get_build_status`, `get_build_results`, `list_projects`, `get_project`, `list_build_configs`, `get_build_config`. The stable top-level shape is documented; nested TeamCity fields remain extensible via `additionalProperties: true`.
- Adds Ajv-based tests that mock each tool's upstream adapter, execute the handler, and validate that the runtime payload conforms to the declared schema — plus server-level tests that cover schema surfacing in `tools/list` and `structuredContent` emission in `tools/call`.

Closes #468 (batch 1). Follow-up batches (agent/pool listings, parameter listings, VCS, server health) can be addressed in subsequent PRs as suggested in the issue.

## Acceptance criteria
- [x] Tool registration accepts an optional `outputSchema` and surfaces it via `tools/list`.
- [x] First batch ships with `outputSchema` populated.
- [x] Tests assert the runtime response actually conforms to the declared schema (Ajv).
- [x] Subsequent batches tracked as follow-up.

## Test plan
- [x] `npm test` passes (2242 passed, 25 skipped).
- [x] `npm run lint:check` clean (no errors; only pre-existing warnings remain).
- [x] `npm run typecheck` clean.
- [ ] Manual: run `tools/list` against an MCP client and confirm `outputSchema` is exposed on the first-batch tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)