### PR TITLE
feat(artifacts): add list_build_artifacts tool for subdirectory browsing

### DIFF
--- a/src/teamcity/artifact-manager.ts
+++ b/src/teamcity/artifact-manager.ts
@@ -27,6 +27,10 @@ export interface ArtifactListOptions {
   minSize?: number;
   maxSize?: number;
   includeNested?: boolean;
+  /** Include directory entries in the result (default: false — directories are skipped). */
+  includeDirectories?: boolean;
+  /** Sub-path to list (e.g. "okd" lists contents of the okd directory). */
+  path?: string;
   limit?: number;
   offset?: number;
   forceRefresh?: boolean;
@@ -104,14 +108,21 @@ export class ArtifactManager {
       // Fetch artifacts from API
       const response = await this.client.modules.builds.getFilesListOfBuild(
         buildLocator,
-        undefined,
+        options.path,
         undefined,
         'file(name,fullName,size,modificationTime,href,children(file(name,fullName,size,modificationTime,href)))'
       );
 
       const baseUrl = this.getBaseUrl();
       const artifactPayload = this.ensureArtifactListingResponse(response.data, buildId);
-      let artifacts = this.parseArtifacts(artifactPayload, buildId, options.includeNested, baseUrl);
+      let artifacts = this.parseArtifacts(
+        artifactPayload,
+        buildId,
+        options.includeNested,
+        baseUrl,
+        [],
+        options.includeDirectories
+      );
 
       // Apply filters
       artifacts = this.applyFilters(artifacts, options);
@@ -410,7 +421,8 @@ export class ArtifactManager {
     buildId: string,
     includeNested: boolean | undefined,
     baseUrl: string,
-    parentSegments: string[] = []
+    parentSegments: string[] = [],
+    includeDirectories?: boolean
   ): ArtifactInfo[] {
     const artifacts: ArtifactInfo[] = [];
     const files = data.file ?? [];
@@ -421,13 +433,24 @@ export class ArtifactManager {
       const isDirectory = Boolean(file.children);
 
       if (isDirectory) {
+        if (includeDirectories && resolvedPath) {
+          artifacts.push({
+            name: file.name ?? pathSegments[pathSegments.length - 1] ?? '',
+            path: resolvedPath,
+            size: file.size ?? 0,
+            modificationTime: file.modificationTime ?? '',
+            downloadUrl: `${baseUrl}/app/rest/builds/id:${buildId}/artifacts/content/${this.encodeArtifactPath(pathSegments)}`,
+            isDirectory: true,
+          });
+        }
         if (includeNested && file.children) {
           const nested = this.parseArtifacts(
             file.children,
             buildId,
             includeNested,
             baseUrl,
-            pathSegments
+            pathSegments,
+            includeDirectories
           );
           artifacts.push(...nested);
         }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3267,6 +3267,78 @@ const DEV_TOOLS: ToolDefinition[] = [
   },
 
   {
+    name: 'list_build_artifacts',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    description:
+      'List artifact files and directories for a build, optionally browsing into subdirectories. Returns an array of artifact entries with name, path, size, and isDirectory flag.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ...buildIdentifierInputProperties,
+        path: {
+          type: 'string',
+          description:
+            'Sub-path to list (e.g. "okd" or "okd/subdir"). Omit to list top-level artifacts.',
+        },
+        includeNested: {
+          type: 'boolean',
+          description: 'Recursively include all files within subdirectories (default: false)',
+        },
+        nameFilter: {
+          type: 'string',
+          description: 'Glob pattern to filter artifacts by name (e.g. "*.yaml")',
+        },
+        pathFilter: {
+          type: 'string',
+          description: 'Glob pattern to filter artifacts by full path',
+        },
+        extension: {
+          type: 'string',
+          description: 'Filter by file extension (e.g. "yaml", ".yaml")',
+        },
+      },
+    },
+    handler: async (args: unknown) => {
+      const schema = buildIdentifierSchema.and(
+        z.object({
+          path: z.string().trim().min(1).optional(),
+          includeNested: z.boolean().optional(),
+          nameFilter: z.string().trim().min(1).optional(),
+          pathFilter: z.string().trim().min(1).optional(),
+          extension: z.string().trim().min(1).optional(),
+        })
+      );
+
+      return runTool(
+        'list_build_artifacts',
+        schema,
+        async (typed) => {
+          const adapter = createAdapterFromTeamCityAPI(TeamCityAPI.getInstance());
+          const { locator: buildLocator } = resolveBuildLocator(typed);
+
+          const manager = new ArtifactManager(adapter);
+          const artifacts = await manager.listArtifacts(buildLocator, {
+            path: typed.path,
+            includeNested: typed.includeNested,
+            includeDirectories: true,
+            nameFilter: typed.nameFilter,
+            pathFilter: typed.pathFilter,
+            extension: typed.extension,
+          });
+
+          return json({ artifacts });
+        },
+        args
+      );
+    },
+  },
+
+  {
     name: 'download_build_artifact',
     annotations: {
       readOnlyHint: false,

--- a/tests/unit/teamcity/artifact-manager.test.ts
+++ b/tests/unit/teamcity/artifact-manager.test.ts
@@ -166,6 +166,92 @@ describe('ArtifactManager', () => {
 
       await expect(manager.listArtifacts('12345')).rejects.toThrow('non-array file field');
     });
+
+    it('should pass path option as basePath to API for subdirectory browsing', async () => {
+      const mockSubdirArtifacts = {
+        file: [
+          {
+            name: 'deploy.yaml',
+            fullName: 'okd/deploy.yaml',
+            size: 2048,
+            modificationTime: '20250829T121400+0000',
+          },
+          {
+            name: 'service.yaml',
+            fullName: 'okd/service.yaml',
+            size: 1024,
+            modificationTime: '20250829T121500+0000',
+          },
+        ],
+      };
+
+      http.get.mockResolvedValue({ data: mockSubdirArtifacts });
+
+      const result = await manager.listArtifacts('12345', { path: 'okd' });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.name).toBe('deploy.yaml');
+      expect(result[1]?.name).toBe('service.yaml');
+    });
+
+    it('should include directory entries when includeDirectories is true', async () => {
+      const mockArtifactsWithDir = {
+        file: [
+          {
+            name: 'okd',
+            fullName: 'okd',
+            size: 0,
+            children: {
+              file: [{ name: 'deploy.yaml', fullName: 'okd/deploy.yaml', size: 2048 }],
+            },
+          },
+          {
+            name: 'readme.txt',
+            fullName: 'readme.txt',
+            size: 512,
+          },
+        ],
+      };
+
+      http.get.mockResolvedValue({ data: mockArtifactsWithDir });
+
+      const result = await manager.listArtifacts('12345', { includeDirectories: true });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.name).toBe('okd');
+      expect(result[0]?.isDirectory).toBe(true);
+      expect(result[1]?.name).toBe('readme.txt');
+      expect(result[1]?.isDirectory).toBe(false);
+    });
+
+    it('should include directories and nested files together', async () => {
+      const mockArtifactsWithDir = {
+        file: [
+          {
+            name: 'okd',
+            fullName: 'okd',
+            size: 0,
+            children: {
+              file: [{ name: 'deploy.yaml', fullName: 'okd/deploy.yaml', size: 2048 }],
+            },
+          },
+        ],
+      };
+
+      http.get.mockResolvedValue({ data: mockArtifactsWithDir });
+
+      const result = await manager.listArtifacts('12345', {
+        includeDirectories: true,
+        includeNested: true,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.name).toBe('okd');
+      expect(result[0]?.isDirectory).toBe(true);
+      expect(result[1]?.name).toBe('deploy.yaml');
+      expect(result[1]?.path).toBe('okd/deploy.yaml');
+      expect(result[1]?.isDirectory).toBe(false);
+    });
   });
 
   describe('Artifact Filtering', () => {

--- a/tests/unit/tools/list-build-artifacts.test.ts
+++ b/tests/unit/tools/list-build-artifacts.test.ts
@@ -1,0 +1,216 @@
+// Mock config to keep tools in dev mode without reading env
+jest.mock('@/config', () => ({
+  getTeamCityUrl: () => 'https://example.test',
+  getTeamCityToken: () => 'token',
+  getMCPMode: () => 'dev',
+}));
+
+jest.mock('@/utils/logger/index', () => {
+  const debug = jest.fn();
+  const info = jest.fn();
+  const warn = jest.fn();
+  const error = jest.fn();
+  const logToolExecution = jest.fn();
+  const logTeamCityRequest = jest.fn();
+  const logLifecycle = jest.fn();
+  const child = jest.fn();
+
+  const mockLoggerInstance = {
+    debug,
+    info,
+    warn,
+    error,
+    logToolExecution,
+    logTeamCityRequest,
+    logLifecycle,
+    child,
+    generateRequestId: () => 'test-request',
+  };
+
+  child.mockReturnValue(mockLoggerInstance);
+
+  return {
+    getLogger: () => mockLoggerInstance,
+    logger: mockLoggerInstance,
+    debug,
+    info,
+    warn,
+    error,
+  };
+});
+
+type ToolHandler = (args: unknown) => Promise<{
+  content?: Array<{ text?: string }>;
+  success?: boolean;
+}>;
+
+describe('tools: list_build_artifacts', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('lists top-level artifacts including directories', async () => {
+    const listArtifacts = jest.fn().mockResolvedValue([
+      {
+        name: 'okd',
+        path: 'okd',
+        size: 0,
+        isDirectory: true,
+        downloadUrl: '',
+        modificationTime: '',
+      },
+      {
+        name: 'readme.txt',
+        path: 'readme.txt',
+        size: 512,
+        isDirectory: false,
+        downloadUrl: '',
+        modificationTime: '',
+      },
+    ]);
+
+    const ArtifactManager = jest.fn().mockImplementation(() => ({ listArtifacts }));
+    const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue({});
+    const getInstance = jest.fn().mockReturnValue({});
+
+    jest.doMock('@/teamcity/artifact-manager', () => ({ ArtifactManager }));
+    jest.doMock('@/teamcity/client-adapter', () => ({ createAdapterFromTeamCityAPI }));
+    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance } }));
+
+    let handler: ToolHandler | undefined;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getRequiredTool } = require('@/tools');
+      handler = getRequiredTool('list_build_artifacts').handler;
+    });
+
+    if (!handler) throw new Error('list_build_artifacts handler not found');
+
+    const response = await handler({ buildId: '123' });
+    const payload = JSON.parse(response.content?.[0]?.text ?? '{}');
+
+    expect(payload.artifacts).toHaveLength(2);
+    expect(payload.artifacts[0].name).toBe('okd');
+    expect(payload.artifacts[0].isDirectory).toBe(true);
+    expect(payload.artifacts[1].name).toBe('readme.txt');
+    expect(listArtifacts).toHaveBeenCalledWith(
+      'id:123',
+      expect.objectContaining({
+        includeDirectories: true,
+      })
+    );
+  });
+
+  it('passes path option for subdirectory browsing', async () => {
+    const listArtifacts = jest.fn().mockResolvedValue([
+      {
+        name: 'deploy.yaml',
+        path: 'okd/deploy.yaml',
+        size: 2048,
+        isDirectory: false,
+        downloadUrl: '',
+        modificationTime: '',
+      },
+    ]);
+
+    const ArtifactManager = jest.fn().mockImplementation(() => ({ listArtifacts }));
+    const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue({});
+    const getInstance = jest.fn().mockReturnValue({});
+
+    jest.doMock('@/teamcity/artifact-manager', () => ({ ArtifactManager }));
+    jest.doMock('@/teamcity/client-adapter', () => ({ createAdapterFromTeamCityAPI }));
+    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance } }));
+
+    let handler: ToolHandler | undefined;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getRequiredTool } = require('@/tools');
+      handler = getRequiredTool('list_build_artifacts').handler;
+    });
+
+    if (!handler) throw new Error('list_build_artifacts handler not found');
+
+    const response = await handler({ buildId: '456', path: 'okd' });
+    const payload = JSON.parse(response.content?.[0]?.text ?? '{}');
+
+    expect(payload.artifacts).toHaveLength(1);
+    expect(payload.artifacts[0].name).toBe('deploy.yaml');
+    expect(listArtifacts).toHaveBeenCalledWith(
+      'id:456',
+      expect.objectContaining({
+        path: 'okd',
+        includeDirectories: true,
+      })
+    );
+  });
+
+  it('passes filter options through to the manager', async () => {
+    const listArtifacts = jest.fn().mockResolvedValue([]);
+
+    const ArtifactManager = jest.fn().mockImplementation(() => ({ listArtifacts }));
+    const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue({});
+    const getInstance = jest.fn().mockReturnValue({});
+
+    jest.doMock('@/teamcity/artifact-manager', () => ({ ArtifactManager }));
+    jest.doMock('@/teamcity/client-adapter', () => ({ createAdapterFromTeamCityAPI }));
+    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance } }));
+
+    let handler: ToolHandler | undefined;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getRequiredTool } = require('@/tools');
+      handler = getRequiredTool('list_build_artifacts').handler;
+    });
+
+    if (!handler) throw new Error('list_build_artifacts handler not found');
+
+    await handler({
+      buildId: '789',
+      path: 'okd',
+      includeNested: true,
+      nameFilter: '*.yaml',
+      extension: 'yaml',
+    });
+
+    expect(listArtifacts).toHaveBeenCalledWith('id:789', {
+      path: 'okd',
+      includeNested: true,
+      includeDirectories: true,
+      nameFilter: '*.yaml',
+      pathFilter: undefined,
+      extension: 'yaml',
+    });
+  });
+
+  it('supports build identification by buildNumber + buildTypeId', async () => {
+    const listArtifacts = jest.fn().mockResolvedValue([]);
+
+    const ArtifactManager = jest.fn().mockImplementation(() => ({ listArtifacts }));
+    const createAdapterFromTeamCityAPI = jest.fn().mockReturnValue({});
+    const getInstance = jest.fn().mockReturnValue({});
+
+    jest.doMock('@/teamcity/artifact-manager', () => ({ ArtifactManager }));
+    jest.doMock('@/teamcity/client-adapter', () => ({ createAdapterFromTeamCityAPI }));
+    jest.doMock('@/api-client', () => ({ TeamCityAPI: { getInstance } }));
+
+    let handler: ToolHandler | undefined;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getRequiredTool } = require('@/tools');
+      handler = getRequiredTool('list_build_artifacts').handler;
+    });
+
+    if (!handler) throw new Error('list_build_artifacts handler not found');
+
+    await handler({
+      buildTypeId: 'MyBuild',
+      buildNumber: '42',
+    });
+
+    expect(listArtifacts).toHaveBeenCalledWith(
+      'buildType:(id:MyBuild),number:42',
+      expect.objectContaining({ includeDirectories: true })
+    );
+  });
+});


### PR DESCRIPTION
Closes #490

## Summary

- Adds a new `list_build_artifacts` dev-mode tool that supports browsing into artifact subdirectories via the TeamCity REST API `basePath` parameter
- Adds `includeDirectories` option to `ArtifactManager.listArtifacts()` so directory entries are visible in listings instead of being silently skipped
- Adds `path` option to `ArtifactListOptions` to scope listings to a specific subdirectory

**Problem:** The existing tools (`get_build_results`, `download_build_artifact`) could list top-level artifacts but had no way to discover what files exist inside subdirectories like `okd/`. The TeamCity REST API supports this via the `basePath` parameter on `getFilesListOfBuild`, but it was never exposed.

**Usage:**
```
list_build_artifacts({ buildId: "123" })                        // top-level
list_build_artifacts({ buildId: "123", path: "okd" })           // browse subdirectory
list_build_artifacts({ buildId: "123", path: "okd", includeNested: true })  // recursive
```

## Test plan

- [x] 3 new unit tests in `artifact-manager.test.ts` (path passthrough, includeDirectories, combined with includeNested)
- [x] 4 new unit tests in `list-build-artifacts.test.ts` (top-level listing, subdirectory browsing, filter options, buildNumber+buildTypeId identification)
- [x] All 91 existing unit test suites pass (1912 tests)
- [x] `npm run check` passes (typecheck + lint + format)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse artifacts under a specific sub-path.
  * Include directory entries in artifact listings (directories returned alongside files).
  * New tool to list build artifacts with optional filters: path, nesting, name, and extension.

* **Tests**
  * Added unit tests covering sub-path browsing, directory inclusion, nested listing, and the new tool’s behavior and filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->