### PR TITLE
ci: bump mcp-publisher to v1.7.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install MCP Publisher
         if: steps.exists.outputs.exists == 'false' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_registry == 'true')
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.4.0/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.6/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
             | tar xz mcp-publisher
 
       - name: Login to MCP Registry


### PR DESCRIPTION
## Summary

- Bumps `mcp-publisher` CLI from v1.4.0 to v1.7.6 in [.github/workflows/publish.yml](.github/workflows/publish.yml)

## Why

The MCP Registry shipped a breaking OIDC-audience change in [v1.7.6](https://github.com/modelcontextprotocol/registry/releases/tag/v1.7.6) ([registry#1229](https://github.com/modelcontextprotocol/registry/pull/1229)) on 2026-04-30. The registry now rejects the audience that the v1.4.0 publisher sends:

```
failed to validate OIDC token: invalid audience:
  expected https://registry.modelcontextprotocol.io, got [mcp-registry]
```

This caused the `Login to MCP Registry` step to fail on the v2.11.0 and v2.12.0 release publishes. The npm publish itself succeeded both times (both versions are live on npm), so user-facing impact is limited to the MCP Registry being out of date.

## Test plan

- [ ] Merge this PR
- [ ] Manually re-run the publish workflow via `workflow_dispatch` with `publish_to_registry: true` to backfill v2.12.0 (and v2.11.0) on the MCP Registry
- [ ] Confirm the registry login + publish steps both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing workflow to use a newer version of the MCP Publisher tool, enhancing the release process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->