### PR TITLE
test(integration): add list_build_artifacts to expected dev-mode tools

### DIFF
--- a/tests/integration/dev-tools-list.test.ts
+++ b/tests/integration/dev-tools-list.test.ts
@@ -8,7 +8,7 @@ const hasTeamCityEnv = Boolean(
 );
 
 // Expected dev-mode tools as per docs/mcp-tools-mode-matrix.md
-// Note: 30 dev-mode tools focused on developer workflows; admin/infrastructure tools moved to full mode
+// Note: 31 dev-mode tools focused on developer workflows; admin/infrastructure tools moved to full mode
 const EXPECTED_DEV_TOOLS = new Set([
   'ping',
   // Mode management
@@ -30,6 +30,7 @@ const EXPECTED_DEV_TOOLS = new Set([
   'get_build_results',
   'download_build_artifact',
   'download_build_artifacts',
+  'list_build_artifacts',
   'analyze_build_problems',
   // Changes & diagnostics
   'list_changes',


### PR DESCRIPTION
## Summary

The `list_build_artifacts` tool added in eacad61 is read-only and exposed in dev mode, but `tests/integration/dev-tools-list.test.ts` was not updated. This causes local `npm test` to fail with an "unexpected extra tool" assertion. CI doesn't run integration tests, so it slipped through.

Fix is a one-line addition to `EXPECTED_DEV_TOOLS` (and updating the comment from 30 → 31 tools).

## Test plan

- [x] `npm test` — 2268 passed, 25 skipped, 0 failures
- [x] `SERIAL_BUILD_TESTS=true npm run test:integration` — 50 passed, 0 skipped
- [x] `npm run check` (typecheck + lint + format) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new dev-mode tool for listing build artifacts, expanding the dev-mode toolset to 31 available tools.

* **Tests**
  * Updated integration test expectations to verify the new dev-mode tool is properly recognized and available.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Daghis/teamcity-mcp/pull/498)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->