### PR TITLE
test(integration): correct EXPECTED_DEV_TOOLS count comment to 32

### DIFF
--- a/tests/integration/dev-tools-list.test.ts
+++ b/tests/integration/dev-tools-list.test.ts
@@ -8,7 +8,7 @@ const hasTeamCityEnv = Boolean(
 );
 
 // Expected dev-mode tools as per docs/mcp-tools-mode-matrix.md
-// Note: 31 dev-mode tools focused on developer workflows; admin/infrastructure tools moved to full mode
+// Note: 32 dev-mode tools focused on developer workflows; admin/infrastructure tools moved to full mode
 const EXPECTED_DEV_TOOLS = new Set([
   'ping',
   // Mode management


### PR DESCRIPTION
## Summary

CodeRabbit caught an off-by-one in #498: the comment on `EXPECTED_DEV_TOOLS` said 31 entries, but the set actually has 32. The original count on `main` (30) was already off by one before #498, and that PR's bump from 30→31 propagated the drift instead of fixing it.

One-line comment fix: 31 → 32.

## Test plan

- [x] `npm run check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated dev mode tools integration test to validate 32 developer-focused tools; admin and infrastructure tools are now available only in full mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Daghis/teamcity-mcp/pull/499)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->