### PR TITLE
docs: commit to AI power-user tool posture (closes #502)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,14 +87,14 @@ annotations: {
 
 ### Standard taxonomy
 
-| Pattern | readOnly | destructive | idempotent | openWorld |
-|---------|----------|-------------|------------|-----------|
-| `list_*`, `get_*`, `count_*`, `check_*`, `fetch_*`, `analyze_*`, `ping` | `true` | `false` | `true` | `true` |
-| `trigger_build`, `cancel_*`, `mute_*`, `move_queued_*`, `reorder_*` | `false` | `false` | `false` | `true` |
-| `delete_*`, `remove_*` | `false` | `true` | `true` | `true` |
-| `update_*`, `set_*`, `manage_*`, `assign_*`, `authorize_*`, `add_*`, `clone_*` | `false` | `false` | `true` | `true` |
-| `create_*`, `upload_*`, `download_*` | `false` | `false` | `false` | `true` |
-| Local-only tools (`get_mcp_mode`, `set_mcp_mode`) | varies | `false` | `true` | `false` |
+| Pattern                                                                        | readOnly | destructive | idempotent | openWorld |
+| ------------------------------------------------------------------------------ | -------- | ----------- | ---------- | --------- |
+| `list_*`, `get_*`, `count_*`, `check_*`, `fetch_*`, `analyze_*`, `ping`        | `true`   | `false`     | `true`     | `true`    |
+| `trigger_build`, `cancel_*`, `mute_*`, `move_queued_*`, `reorder_*`            | `false`  | `false`     | `false`    | `true`    |
+| `delete_*`, `remove_*`                                                         | `false`  | `true`      | `true`     | `true`    |
+| `update_*`, `set_*`, `manage_*`, `assign_*`, `authorize_*`, `add_*`, `clone_*` | `false`  | `false`     | `true`     | `true`    |
+| `create_*`, `upload_*`, `download_*`                                           | `false`  | `false`     | `false`    | `true`    |
+| Local-only tools (`get_mcp_mode`, `set_mcp_mode`)                              | varies   | `false`     | `true`     | `false`   |
 
 Per-tool exceptions are fine — apply judgment over pattern-matching when a tool doesn't fit the table.
 
@@ -128,16 +128,33 @@ Limit the disclosure to one short clause; do not enumerate every possible error 
 
 ### Examples
 
-| Tool | Description |
-| --- | --- |
-| `ping` | `Test MCP server connectivity. Returns a confirmation echo and optional message.` |
-| `list_builds` | `List TeamCity builds. Supports pagination and locator filtering.` |
-| `trigger_build` | `` Trigger a new build; runs asynchronously, use `wait_for_build` to monitor. Returns the queued build id; returns 404 if buildTypeId is unknown. `` |
-| `cancel_queued_build` | `Cancel a queued (not-yet-running) build. Idempotent; returns 404 if the build already started or was cancelled.` |
-| `delete_project` | `Delete a TeamCity project. Irreversible; returns 404 if the project does not exist.` |
+| Tool                    | Description                                                                                                                                         |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ping`                  | `Test MCP server connectivity. Returns a confirmation echo and optional message.`                                                                   |
+| `list_builds`           | `List TeamCity builds. Supports pagination and locator filtering.`                                                                                  |
+| `trigger_build`         | ``Trigger a new build; runs asynchronously, use `wait_for_build` to monitor. Returns the queued build id; returns 404 if buildTypeId is unknown.``  |
+| `cancel_queued_build`   | `Cancel a queued (not-yet-running) build. Idempotent; returns 404 if the build already started or was cancelled.`                                   |
+| `delete_project`        | `Delete a TeamCity project. Irreversible; returns 404 if the project does not exist.`                                                               |
 | `set_vcs_root_property` | `Set a single VCS root property such as branch, branchSpec, or url. Returns the updated value; returns 404 if the VCS root or property is unknown.` |
 
 A CI test (`tests/unit/tools/tool-descriptions.test.ts`) enforces these rules on every registered tool, including the return/error disclosure for mutators.
+
+## Adding a New Tool
+
+teamcity-mcp commits to the **AI power-user tool** posture — every AI-workflow operation works end-to-end with typed, safe tools. See [`docs/strategy.md`](docs/strategy.md) and [`docs/non-goals.md`](docs/non-goals.md) for the full reasoning and the explicit "no" list.
+
+Before opening a PR that adds a new tool, walk this checklist:
+
+- [ ] The operation closes a real AI workflow — not just "REST has it, we should too."
+- [ ] The operation is NOT on [`docs/non-goals.md`](docs/non-goals.md). If it is, either reconsider, or pair this PR with one that amends the non-goals list and justifies the reversal.
+- [ ] The tool has a typed Zod input schema covering every documented argument.
+- [ ] Tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) are accurate.
+- [ ] Mode placement is correct: `dev` is reserved for read or low-risk write operations; everything else is `full`.
+- [ ] The description is concise and disambiguates against any sibling tools (see issue #471 for the curated sibling set).
+- [ ] Mutating tools return structured failure objects (`{ success: false, error }`) instead of throwing, and disclose at least one common failure mode in the description.
+- [ ] Tests cover the success path, common failure modes, and idempotency where the annotation claims it.
+
+If steps 1-2 fail the operation is out of scope. If steps 3-8 fail, fix the gap before merging.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ See the [Tools Mode Matrix](docs/mcp-tools-mode-matrix.md) for the complete list
 - Performance-conscious: fast startup with minimal overhead
 - Clean codebase with clear module boundaries
 
+## Choosing between teamcity-mcp and the built-in MCP
+
+TeamCity 2026.1 ships with a built-in MCP endpoint at `<server-url>/app/mcp` exposing three tools: build log retrieval, a generic REST GET, and a build trigger (forced to `personal=true`). It is server-resident, requires no install, and is a sensible default for read-and-rerun workflows.
+
+teamcity-mcp is a different shape: a 96-tool typed surface focused on AI-driven workflows that need writes, multi-server support, or pre-2026.1 compatibility.
+
+| Use case                                                              | Recommendation                                                                             |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Read build logs, trigger builds, simple read flows                    | Built-in (TeamCity 2026.1+) — zero install                                                 |
+| Manage parameters, agents, queue, mutes, build configs, VCS roots     | teamcity-mcp                                                                               |
+| TeamCity server older than 2026.1                                     | teamcity-mcp                                                                               |
+| Multi-server / multi-tenant deployment                                | teamcity-mcp (HTTP transport — [PR #491](https://github.com/Daghis/teamcity-mcp/pull/491)) |
+| Typed tool surface for better agent reliability on chained operations | teamcity-mcp                                                                               |
+
+Both can coexist. The built-in is a good first stop; teamcity-mcp is the power tool for everything the built-in doesn't reach.
+
+For the design reasoning, see [docs/strategy.md](docs/strategy.md) and [docs/non-goals.md](docs/non-goals.md).
+
 ## Installation
 
 ### Prerequisites
@@ -110,7 +128,14 @@ On Windows, Claude Code's MCP configuration [may not properly merge environment 
   "mcpServers": {
     "teamcity": {
       "command": "npx",
-      "args": ["-y", "@daghis/teamcity-mcp", "--url", "https://teamcity.example.com", "--token", "YOUR_TOKEN"]
+      "args": [
+        "-y",
+        "@daghis/teamcity-mcp",
+        "--url",
+        "https://teamcity.example.com",
+        "--token",
+        "YOUR_TOKEN"
+      ]
     }
   }
 }

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -1,0 +1,53 @@
+# teamcity-mcp Non-Goals
+
+## Purpose
+
+This is the "no" list. Every entry below is an operation or capability that teamcity-mcp will not expose, with a one-line rationale.
+
+It is paired with [`strategy.md`](strategy.md), which defines the posture this list flows from. The short version: teamcity-mcp is the **AI power-user tool**. Operations on this list either undermine that posture (e.g. generic REST passthrough), or belong to workflows agents shouldn't be driving (admin, governance, server maintenance).
+
+## How to read this list
+
+Each entry has:
+
+- **Bold name** — what we won't do.
+- **Rationale** — one or two sentences explaining why.
+- **Reconsider when…** — optional. Present only when there's a concrete trigger we can imagine that would justify revisiting.
+
+## The list
+
+1. **Generic REST passthrough tool.** No `rest_get` or `rest_post` style tool that lets an agent call any TeamCity endpoint with arbitrary path and body. Typing is our moat; this would dilute it on every call. JetBrains' built-in MCP already covers this use case for users who want it.
+
+2. **User, group, role, and permission CRUD.** Creating users, assigning roles, managing groups, granting permissions. Admin workflows that humans do through the TeamCity UI and that have no business being agent-driven.
+   _Reconsider when:_ a clear AI-driven onboarding/provisioning workflow emerges with explicit human-in-the-loop guardrails.
+
+3. **License management.** Reading or modifying license keys, agent counts, build limits. Admin-only and single-tenant.
+
+4. **Backup, cleanup, and maintenance operations.** Triggering backups, scheduling cleanup, managing data retention. Server-admin territory; high blast radius if an agent gets it wrong.
+
+5. **Plugin and tool installation management.** Installing plugins, registering Maven/Gradle/Node versions on agents. Server-admin territory.
+
+6. **Audit log writes.** Read access to audit logs may be exposed selectively (Tier 6 in the roadmap); writes never. Audit integrity is a foundational governance property.
+
+7. **Global server settings writes.** Cross-cutting configuration that affects every project and user. Reads may be exposed if a workflow needs them; writes are a footgun.
+
+8. **Versioned settings writes.** TeamCity's "config-as-code" feature commits project settings to Git. Allowing an agent to drive this directly creates a high-risk path where mistakes propagate through version control. The status (`get_versioned_settings_status`) is exposed; mutations are not.
+
+9. **The full notifier endpoint surface.** We will expose at most 1-2 generic notifier types (likely webhook + Slack) when needed. The long tail of typed notifier endpoints (email, IRC, etc.) doesn't justify maintaining typed schemas.
+   _Reconsider when:_ a specific notifier sees repeated demand in real workflows.
+
+10. **Avatar and profile cosmetics.** Setting user avatars, profile descriptions, etc. Not a workflow.
+
+11. **Deep build-chain rebuild orchestration.** Implementing our own dependency-graph traversal for cascading rebuilds. teamcity-mcp triggers builds correctly with the right options (`rebuildAllDependencies`, etc.); TeamCity's existing engine handles the cascade. We do not reimplement it.
+
+## Adding to this list
+
+A PR that adds an entry must:
+
+- Name what's being excluded specifically (an endpoint family, a capability, not a vague theme).
+- Justify the exclusion against the posture in [`strategy.md`](strategy.md).
+- If a "reconsider when…" trigger is conceivable, include it.
+
+## Removing from this list
+
+A PR that removes an entry is usually paired with a PR that adds the corresponding tool. The justification must explicitly address what changed since the entry was added — ideally pointing to the "reconsider when…" trigger that fired, or arguing why the original rationale no longer holds.

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -1,0 +1,89 @@
+# teamcity-mcp Strategy
+
+## Purpose
+
+This document is the decision gate for "should we add tool X?" — and the answer to "why does teamcity-mcp exist when TeamCity 2026.1 ships a built-in MCP endpoint?"
+
+It is paired with [`non-goals.md`](non-goals.md), which lists what teamcity-mcp explicitly will _not_ expose.
+
+## The decision
+
+**teamcity-mcp commits to the "AI power-user tool" posture.**
+
+Every AI-workflow operation works end-to-end with typed, safe tools. teamcity-mcp is not a REST mirror, not a superset of the JetBrains built-in MCP, and not an admin tool.
+
+## What this means concretely
+
+teamcity-mcp **does**:
+
+- Expose every operation an AI agent reasonably needs to fix a build, debug a test, manage a release, or wire up a new pipeline.
+- Invest deeply in fewer, better tools — typed Zod schemas, accurate annotations, idempotency hints, structured error contracts, examples.
+- Stratify by safety: a small `dev` mode for read and low-risk write operations; a larger `full` mode for the rest. Mode placement is a first-class design concern.
+- Support TeamCity servers older than 2026.1, where the built-in MCP is unavailable.
+- Run as both stdio and HTTP transports, with per-credential isolation suitable for multi-tenant deployment.
+
+teamcity-mcp **does not**:
+
+- Offer a generic "REST passthrough" tool that lets an agent call any TeamCity endpoint. Typing is our moat; offloading endpoint-shape learning to the LLM on every call would forfeit it.
+- Cover admin and governance workflows that humans do through the TeamCity UI (see [`non-goals.md`](non-goals.md)).
+- Match the JetBrains built-in MCP's surface point-for-point. Where their offering wins on adoption friction (it's server-resident, zero install), ours wins on coverage, typing, and write capability.
+
+## Alternatives considered
+
+Three postures were on the table before this commitment. Each is internally coherent; we picked the one that fits this project's strengths and the competitive landscape.
+
+| Posture                   | Promise                                                              | Why we rejected it                                                                                                                                                                    |
+| ------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **REST mirror**           | Every TeamCity REST endpoint has a corresponding MCP tool.           | Forces breadth-first growth at the cost of typing and safety quality. With ~200 REST operations, even sustained effort produces a thin, fragile surface. Defeats our differentiation. |
+| **JetBrains-superset**    | Match the official MCP's surface exactly, then add.                  | Cedes strategic direction to a vendor that has already declared a deliberately narrow scope. We'd be permanently reactive.                                                            |
+| **AI power-user tool** ⭐ | Every AI-workflow operation works end-to-end with typed, safe tools. | Plays to our existing strengths (96 tools, dev/full mode, npm distribution) and gives us a clear yes/no test for new tools.                                                           |
+
+## Why this posture wins for us
+
+Four reasons, in decreasing order of strategic weight:
+
+1. **Typing is the moat.** Generic REST-passthrough tools force the LLM to learn TeamCity's REST shape every session — paths, locators, response schemas, error semantics. Typed tools collapse that into a function call with a schema. Agent reliability on chained operations is measurably better with typed tools. This advantage compounds with every new capability.
+
+2. **Write coverage is the differentiator.** The JetBrains built-in MCP supports only one write operation: triggering a build (forced to `personal=true`). teamcity-mcp covers parameters, agents, queue, mutes, build configs, VCS roots, build steps, triggers, features, dependencies, and more. If an AI workflow needs to _change_ anything beyond starting a build, teamcity-mcp is the only option.
+
+3. **Pre-2026.1 servers are an addressable market.** Every TeamCity instance not yet on 2026.1 has no built-in option. Adoption of major TeamCity versions is slow in regulated environments; this market will exist for years.
+
+4. **Multi-tenant deployment is something the built-in can't easily replicate.** A server-resident MCP necessarily speaks the host server's auth. teamcity-mcp can run anywhere, with per-request credentials and connection isolation (PR #491). For organizations running multiple TeamCity instances or mixing dev/staging/prod servers, this is decisive.
+
+## Competitive landscape
+
+TeamCity 2026.1 ships with a built-in MCP endpoint at `<server-url>/app/mcp`, exposing three tools:
+
+- `teamcity_build_log` — paginated build log retrieval
+- `teamcity_rest_get` — generic GET against the REST API
+- `teamcity_rest_post` — restricted to triggering builds (`personal=true` forced)
+
+This is a well-chosen minimum. It covers the most common AI ask ("what failed and rerun it") with zero install friction. It is not, and is not trying to be, a power tool.
+
+teamcity-mcp's positioning is therefore:
+
+- **Use the built-in** when the workflow is read-heavy ("what failed?") and trigger-only.
+- **Use teamcity-mcp** when the workflow needs writes beyond trigger, types for reliability, or multi-server / older-server support.
+
+See [README.md](../README.md) for the user-facing version of this decision.
+
+## How to use this document
+
+When considering adding a new tool, walk this flow:
+
+1. **Posture check.** Does the operation close an AI workflow that's currently broken or requires REST passthrough? If no, stop.
+2. **Non-goals check.** Is the operation on [`non-goals.md`](non-goals.md)? If yes, stop (or open a PR to amend the non-goals list with explicit justification).
+3. **Quality check.** Can the tool ship with a typed schema, accurate annotations, idempotency hints, structured errors, and tests? If no, fix the gap before merging.
+4. **Mode check.** Should this tool live in `dev` (read or low-risk write) or `full` (writes, admin-adjacent)? Default to `full` when unsure; promoting to `dev` later is cheaper than restricting after release.
+
+If steps 1-4 all pass, the tool is in-scope. Build it.
+
+## When this posture should be revisited
+
+This posture is committed for the 2026 product cycle. Concrete triggers for revisiting:
+
+- The JetBrains built-in MCP expands to substantial write coverage, eliminating teamcity-mcp's most defensible differentiator. (At that point we'd need to re-examine whether typing alone is enough.)
+- Agent ergonomics undergo a paradigm shift — for instance, if frontier models become so good at generic REST navigation that typed tools no longer measurably outperform `rest_get`-style passthroughs.
+- TeamCity's REST API surface itself materially changes, requiring a recalculation of what "AI workflow coverage" means.
+
+Absent these triggers, this posture is the steady state. Major scope decisions reference this doc; they don't relitigate it.


### PR DESCRIPTION
## Summary

Establishes the written design posture and the explicit non-goals list that the strategic gap-coverage initiative (#501) depends on.

Closes #502. Unblocks #503 (coverage matrix) and #504 (roadmap).

## What's new

- **`docs/strategy.md`** — Commits teamcity-mcp to the **AI power-user tool** posture. Covers: what that means concretely, alternatives considered (REST mirror, JetBrains-superset, AI power-user), why this posture wins for us, the competitive landscape vs. the TC 2026.1 built-in MCP, how to use the doc as a decision gate, and explicit triggers for revisiting.
- **`docs/non-goals.md`** — The explicit "no" list. 11 entries covering generic REST passthrough, admin/governance CRUD, license/backup/cleanup/plugin management, audit/global-settings/versioned-settings writes, notifier long tail, avatar/profile cosmetics, deep build-chain orchestration. Each entry has a one-line rationale; "reconsider when…" criteria are included where the trigger is obvious.

## What's modified

- **`README.md`** — New section *"Choosing between teamcity-mcp and the built-in MCP"* between `Features` and `Installation`. Decision table + honest-neutral framing; links out to `docs/strategy.md` and `docs/non-goals.md`.
- **`CONTRIBUTING.md`** — New section *"Adding a new tool"* between `Tool Descriptions` and `Code Style`. Pre-flight checklist that references strategy + non-goals as the decision gate, plus typing/annotation/mode/test requirements.

## Acceptance criteria (from #502)

- [x] `docs/strategy.md` committed with chosen posture, rejected alternatives, reasoning
- [x] `docs/non-goals.md` committed with the 11-entry list and one-line rationales
- [x] README links to both docs from a new "Why teamcity-mcp vs. the built-in MCP?" section (titled "Choosing between teamcity-mcp and the built-in MCP" — same intent)
- [x] CONTRIBUTING.md gains "Adding a new tool" section referencing the posture/non-goals as the decision gate

## Test plan

- [x] `npm run check` (typecheck + lint + format on src/tests) — passes
- [x] `npx prettier --check` on the four modified docs — passes after auto-format
- [x] Manual link-check: every internal link in the new docs resolves
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated contribution guidelines with clearer tool annotation requirements and standardized description examples for consistency.
  * Added strategy documentation to guide tool evaluation decisions and establish project scope boundaries.
  * Added non-goals documentation specifying excluded TeamCity operations and capabilities.
  * Added comparison guide to help users choose between teamcity-mcp and TeamCity's built-in MCP endpoint.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Daghis/teamcity-mcp/pull/505)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->