### PR TITLE
docs: address CodeRabbit findings from #505

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,14 +87,14 @@ annotations: {
 
 ### Standard taxonomy
 
-| Pattern                                                                        | readOnly | destructive | idempotent | openWorld |
-| ------------------------------------------------------------------------------ | -------- | ----------- | ---------- | --------- |
-| `list_*`, `get_*`, `count_*`, `check_*`, `fetch_*`, `analyze_*`, `ping`        | `true`   | `false`     | `true`     | `true`    |
-| `trigger_build`, `cancel_*`, `mute_*`, `move_queued_*`, `reorder_*`            | `false`  | `false`     | `false`    | `true`    |
-| `delete_*`, `remove_*`                                                         | `false`  | `true`      | `true`     | `true`    |
-| `update_*`, `set_*`, `manage_*`, `assign_*`, `authorize_*`, `add_*`, `clone_*` | `false`  | `false`     | `true`     | `true`    |
-| `create_*`, `upload_*`, `download_*`                                           | `false`  | `false`     | `false`    | `true`    |
-| Local-only tools (`get_mcp_mode`, `set_mcp_mode`)                              | varies   | `false`     | `true`     | `false`   |
+| Pattern                                                                               | readOnly | destructive | idempotent | openWorld |
+| ------------------------------------------------------------------------------------- | -------- | ----------- | ---------- | --------- |
+| `list_*`, `get_*`, `count_*`, `check_*`, `fetch_*`, `analyze_*`, `download_*`, `ping` | `true`   | `false`     | `true`     | `true`    |
+| `trigger_build`, `cancel_*`, `mute_*`, `move_queued_*`, `reorder_*`                   | `false`  | `false`     | `false`    | `true`    |
+| `delete_*`, `remove_*`                                                                | `false`  | `true`      | `true`     | `true`    |
+| `update_*`, `set_*`, `manage_*`, `assign_*`, `authorize_*`, `add_*`, `clone_*`        | `false`  | `false`     | `true`     | `true`    |
+| `create_*`, `upload_*`                                                                | `false`  | `false`     | `false`    | `true`    |
+| Local-only tools (`get_mcp_mode`, `set_mcp_mode`)                                     | varies   | `false`     | `true`     | `false`   |
 
 Per-tool exceptions are fine — apply judgment over pattern-matching when a tool doesn't fit the table.
 
@@ -132,7 +132,7 @@ Limit the disclosure to one short clause; do not enumerate every possible error 
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ping`                  | `Test MCP server connectivity. Returns a confirmation echo and optional message.`                                                                   |
 | `list_builds`           | `List TeamCity builds. Supports pagination and locator filtering.`                                                                                  |
-| `trigger_build`         | ``Trigger a new build; runs asynchronously, use `wait_for_build` to monitor. Returns the queued build id; returns 404 if buildTypeId is unknown.``  |
+| `trigger_build`         | `Trigger a new build; runs asynchronously, use wait_for_build to monitor. Returns the queued build id; returns 404 if buildTypeId is unknown.`      |
 | `cancel_queued_build`   | `Cancel a queued (not-yet-running) build. Idempotent; returns 404 if the build already started or was cancelled.`                                   |
 | `delete_project`        | `Delete a TeamCity project. Irreversible; returns 404 if the project does not exist.`                                                               |
 | `set_vcs_root_property` | `Set a single VCS root property such as branch, branchSpec, or url. Returns the updated value; returns 404 if the VCS root or property is unknown.` |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See the [Tools Mode Matrix](docs/mcp-tools-mode-matrix.md) for the complete list
 
 TeamCity 2026.1 ships with a built-in MCP endpoint at `<server-url>/app/mcp` exposing three tools: build log retrieval, a generic REST GET, and a build trigger (forced to `personal=true`). It is server-resident, requires no install, and is a sensible default for read-and-rerun workflows.
 
-teamcity-mcp is a different shape: a 96-tool typed surface focused on AI-driven workflows that need writes, multi-server support, or pre-2026.1 compatibility.
+teamcity-mcp is a different shape: an 87-tool typed surface focused on AI-driven workflows that need writes, multi-server support, or pre-2026.1 compatibility.
 
 | Use case                                                              | Recommendation                                                                             |
 | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
## Summary

Three small doc fixes flagged by CodeRabbit during review of #505:

| File | Fix | Severity |
|---|---|---|
| README.md (line 54) | Tool count `96` → `87` in the new comparison section, matching the existing Features section. I introduced the `96` figure from a grep over `name:` in `src/tools.ts` that also picked up schema field names. | 🟡 Minor (my bug) |
| CONTRIBUTING.md (taxonomy table) | Move `download_*` from the create/upload row to the read-only row. Downloads are read-only and retry-safe, so the prior grouping would have driven incorrect MCP hints. | 🟠 Major (pre-existing) |
| CONTRIBUTING.md (examples table) | Simplify `trigger_build` description to use single backticks matching every other row. Removes the awkward doubled-backtick rendering. | 🟡 Minor (pre-existing) |

## Test plan

- [x] `npx prettier --check` on modified files
- [x] Manual diff review
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tool taxonomy classifications to align with standard behavior patterns
  * Refined tool surface from 96 to 87 focused tools, prioritizing core functionality for AI-driven workflows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Daghis/teamcity-mcp/pull/506)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->