### PR TITLE
fix(tools): mark download_* as readOnly and idempotent

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3341,9 +3341,9 @@ const DEV_TOOLS: ToolDefinition[] = [
   {
     name: 'download_build_artifact',
     annotations: {
-      readOnlyHint: false,
+      readOnlyHint: true,
       destructiveHint: false,
-      idempotentHint: false,
+      idempotentHint: true,
       openWorldHint: true,
     },
     description:
@@ -3415,9 +3415,9 @@ const DEV_TOOLS: ToolDefinition[] = [
   {
     name: 'download_build_artifacts',
     annotations: {
-      readOnlyHint: false,
+      readOnlyHint: true,
       destructiveHint: false,
-      idempotentHint: false,
+      idempotentHint: true,
       openWorldHint: true,
     },
     description:


### PR DESCRIPTION
## Summary

Reconcile a discrepancy flagged by `claude-review` on [#506](https://github.com/Daghis/teamcity-mcp/pull/506):

- The annotation taxonomy in `CONTRIBUTING.md` (landed in #506) classifies `download_*` tools as `readOnlyHint=true, idempotentHint=true`.
- The runtime tool registrations in `src/tools.ts` had the opposite (`false / false`).

This PR updates the runtime annotations to match the taxonomy — `download_build_artifact` and `download_build_artifacts` are now `readOnlyHint: true, idempotentHint: true` (and remain `destructiveHint: false, openWorldHint: true`).

## Why this direction (not revert the taxonomy)

Downloads don't mutate TeamCity state and are safe to retry. The optional `outputPath` writes a local file, but that's a client-side convenience, not a TeamCity-state change. Classifying downloads alongside `create_*`/`upload_*` (which create new server-side artifacts) would mislead agents into treating safe retries as unsafe.

## Test plan

- [x] `npm run check` — typecheck + lint + format pass
- [x] `tests/unit/tools/tool-annotations.test.ts` — passes (taxonomy enforcement)
- [x] `tests/unit/tools/tool-descriptions.test.ts` — passes (description-rule enforcement; read-only tools have no mandatory return/error disclosure, so the existing 2-sentence descriptions still comply)
- [x] Full unit suite: 2268 passed, 0 failed
- [ ] CI green
- [ ] CodeRabbit + claude-review hold the line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tool annotations for download build artifact operations to reflect their safe, non-state-modifying nature and ability to be retried without side effects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Daghis/teamcity-mcp/pull/507)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->