### PR TITLE
ci: skip Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip on fork PRs: forks don't receive repository secrets, so the review
+    # would fail with an empty CLAUDE_CODE_OAUTH_TOKEN. A skipped job shows a
+    # neutral status instead of a misleading red ❌.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What

Adds a job-level `if:` to `.github/workflows/claude-code-review.yml` so the `claude-review` job runs only for same-repo PRs:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

This replaces the dead commented-out "Filter by PR author" block.

## Why

The `claude-review` check fails on every pull request from an external contributor (e.g. [#510](https://github.com/Daghis/teamcity-mcp/pull/510) from `Leon69924`). The workflow runs on the `pull_request` event, and GitHub does not expose repository secrets to `pull_request` runs originating from a fork — so `secrets.CLAUDE_CODE_OAUTH_TOKEN` is empty and the action cannot authenticate. The result is a misleading red ❌ that the contributor has no way to resolve.

There is no way to give a fork `pull_request` run a credential (not repo/environment secrets, not OIDC). Genuinely running the review for external contributors would require a gated `pull_request_target` workflow with real security hardening — out of scope here. This PR simply stops the misleading failure.

## Behavior after this change

- **Same-repo PRs** — `head.repo.full_name` equals `github.repository` → the review runs exactly as before.
- **Fork PRs** — they differ → the job is **skipped**. A job skipped by an `if:` condition reports a neutral status, not a failure — no red ❌.

## Reviewer notes

- This does not retroactively change #510's existing red ❌ (that check already ran); the new behavior applies to PRs evaluated after this lands on `main`.
- Verified logic only; full end-to-end confirmation needs an actual fork PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized automated code review workflow execution conditions to improve efficiency and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Daghis/teamcity-mcp/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->